### PR TITLE
Questly : application iOS de tâches gamifiée avec calendrier complet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,10 @@ _includes/notes_graph.json
 
 # Obsidian config
 .obsidian/
+
+# Swift / Xcode
+.build/
+DerivedData/
+*.xcuserstate
+xcuserdata/
+.swiftpm/

--- a/QuestlyApp/Packages/QuestlyKit/Package.swift
+++ b/QuestlyApp/Packages/QuestlyKit/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "QuestlyKit",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v14)
+    ],
+    products: [
+        .library(name: "QuestlyKit", targets: ["QuestlyKit"])
+    ],
+    targets: [
+        .target(name: "QuestlyKit"),
+        .testTarget(name: "QuestlyKitTests", dependencies: ["QuestlyKit"])
+    ]
+)

--- a/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Core/DateSupport.swift
+++ b/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Core/DateSupport.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+/// Abstraction de l'horloge pour rendre toute la logique testable.
+public protocol DateProviding: Sendable {
+    var now: Date { get }
+}
+
+public struct SystemDateProvider: DateProviding {
+    public init() {}
+    public var now: Date { Date() }
+}
+
+/// Horloge figée, utilisée par les tests et les aperçus SwiftUI.
+public struct FixedDateProvider: DateProviding {
+    public let now: Date
+    public init(_ now: Date) { self.now = now }
+}
+
+// MARK: - Calendar helpers
+
+public extension Calendar {
+    /// Calendrier grégorien stable (UTC-agnostique) pour les calculs déterministes.
+    static func questly(timeZone: TimeZone = .current, firstWeekday: Int = 2) -> Calendar {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = timeZone
+        cal.firstWeekday = firstWeekday
+        cal.minimumDaysInFirstWeek = 4
+        return cal
+    }
+
+    func startOfDay(_ date: Date) -> Date { startOfDay(for: date) }
+
+    func endOfDay(_ date: Date) -> Date {
+        self.date(byAdding: DateComponents(day: 1, second: -1), to: startOfDay(for: date)) ?? date
+    }
+
+    func startOfWeek(_ date: Date) -> Date {
+        let comps = dateComponents([.yearForWeekOfYear, .weekOfYear], from: date)
+        return self.date(from: comps) ?? startOfDay(for: date)
+    }
+
+    func endOfWeek(_ date: Date) -> Date {
+        let start = startOfWeek(date)
+        return self.date(byAdding: DateComponents(day: 7, second: -1), to: start) ?? date
+    }
+
+    func startOfMonth(_ date: Date) -> Date {
+        let comps = dateComponents([.year, .month], from: date)
+        return self.date(from: comps) ?? startOfDay(for: date)
+    }
+
+    func endOfMonth(_ date: Date) -> Date {
+        let start = startOfMonth(date)
+        return self.date(byAdding: DateComponents(month: 1, second: -1), to: start) ?? date
+    }
+
+    func startOfYear(_ date: Date) -> Date {
+        let comps = dateComponents([.year], from: date)
+        return self.date(from: comps) ?? startOfDay(for: date)
+    }
+
+    func daysBetween(_ from: Date, _ to: Date) -> Int {
+        let a = startOfDay(for: from)
+        let b = startOfDay(for: to)
+        return dateComponents([.day], from: a, to: b).day ?? 0
+    }
+
+    func isSameDay(_ a: Date, _ b: Date) -> Bool {
+        isDate(a, inSameDayAs: b)
+    }
+
+    func numberOfDaysInMonth(_ date: Date) -> Int {
+        range(of: .day, in: .month, for: date)?.count ?? 30
+    }
+
+    func isWeekend(_ date: Date) -> Bool {
+        let weekday = component(.weekday, from: date)
+        return weekday == 1 || weekday == 7
+    }
+
+    /// Applique une heure/minute à une date en conservant son jour.
+    func setting(hour: Int, minute: Int, of date: Date) -> Date {
+        self.date(bySettingHour: hour, minute: minute, second: 0, of: date) ?? date
+    }
+
+    /// Grille de 42 jours (6 semaines) affichée par la vue Mois.
+    func monthGrid(for date: Date) -> [Date] {
+        let first = startOfMonth(date)
+        let gridStart = startOfWeek(first)
+        return (0..<42).compactMap { self.date(byAdding: .day, value: $0, to: gridStart) }
+    }
+
+    /// Les 7 jours de la semaine contenant `date`.
+    func weekDays(for date: Date) -> [Date] {
+        let start = startOfWeek(date)
+        return (0..<7).compactMap { self.date(byAdding: .day, value: $0, to: start) }
+    }
+}
+
+// MARK: - Date helpers
+
+public extension Date {
+    func adding(days: Int, calendar: Calendar = .questly()) -> Date {
+        calendar.date(byAdding: .day, value: days, to: self) ?? self
+    }
+
+    func adding(minutes: Int) -> Date {
+        addingTimeInterval(TimeInterval(minutes) * 60)
+    }
+
+    /// Minutes écoulées depuis minuit — sert à positionner les blocs sur la timeline.
+    func minutesSinceMidnight(calendar: Calendar = .questly()) -> Int {
+        let comps = calendar.dateComponents([.hour, .minute], from: self)
+        return (comps.hour ?? 0) * 60 + (comps.minute ?? 0)
+    }
+}
+
+// MARK: - Time interval formatting
+
+public enum DurationFormatter {
+    /// « 1 h 30 », « 45 min », « 2 h ».
+    public static func short(minutes: Int) -> String {
+        guard minutes > 0 else { return "—" }
+        let h = minutes / 60
+        let m = minutes % 60
+        if h == 0 { return "\(m) min" }
+        if m == 0 { return "\(h) h" }
+        return "\(h) h \(m)"
+    }
+
+    /// « 01:23:45 » pour le chronomètre de concentration.
+    public static func clock(seconds: Int) -> String {
+        let s = max(0, seconds)
+        let h = s / 3600
+        let m = (s % 3600) / 60
+        let sec = s % 60
+        if h > 0 {
+            return String(format: "%d:%02d:%02d", h, m, sec)
+        }
+        return String(format: "%02d:%02d", m, sec)
+    }
+}

--- a/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Core/Enums.swift
+++ b/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Core/Enums.swift
@@ -1,0 +1,397 @@
+import Foundation
+
+// MARK: - Priority
+
+/// Priorité d'une quête, façon Todoist : `p1` est la plus urgente.
+public enum Priority: Int, Codable, CaseIterable, Sendable, Identifiable {
+    case p1 = 1
+    case p2 = 2
+    case p3 = 3
+    case p4 = 4
+
+    public var id: Int { rawValue }
+
+    /// Priorité par défaut d'une nouvelle tâche.
+    public static let `default`: Priority = .p4
+
+    /// Plus le score est haut, plus la tâche est urgente. Pratique pour trier.
+    public var urgencyScore: Int { 5 - rawValue }
+
+    public var label: String {
+        switch self {
+        case .p1: return "Critique"
+        case .p2: return "Élevée"
+        case .p3: return "Moyenne"
+        case .p4: return "Normale"
+        }
+    }
+
+    public var shortLabel: String { "P\(rawValue)" }
+
+    public var symbolName: String {
+        switch self {
+        case .p1: return "flame.fill"
+        case .p2: return "exclamationmark.2"
+        case .p3: return "exclamationmark"
+        case .p4: return "circle"
+        }
+    }
+
+    /// Teinte hexadécimale associée (le layer UI la convertit en `Color`).
+    public var hex: String {
+        switch self {
+        case .p1: return "FF453A"
+        case .p2: return "FF9F0A"
+        case .p3: return "0A84FF"
+        case .p4: return "8E8E93"
+        }
+    }
+
+    /// Multiplicateur d'XP : viser les tâches critiques rapporte plus.
+    public var xpMultiplier: Double {
+        switch self {
+        case .p1: return 1.50
+        case .p2: return 1.25
+        case .p3: return 1.10
+        case .p4: return 1.00
+        }
+    }
+}
+
+extension Priority: Comparable {
+    /// `p4 < p1` : l'ordre naturel va du moins urgent au plus urgent.
+    public static func < (lhs: Priority, rhs: Priority) -> Bool {
+        lhs.urgencyScore < rhs.urgencyScore
+    }
+}
+
+// MARK: - Difficulty
+
+/// Difficulté estimée : c'est le principal levier de récompense.
+public enum Difficulty: Int, Codable, CaseIterable, Sendable, Identifiable {
+    case trivial = 0
+    case easy = 1
+    case medium = 2
+    case hard = 3
+    case epic = 4
+    case legendary = 5
+
+    public var id: Int { rawValue }
+
+    public static let `default`: Difficulty = .medium
+
+    public var label: String {
+        switch self {
+        case .trivial: return "Broutille"
+        case .easy: return "Facile"
+        case .medium: return "Normale"
+        case .hard: return "Ardue"
+        case .epic: return "Épique"
+        case .legendary: return "Légendaire"
+        }
+    }
+
+    /// XP de base rapporté par la tâche avant tout bonus.
+    public var baseXP: Int {
+        switch self {
+        case .trivial: return 5
+        case .easy: return 10
+        case .medium: return 20
+        case .hard: return 35
+        case .epic: return 60
+        case .legendary: return 100
+        }
+    }
+
+    /// Points de vie du « boss » associé, en minutes de concentration.
+    public var bossHitPoints: Int {
+        switch self {
+        case .trivial: return 10
+        case .easy: return 25
+        case .medium: return 50
+        case .hard: return 90
+        case .epic: return 150
+        case .legendary: return 240
+        }
+    }
+
+    public var symbolName: String {
+        switch self {
+        case .trivial: return "leaf.fill"
+        case .easy: return "circle.hexagongrid.fill"
+        case .medium: return "shield.lefthalf.filled"
+        case .hard: return "bolt.shield.fill"
+        case .epic: return "crown.fill"
+        case .legendary: return "sparkles"
+        }
+    }
+
+    public var hex: String {
+        switch self {
+        case .trivial: return "9CA3AF"
+        case .easy: return "34D399"
+        case .medium: return "60A5FA"
+        case .hard: return "F59E0B"
+        case .epic: return "A78BFA"
+        case .legendary: return "F472B6"
+        }
+    }
+}
+
+// MARK: - Energy
+
+/// Énergie requise. Sert au planificateur intelligent pour placer les tâches
+/// exigeantes dans les créneaux où l'utilisateur est au top.
+public enum EnergyLevel: Int, Codable, CaseIterable, Sendable, Identifiable {
+    case low = 0
+    case medium = 1
+    case high = 2
+
+    public var id: Int { rawValue }
+
+    public static let `default`: EnergyLevel = .medium
+
+    public var label: String {
+        switch self {
+        case .low: return "Basse"
+        case .medium: return "Moyenne"
+        case .high: return "Haute"
+        }
+    }
+
+    public var symbolName: String {
+        switch self {
+        case .low: return "battery.25"
+        case .medium: return "battery.50"
+        case .high: return "battery.100.bolt"
+        }
+    }
+}
+
+// MARK: - Life areas (les « attributs » du héros)
+
+/// Domaines de vie : ce sont les statistiques du personnage. Chaque tâche
+/// terminée fait progresser l'attribut correspondant.
+public enum LifeArea: String, Codable, CaseIterable, Sendable, Identifiable {
+    case body
+    case mind
+    case heart
+    case craft
+    case wealth
+    case home
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .body: return "Corps"
+        case .mind: return "Esprit"
+        case .heart: return "Cœur"
+        case .craft: return "Œuvre"
+        case .wealth: return "Fortune"
+        case .home: return "Foyer"
+        }
+    }
+
+    public var subtitle: String {
+        switch self {
+        case .body: return "Sport, sommeil, santé"
+        case .mind: return "Lecture, études, focus"
+        case .heart: return "Proches, liens, soi"
+        case .craft: return "Travail, création, projets"
+        case .wealth: return "Argent, admin, avenir"
+        case .home: return "Maison, courses, ordre"
+        }
+    }
+
+    public var symbolName: String {
+        switch self {
+        case .body: return "figure.run"
+        case .mind: return "brain.head.profile"
+        case .heart: return "heart.fill"
+        case .craft: return "hammer.fill"
+        case .wealth: return "banknote.fill"
+        case .home: return "house.fill"
+        }
+    }
+
+    public var hex: String {
+        switch self {
+        case .body: return "FF6B6B"
+        case .mind: return "5E9BFF"
+        case .heart: return "FF7AC6"
+        case .craft: return "FFB020"
+        case .wealth: return "34D399"
+        case .home: return "A78BFA"
+        }
+    }
+}
+
+// MARK: - Rarity
+
+/// Rareté d'un butin, d'un haut fait ou d'un objet de la boutique.
+public enum Rarity: Int, Codable, CaseIterable, Sendable, Identifiable, Comparable {
+    case common = 0
+    case uncommon = 1
+    case rare = 2
+    case epic = 3
+    case legendary = 4
+    case mythic = 5
+
+    public var id: Int { rawValue }
+
+    public var label: String {
+        switch self {
+        case .common: return "Commun"
+        case .uncommon: return "Peu commun"
+        case .rare: return "Rare"
+        case .epic: return "Épique"
+        case .legendary: return "Légendaire"
+        case .mythic: return "Mythique"
+        }
+    }
+
+    public var hex: String {
+        switch self {
+        case .common: return "9CA3AF"
+        case .uncommon: return "34D399"
+        case .rare: return "3B82F6"
+        case .epic: return "A855F7"
+        case .legendary: return "F59E0B"
+        case .mythic: return "FF2D95"
+        }
+    }
+
+    /// Poids du tirage au sort d'un coffre standard.
+    public var lootWeight: Double {
+        switch self {
+        case .common: return 52
+        case .uncommon: return 26
+        case .rare: return 13
+        case .epic: return 6
+        case .legendary: return 2.5
+        case .mythic: return 0.5
+        }
+    }
+
+    public static func < (lhs: Rarity, rhs: Rarity) -> Bool { lhs.rawValue < rhs.rawValue }
+}
+
+// MARK: - Task status
+
+public enum TaskStatus: Int, Codable, CaseIterable, Sendable {
+    case inbox = 0
+    case active = 1
+    case completed = 2
+    case archived = 3
+    case abandoned = 4
+
+    public var isOpen: Bool { self == .inbox || self == .active }
+}
+
+// MARK: - Smart lists
+
+/// Listes intelligentes proposées dans l'onglet Quêtes.
+public enum SmartList: String, Codable, CaseIterable, Sendable, Identifiable {
+    case inbox
+    case today
+    case upcoming
+    case overdue
+    case anytime
+    case someday
+    case flagged
+    case bosses
+    case completed
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .inbox: return "Boîte de réception"
+        case .today: return "Aujourd'hui"
+        case .upcoming: return "À venir"
+        case .overdue: return "En retard"
+        case .anytime: return "N'importe quand"
+        case .someday: return "Un jour"
+        case .flagged: return "Épinglées"
+        case .bosses: return "Boss"
+        case .completed: return "Accomplies"
+        }
+    }
+
+    public var symbolName: String {
+        switch self {
+        case .inbox: return "tray.fill"
+        case .today: return "sun.max.fill"
+        case .upcoming: return "calendar"
+        case .overdue: return "exclamationmark.triangle.fill"
+        case .anytime: return "shuffle"
+        case .someday: return "archivebox.fill"
+        case .flagged: return "flag.fill"
+        case .bosses: return "crown.fill"
+        case .completed: return "checkmark.seal.fill"
+        }
+    }
+
+    public var hex: String {
+        switch self {
+        case .inbox: return "8E8E93"
+        case .today: return "FF9F0A"
+        case .upcoming: return "5E5CE6"
+        case .overdue: return "FF453A"
+        case .anytime: return "30D158"
+        case .someday: return "64D2FF"
+        case .flagged: return "FFD60A"
+        case .bosses: return "BF5AF2"
+        case .completed: return "34D399"
+        }
+    }
+}
+
+// MARK: - Sorting
+
+public enum TaskSortOrder: String, Codable, CaseIterable, Sendable, Identifiable {
+    case smart
+    case dueDate
+    case priority
+    case difficulty
+    case alphabetical
+    case created
+    case xpValue
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .smart: return "Intelligent"
+        case .dueDate: return "Échéance"
+        case .priority: return "Priorité"
+        case .difficulty: return "Difficulté"
+        case .alphabetical: return "Alphabétique"
+        case .created: return "Création"
+        case .xpValue: return "XP"
+        }
+    }
+}
+
+public enum TaskGrouping: String, Codable, CaseIterable, Sendable, Identifiable {
+    case none
+    case date
+    case priority
+    case project
+    case lifeArea
+    case difficulty
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .none: return "Aucun"
+        case .date: return "Date"
+        case .priority: return "Priorité"
+        case .project: return "Projet"
+        case .lifeArea: return "Domaine"
+        case .difficulty: return "Difficulté"
+        }
+    }
+}

--- a/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Gamification/AchievementCatalog.swift
+++ b/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Gamification/AchievementCatalog.swift
@@ -1,0 +1,385 @@
+import Foundation
+
+/// Le catalogue complet des hauts faits. Purement déclaratif : ajouter une
+/// ligne suffit à créer un nouveau badge, sa progression et ses récompenses.
+public enum AchievementCatalog {
+
+    public static let all: [AchievementDefinition] = beginnings + volume + consistency
+        + focus + mastery + balance + collection + secrets
+
+    public static func definition(id: String) -> AchievementDefinition? {
+        lookup[id]
+    }
+
+    private static let lookup: [String: AchievementDefinition] = {
+        Dictionary(all.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+    }()
+
+    public static func grouped() -> [(category: AchievementCategory, items: [AchievementDefinition])] {
+        AchievementCategory.allCases.map { category in
+            (category, all.filter { $0.category == category })
+        }
+    }
+
+    // MARK: Premiers pas
+
+    static let beginnings: [AchievementDefinition] = [
+        AchievementDefinition(
+            id: "first.blood", title: "Le grand départ",
+            detail: "Accomplir sa toute première quête.",
+            symbolName: "flag.checkered", rarity: .common,
+            category: .beginnings, metric: .tasksCompleted, goal: 1
+        ),
+        AchievementDefinition(
+            id: "first.plan", title: "Cartographe",
+            detail: "Créer 10 quêtes.",
+            symbolName: "map.fill", rarity: .common,
+            category: .beginnings, metric: .tasksCreated, goal: 10
+        ),
+        AchievementDefinition(
+            id: "first.focus", title: "Première transe",
+            detail: "Terminer une session de concentration.",
+            symbolName: "timer", rarity: .common,
+            category: .beginnings, metric: .focusSessions, goal: 1
+        ),
+        AchievementDefinition(
+            id: "first.boss", title: "Tombeur de géant",
+            detail: "Vaincre un premier boss.",
+            symbolName: "crown.fill", rarity: .uncommon,
+            category: .beginnings, metric: .bossesDefeated, goal: 1
+        ),
+        AchievementDefinition(
+            id: "first.block", title: "Maître du temps",
+            detail: "Planifier 5 blocs dans le calendrier.",
+            symbolName: "calendar.badge.clock", rarity: .common,
+            category: .beginnings, metric: .calendarBlocks, goal: 5
+        ),
+        AchievementDefinition(
+            id: "first.level5", title: "On prend ses marques",
+            detail: "Atteindre le niveau 5.",
+            symbolName: "arrow.up.circle.fill", rarity: .common,
+            category: .beginnings, metric: .level, goal: 5
+        )
+    ]
+
+    // MARK: Volume
+
+    static let volume: [AchievementDefinition] = [
+        AchievementDefinition(
+            id: "vol.25", title: "Bon élève",
+            detail: "Accomplir 25 quêtes.",
+            symbolName: "checkmark.circle.fill", rarity: .common,
+            category: .volume, metric: .tasksCompleted, goal: 25
+        ),
+        AchievementDefinition(
+            id: "vol.100", title: "Centurion",
+            detail: "Accomplir 100 quêtes.",
+            symbolName: "100.circle.fill", rarity: .uncommon,
+            category: .volume, metric: .tasksCompleted, goal: 100
+        ),
+        AchievementDefinition(
+            id: "vol.500", title: "Infatigable",
+            detail: "Accomplir 500 quêtes.",
+            symbolName: "bolt.circle.fill", rarity: .rare,
+            category: .volume, metric: .tasksCompleted, goal: 500
+        ),
+        AchievementDefinition(
+            id: "vol.1000", title: "Millénaire",
+            detail: "Accomplir 1 000 quêtes.",
+            symbolName: "star.circle.fill", rarity: .epic,
+            category: .volume, metric: .tasksCompleted, goal: 1000
+        ),
+        AchievementDefinition(
+            id: "vol.5000", title: "Force de la nature",
+            detail: "Accomplir 5 000 quêtes.",
+            symbolName: "tornado", rarity: .legendary,
+            category: .volume, metric: .tasksCompleted, goal: 5000
+        ),
+        AchievementDefinition(
+            id: "vol.boss10", title: "Chasseur de boss",
+            detail: "Vaincre 10 boss.",
+            symbolName: "shield.lefthalf.filled.badge.checkmark", rarity: .rare,
+            category: .volume, metric: .bossesDefeated, goal: 10
+        ),
+        AchievementDefinition(
+            id: "vol.boss50", title: "Bourreau des colosses",
+            detail: "Vaincre 50 boss.",
+            symbolName: "crown.fill", rarity: .legendary,
+            category: .volume, metric: .bossesDefeated, goal: 50
+        ),
+        AchievementDefinition(
+            id: "vol.projects10", title: "Bâtisseur",
+            detail: "Terminer 10 projets.",
+            symbolName: "building.columns.fill", rarity: .rare,
+            category: .volume, metric: .projectsCompleted, goal: 10
+        ),
+        AchievementDefinition(
+            id: "vol.ontime100", title: "Montre suisse",
+            detail: "100 quêtes livrées dans les temps.",
+            symbolName: "clock.badge.checkmark.fill", rarity: .rare,
+            category: .volume, metric: .onTimeCompletions, goal: 100
+        )
+    ]
+
+    // MARK: Régularité
+
+    static let consistency: [AchievementDefinition] = [
+        AchievementDefinition(
+            id: "streak.3", title: "Ça mord",
+            detail: "3 jours d'affilée.",
+            symbolName: "flame", rarity: .common,
+            category: .consistency, metric: .currentStreak, goal: 3
+        ),
+        AchievementDefinition(
+            id: "streak.7", title: "Semaine parfaite",
+            detail: "7 jours d'affilée.",
+            symbolName: "flame.fill", rarity: .uncommon,
+            category: .consistency, metric: .currentStreak, goal: 7
+        ),
+        AchievementDefinition(
+            id: "streak.30", title: "Un mois sans faillir",
+            detail: "30 jours d'affilée.",
+            symbolName: "flame.circle.fill", rarity: .rare,
+            category: .consistency, metric: .longestStreak, goal: 30
+        ),
+        AchievementDefinition(
+            id: "streak.100", title: "Cent jours de braise",
+            detail: "100 jours d'affilée.",
+            symbolName: "flame.circle.fill", rarity: .epic,
+            category: .consistency, metric: .longestStreak, goal: 100
+        ),
+        AchievementDefinition(
+            id: "streak.365", title: "Une année entière",
+            detail: "365 jours d'affilée.",
+            symbolName: "sun.max.trianglebadge.exclamationmark.fill", rarity: .mythic,
+            category: .consistency, metric: .longestStreak, goal: 365
+        ),
+        AchievementDefinition(
+            id: "perfect.10", title: "Journées sans faille",
+            detail: "10 journées où tout le plan a été bouclé.",
+            symbolName: "checkmark.seal.fill", rarity: .rare,
+            category: .consistency, metric: .perfectDays, goal: 10
+        ),
+        AchievementDefinition(
+            id: "perfect.50", title: "Perfectionniste",
+            detail: "50 journées parfaites.",
+            symbolName: "seal.fill", rarity: .legendary,
+            category: .consistency, metric: .perfectDays, goal: 50
+        ),
+        AchievementDefinition(
+            id: "habit.30", title: "Nouvelle nature",
+            detail: "Tenir une habitude 30 jours de suite.",
+            symbolName: "repeat.circle.fill", rarity: .epic,
+            category: .consistency, metric: .habitChain, goal: 30
+        ),
+        AchievementDefinition(
+            id: "habit.200", title: "Rituel gravé",
+            detail: "200 validations d'habitudes.",
+            symbolName: "arrow.triangle.2.circlepath", rarity: .rare,
+            category: .consistency, metric: .habitsCompleted, goal: 200
+        ),
+        AchievementDefinition(
+            id: "loyal.365", title: "Compagnon de route",
+            detail: "Un an d'utilisation de Questly.",
+            symbolName: "heart.circle.fill", rarity: .legendary,
+            category: .consistency, metric: .loyaltyDays, goal: 365
+        )
+    ]
+
+    // MARK: Concentration
+
+    static let focus: [AchievementDefinition] = [
+        AchievementDefinition(
+            id: "focus.60", title: "Une heure au calme",
+            detail: "60 minutes de concentration cumulées.",
+            symbolName: "hourglass", rarity: .common,
+            category: .focus, metric: .focusMinutes, goal: 60
+        ),
+        AchievementDefinition(
+            id: "focus.600", title: "Dix heures d'apnée",
+            detail: "600 minutes de concentration.",
+            symbolName: "hourglass.bottomhalf.filled", rarity: .uncommon,
+            category: .focus, metric: .focusMinutes, goal: 600
+        ),
+        AchievementDefinition(
+            id: "focus.3000", title: "Moine du deep work",
+            detail: "50 heures de concentration.",
+            symbolName: "brain.head.profile", rarity: .epic,
+            category: .focus, metric: .focusMinutes, goal: 3000
+        ),
+        AchievementDefinition(
+            id: "focus.12000", title: "Le flux incarné",
+            detail: "200 heures de concentration.",
+            symbolName: "infinity.circle.fill", rarity: .mythic,
+            category: .focus, metric: .focusMinutes, goal: 12000
+        ),
+        AchievementDefinition(
+            id: "focus.sessions100", title: "Cent plongées",
+            detail: "100 sessions de concentration.",
+            symbolName: "target", rarity: .rare,
+            category: .focus, metric: .focusSessions, goal: 100
+        ),
+        AchievementDefinition(
+            id: "combo.5", title: "Enchaînement",
+            detail: "Valider 5 quêtes en moins de 5 minutes.",
+            symbolName: "bolt.fill", rarity: .uncommon,
+            category: .focus, metric: .maxCombo, goal: 5
+        ),
+        AchievementDefinition(
+            id: "combo.10", title: "Déferlante",
+            detail: "Combo ×10.",
+            symbolName: "bolt.trianglebadge.exclamationmark.fill", rarity: .epic,
+            category: .focus, metric: .maxCombo, goal: 10
+        )
+    ]
+
+    // MARK: Maîtrise
+
+    static let mastery: [AchievementDefinition] = [
+        AchievementDefinition(
+            id: "level.10", title: "Aventurier confirmé",
+            detail: "Atteindre le niveau 10.",
+            symbolName: "figure.walk", rarity: .uncommon,
+            category: .mastery, metric: .level, goal: 10
+        ),
+        AchievementDefinition(
+            id: "level.25", title: "Chevalier",
+            detail: "Atteindre le niveau 25.",
+            symbolName: "shield.fill", rarity: .rare,
+            category: .mastery, metric: .level, goal: 25
+        ),
+        AchievementDefinition(
+            id: "level.50", title: "Champion du royaume",
+            detail: "Atteindre le niveau 50.",
+            symbolName: "trophy.fill", rarity: .epic,
+            category: .mastery, metric: .level, goal: 50
+        ),
+        AchievementDefinition(
+            id: "level.100", title: "Légende vivante",
+            detail: "Atteindre le niveau 100.",
+            symbolName: "sparkles", rarity: .mythic,
+            category: .mastery, metric: .level, goal: 100
+        ),
+        AchievementDefinition(
+            id: "xp.100k", title: "Cent mille",
+            detail: "Cumuler 100 000 XP.",
+            symbolName: "chart.line.uptrend.xyaxis", rarity: .legendary,
+            category: .mastery, metric: .totalXP, goal: 100_000
+        ),
+        AchievementDefinition(
+            id: "quests.100", title: "Fidèle au tableau",
+            detail: "Terminer 100 quêtes quotidiennes.",
+            symbolName: "scroll.fill", rarity: .rare,
+            category: .mastery, metric: .questsCompleted, goal: 100
+        ),
+        AchievementDefinition(
+            id: "inbox.30", title: "Boîte au clair",
+            detail: "30 journées terminées avec une boîte de réception vide.",
+            symbolName: "tray.full.fill", rarity: .epic,
+            category: .mastery, metric: .inboxZeroDays, goal: 30
+        )
+    ]
+
+    // MARK: Équilibre
+
+    static let balance: [AchievementDefinition] = LifeArea.allCases.map { area in
+        AchievementDefinition(
+            id: "area.\(area.rawValue).50",
+            title: "Gardien·ne du domaine \(area.label)",
+            detail: "50 quêtes accomplies dans le domaine \(area.label).",
+            symbolName: area.symbolName,
+            rarity: .rare,
+            category: .balance,
+            metric: .areaCompletions(area),
+            goal: 50
+        )
+    } + LifeArea.allCases.map { area in
+        AchievementDefinition(
+            id: "attr.\(area.rawValue).10",
+            title: "\(area.label) niveau 10",
+            detail: "Porter l'attribut \(area.label) au niveau 10.",
+            symbolName: area.symbolName,
+            rarity: .epic,
+            category: .balance,
+            metric: .attributeLevel(area),
+            goal: 10
+        )
+    } + [
+        AchievementDefinition(
+            id: "balance.all", title: "Vie équilibrée",
+            detail: "Au moins 10 quêtes dans chacun des 6 domaines.",
+            symbolName: "circle.hexagongrid.fill", rarity: .legendary,
+            category: .balance, metric: .balancedAreas, goal: LifeArea.allCases.count
+        )
+    ]
+
+    // MARK: Collection
+
+    static let collection: [AchievementDefinition] = [
+        AchievementDefinition(
+            id: "coins.1000", title: "Petite bourse",
+            detail: "Gagner 1 000 pièces.",
+            symbolName: "dollarsign.circle.fill", rarity: .common,
+            category: .collection, metric: .coinsEarned, goal: 1000
+        ),
+        AchievementDefinition(
+            id: "coins.25000", title: "Dragon sur son or",
+            detail: "Gagner 25 000 pièces.",
+            symbolName: "cube.transparent.fill", rarity: .epic,
+            category: .collection, metric: .coinsEarned, goal: 25000
+        ),
+        AchievementDefinition(
+            id: "spend.5000", title: "Dépensier assumé",
+            detail: "Dépenser 5 000 pièces à l'échoppe.",
+            symbolName: "bag.fill", rarity: .rare,
+            category: .collection, metric: .coinsSpent, goal: 5000
+        ),
+        AchievementDefinition(
+            id: "gems.100", title: "Collectionneur de gemmes",
+            detail: "Obtenir 100 gemmes.",
+            symbolName: "diamond.fill", rarity: .epic,
+            category: .collection, metric: .gemsEarned, goal: 100
+        ),
+        AchievementDefinition(
+            id: "notes.50", title: "Chroniqueur",
+            detail: "Écrire 50 notes de journal.",
+            symbolName: "book.pages.fill", rarity: .uncommon,
+            category: .collection, metric: .notesWritten, goal: 50
+        ),
+        AchievementDefinition(
+            id: "blocks.200", title: "Architecte des journées",
+            detail: "Planifier 200 blocs de temps.",
+            symbolName: "rectangle.3.group.fill", rarity: .rare,
+            category: .collection, metric: .calendarBlocks, goal: 200
+        )
+    ]
+
+    // MARK: Secrets
+
+    static let secrets: [AchievementDefinition] = [
+        AchievementDefinition(
+            id: "secret.earlybird", title: "L'aube t'appartient",
+            detail: "50 quêtes accomplies avant 7 h du matin.",
+            symbolName: "sunrise.fill", rarity: .epic,
+            category: .secret, metric: .earlyBird, goal: 50, isSecret: true
+        ),
+        AchievementDefinition(
+            id: "secret.nightowl", title: "Créature de la nuit",
+            detail: "50 quêtes accomplies après 23 h.",
+            symbolName: "moon.stars.fill", rarity: .epic,
+            category: .secret, metric: .nightOwl, goal: 50, isSecret: true
+        ),
+        AchievementDefinition(
+            id: "secret.weekend", title: "Week-end productif",
+            detail: "100 quêtes accomplies un samedi ou un dimanche.",
+            symbolName: "beach.umbrella.fill", rarity: .rare,
+            category: .secret, metric: .weekendWarrior, goal: 100, isSecret: true
+        ),
+        AchievementDefinition(
+            id: "secret.marathon", title: "Marathonien",
+            detail: "Une session de concentration de 4 heures cumulées dans la journée.",
+            symbolName: "figure.run.circle.fill", rarity: .legendary,
+            category: .secret, metric: .focusMinutes, goal: 240, isSecret: true
+        )
+    ]
+}

--- a/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Gamification/Achievements.swift
+++ b/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Gamification/Achievements.swift
@@ -1,0 +1,350 @@
+import Foundation
+
+// MARK: - Snapshot
+
+/// Tous les compteurs du joueur, agrégés par le layer app puis passés au
+/// moteur de hauts faits.
+public struct PlayerSnapshot: Sendable, Equatable {
+    public var level: Int
+    public var totalXP: Int
+    public var tasksCompleted: Int
+    public var tasksCreated: Int
+    public var bossesDefeated: Int
+    public var currentStreak: Int
+    public var longestStreak: Int
+    public var focusMinutes: Int
+    public var focusSessions: Int
+    public var perfectDays: Int
+    public var earlyBirdCompletions: Int
+    public var nightOwlCompletions: Int
+    public var weekendCompletions: Int
+    public var habitsCompleted: Int
+    public var longestHabitChain: Int
+    public var projectsCompleted: Int
+    public var coinsEarned: Int
+    public var coinsSpent: Int
+    public var gemsEarned: Int
+    public var questsCompleted: Int
+    public var maxCombo: Int
+    public var inboxZeroDays: Int
+    public var onTimeCompletions: Int
+    public var completionsByArea: [LifeArea: Int]
+    public var attributeLevels: [LifeArea: Int]
+    public var calendarBlocksScheduled: Int
+    public var notesWritten: Int
+    public var daysSinceFirstLaunch: Int
+
+    public init(
+        level: Int = 1,
+        totalXP: Int = 0,
+        tasksCompleted: Int = 0,
+        tasksCreated: Int = 0,
+        bossesDefeated: Int = 0,
+        currentStreak: Int = 0,
+        longestStreak: Int = 0,
+        focusMinutes: Int = 0,
+        focusSessions: Int = 0,
+        perfectDays: Int = 0,
+        earlyBirdCompletions: Int = 0,
+        nightOwlCompletions: Int = 0,
+        weekendCompletions: Int = 0,
+        habitsCompleted: Int = 0,
+        longestHabitChain: Int = 0,
+        projectsCompleted: Int = 0,
+        coinsEarned: Int = 0,
+        coinsSpent: Int = 0,
+        gemsEarned: Int = 0,
+        questsCompleted: Int = 0,
+        maxCombo: Int = 0,
+        inboxZeroDays: Int = 0,
+        onTimeCompletions: Int = 0,
+        completionsByArea: [LifeArea: Int] = [:],
+        attributeLevels: [LifeArea: Int] = [:],
+        calendarBlocksScheduled: Int = 0,
+        notesWritten: Int = 0,
+        daysSinceFirstLaunch: Int = 0
+    ) {
+        self.level = level
+        self.totalXP = totalXP
+        self.tasksCompleted = tasksCompleted
+        self.tasksCreated = tasksCreated
+        self.bossesDefeated = bossesDefeated
+        self.currentStreak = currentStreak
+        self.longestStreak = longestStreak
+        self.focusMinutes = focusMinutes
+        self.focusSessions = focusSessions
+        self.perfectDays = perfectDays
+        self.earlyBirdCompletions = earlyBirdCompletions
+        self.nightOwlCompletions = nightOwlCompletions
+        self.weekendCompletions = weekendCompletions
+        self.habitsCompleted = habitsCompleted
+        self.longestHabitChain = longestHabitChain
+        self.projectsCompleted = projectsCompleted
+        self.coinsEarned = coinsEarned
+        self.coinsSpent = coinsSpent
+        self.gemsEarned = gemsEarned
+        self.questsCompleted = questsCompleted
+        self.maxCombo = maxCombo
+        self.inboxZeroDays = inboxZeroDays
+        self.onTimeCompletions = onTimeCompletions
+        self.completionsByArea = completionsByArea
+        self.attributeLevels = attributeLevels
+        self.calendarBlocksScheduled = calendarBlocksScheduled
+        self.notesWritten = notesWritten
+        self.daysSinceFirstLaunch = daysSinceFirstLaunch
+    }
+
+    public func value(for metric: AchievementMetric) -> Int {
+        switch metric {
+        case .level: return level
+        case .totalXP: return totalXP
+        case .tasksCompleted: return tasksCompleted
+        case .tasksCreated: return tasksCreated
+        case .bossesDefeated: return bossesDefeated
+        case .currentStreak: return currentStreak
+        case .longestStreak: return longestStreak
+        case .focusMinutes: return focusMinutes
+        case .focusSessions: return focusSessions
+        case .perfectDays: return perfectDays
+        case .earlyBird: return earlyBirdCompletions
+        case .nightOwl: return nightOwlCompletions
+        case .weekendWarrior: return weekendCompletions
+        case .habitsCompleted: return habitsCompleted
+        case .habitChain: return longestHabitChain
+        case .projectsCompleted: return projectsCompleted
+        case .coinsEarned: return coinsEarned
+        case .coinsSpent: return coinsSpent
+        case .gemsEarned: return gemsEarned
+        case .questsCompleted: return questsCompleted
+        case .maxCombo: return maxCombo
+        case .inboxZeroDays: return inboxZeroDays
+        case .onTimeCompletions: return onTimeCompletions
+        case .calendarBlocks: return calendarBlocksScheduled
+        case .notesWritten: return notesWritten
+        case .loyaltyDays: return daysSinceFirstLaunch
+        case .areaCompletions(let area): return completionsByArea[area] ?? 0
+        case .attributeLevel(let area): return attributeLevels[area] ?? 1
+        case .balancedAreas:
+            // Nombre de domaines ayant au moins 10 tâches accomplies.
+            return LifeArea.allCases.filter { (completionsByArea[$0] ?? 0) >= 10 }.count
+        }
+    }
+}
+
+// MARK: - Metric
+
+public enum AchievementMetric: Hashable, Sendable {
+    case level
+    case totalXP
+    case tasksCompleted
+    case tasksCreated
+    case bossesDefeated
+    case currentStreak
+    case longestStreak
+    case focusMinutes
+    case focusSessions
+    case perfectDays
+    case earlyBird
+    case nightOwl
+    case weekendWarrior
+    case habitsCompleted
+    case habitChain
+    case projectsCompleted
+    case coinsEarned
+    case coinsSpent
+    case gemsEarned
+    case questsCompleted
+    case maxCombo
+    case inboxZeroDays
+    case onTimeCompletions
+    case calendarBlocks
+    case notesWritten
+    case loyaltyDays
+    case areaCompletions(LifeArea)
+    case attributeLevel(LifeArea)
+    case balancedAreas
+}
+
+// MARK: - Definition
+
+public enum AchievementCategory: String, CaseIterable, Sendable, Identifiable {
+    case beginnings
+    case volume
+    case consistency
+    case focus
+    case mastery
+    case balance
+    case collection
+    case secret
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .beginnings: return "Premiers pas"
+        case .volume: return "Volume"
+        case .consistency: return "Régularité"
+        case .focus: return "Concentration"
+        case .mastery: return "Maîtrise"
+        case .balance: return "Équilibre"
+        case .collection: return "Collection"
+        case .secret: return "Secrets"
+        }
+    }
+
+    public var symbolName: String {
+        switch self {
+        case .beginnings: return "sparkle"
+        case .volume: return "square.stack.3d.up.fill"
+        case .consistency: return "flame.fill"
+        case .focus: return "timer"
+        case .mastery: return "crown.fill"
+        case .balance: return "circle.hexagongrid.fill"
+        case .collection: return "shippingbox.fill"
+        case .secret: return "eye.slash.fill"
+        }
+    }
+}
+
+public struct AchievementDefinition: Identifiable, Sendable, Equatable {
+    public let id: String
+    public let title: String
+    public let detail: String
+    public let symbolName: String
+    public let rarity: Rarity
+    public let category: AchievementCategory
+    public let metric: AchievementMetric
+    public let goal: Int
+    public let xpReward: Int
+    public let coinReward: Int
+    public let gemReward: Int
+    /// Un haut fait secret reste masqué tant qu'il n'est pas débloqué.
+    public let isSecret: Bool
+
+    public init(
+        id: String,
+        title: String,
+        detail: String,
+        symbolName: String,
+        rarity: Rarity,
+        category: AchievementCategory,
+        metric: AchievementMetric,
+        goal: Int,
+        xpReward: Int? = nil,
+        coinReward: Int? = nil,
+        gemReward: Int? = nil,
+        isSecret: Bool = false
+    ) {
+        self.id = id
+        self.title = title
+        self.detail = detail
+        self.symbolName = symbolName
+        self.rarity = rarity
+        self.category = category
+        self.metric = metric
+        self.goal = goal
+        self.xpReward = xpReward ?? AchievementDefinition.defaultXP(for: rarity)
+        self.coinReward = coinReward ?? AchievementDefinition.defaultCoins(for: rarity)
+        self.gemReward = gemReward ?? AchievementDefinition.defaultGems(for: rarity)
+        self.isSecret = isSecret
+    }
+
+    static func defaultXP(for rarity: Rarity) -> Int {
+        switch rarity {
+        case .common: return 50
+        case .uncommon: return 120
+        case .rare: return 250
+        case .epic: return 500
+        case .legendary: return 1000
+        case .mythic: return 2500
+        }
+    }
+
+    static func defaultCoins(for rarity: Rarity) -> Int {
+        switch rarity {
+        case .common: return 20
+        case .uncommon: return 50
+        case .rare: return 120
+        case .epic: return 300
+        case .legendary: return 700
+        case .mythic: return 1500
+        }
+    }
+
+    static func defaultGems(for rarity: Rarity) -> Int {
+        switch rarity {
+        case .common: return 0
+        case .uncommon: return 1
+        case .rare: return 3
+        case .epic: return 8
+        case .legendary: return 20
+        case .mythic: return 50
+        }
+    }
+}
+
+// MARK: - Progress
+
+public struct AchievementProgress: Identifiable, Sendable, Equatable {
+    public let definition: AchievementDefinition
+    public let value: Int
+    public let unlockedAt: Date?
+
+    public var id: String { definition.id }
+    public var isUnlocked: Bool { unlockedAt != nil || value >= definition.goal }
+    public var fraction: Double {
+        guard definition.goal > 0 else { return 1 }
+        return min(1, Double(value) / Double(definition.goal))
+    }
+    public var remaining: Int { max(0, definition.goal - value) }
+
+    public init(definition: AchievementDefinition, value: Int, unlockedAt: Date?) {
+        self.definition = definition
+        self.value = value
+        self.unlockedAt = unlockedAt
+    }
+}
+
+// MARK: - Engine
+
+public enum AchievementEngine {
+
+    /// Évalue tout le catalogue et renvoie la progression de chaque haut fait.
+    public static func evaluate(
+        snapshot: PlayerSnapshot,
+        unlockDates: [String: Date] = [:]
+    ) -> [AchievementProgress] {
+        AchievementCatalog.all.map { definition in
+            AchievementProgress(
+                definition: definition,
+                value: snapshot.value(for: definition.metric),
+                unlockedAt: unlockDates[definition.id]
+            )
+        }
+    }
+
+    /// Hauts faits franchis depuis le dernier passage : c'est ce qui déclenche
+    /// la fanfare et les confettis.
+    public static func newlyUnlocked(
+        snapshot: PlayerSnapshot,
+        alreadyUnlocked: Set<String>
+    ) -> [AchievementDefinition] {
+        AchievementCatalog.all.filter { definition in
+            !alreadyUnlocked.contains(definition.id)
+                && snapshot.value(for: definition.metric) >= definition.goal
+        }
+    }
+
+    /// Les prochains objectifs à portée de main, pour la carte « bientôt ».
+    public static func almostThere(
+        snapshot: PlayerSnapshot,
+        unlockDates: [String: Date] = [:],
+        limit: Int = 3
+    ) -> [AchievementProgress] {
+        evaluate(snapshot: snapshot, unlockDates: unlockDates)
+            .filter { !$0.isUnlocked && $0.fraction > 0 }
+            .sorted { $0.fraction > $1.fraction }
+            .prefix(limit)
+            .map { $0 }
+    }
+}

--- a/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Gamification/AvatarCatalog.swift
+++ b/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Gamification/AvatarCatalog.swift
@@ -1,0 +1,152 @@
+import Foundation
+
+/// Emplacements personnalisables du héros. L'avatar est composé de symboles
+/// système et d'emojis : zéro asset externe, rendu net à toutes les tailles.
+public enum AvatarSlot: String, CaseIterable, Codable, Sendable, Identifiable {
+    case face
+    case headgear
+    case companion
+    case aura
+    case frame
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .face: return "Visage"
+        case .headgear: return "Couvre-chef"
+        case .companion: return "Familier"
+        case .aura: return "Aura"
+        case .frame: return "Cadre"
+        }
+    }
+
+    public var symbolName: String {
+        switch self {
+        case .face: return "face.smiling"
+        case .headgear: return "crown"
+        case .companion: return "pawprint.fill"
+        case .aura: return "sparkles"
+        case .frame: return "circle.dashed"
+        }
+    }
+}
+
+public struct AvatarPart: Identifiable, Sendable, Equatable, Hashable {
+    public let id: String
+    public let name: String
+    public let slot: AvatarSlot
+    /// Emoji affiché pour les visages et familiers.
+    public let emoji: String?
+    /// Symbole SF utilisé pour les auras, cadres et couvre-chefs.
+    public let symbolName: String
+    public let rarity: Rarity
+    public let requiredLevel: Int
+    public let price: Price
+
+    public init(
+        id: String,
+        name: String,
+        slot: AvatarSlot,
+        emoji: String? = nil,
+        symbolName: String,
+        rarity: Rarity = .common,
+        requiredLevel: Int = 1,
+        price: Price = .free
+    ) {
+        self.id = id
+        self.name = name
+        self.slot = slot
+        self.emoji = emoji
+        self.symbolName = symbolName
+        self.rarity = rarity
+        self.requiredLevel = requiredLevel
+        self.price = price
+    }
+
+    public var isFree: Bool { price.isFree && requiredLevel <= 1 }
+}
+
+public enum AvatarCatalog {
+
+    public static let parts: [AvatarPart] = faces + headgear + companions + auras + frames
+
+    public static var purchasableParts: [AvatarPart] {
+        parts.filter { !$0.price.isFree }
+    }
+
+    public static func part(id: String) -> AvatarPart? {
+        parts.first { $0.id == id }
+    }
+
+    public static func parts(in slot: AvatarSlot) -> [AvatarPart] {
+        parts.filter { $0.slot == slot }
+    }
+
+    /// Pièces débloquées gratuitement à un niveau donné.
+    public static func unlocked(atLevel level: Int) -> [AvatarPart] {
+        parts.filter { $0.price.isFree && $0.requiredLevel <= level }
+    }
+
+    public static let defaultLoadout: [AvatarSlot: String] = [
+        .face: "face.explorer",
+        .frame: "frame.simple"
+    ]
+
+    // MARK: Visages
+
+    static let faces: [AvatarPart] = [
+        AvatarPart(id: "face.explorer", name: "Exploratrice", slot: .face, emoji: "🧭", symbolName: "face.smiling"),
+        AvatarPart(id: "face.scholar", name: "Érudit", slot: .face, emoji: "🦉", symbolName: "book.closed.fill"),
+        AvatarPart(id: "face.fox", name: "Renard", slot: .face, emoji: "🦊", symbolName: "pawprint.fill", rarity: .uncommon, requiredLevel: 3),
+        AvatarPart(id: "face.dragon", name: "Dragonnet", slot: .face, emoji: "🐉", symbolName: "flame.fill", rarity: .rare, requiredLevel: 12, price: Price(coins: 1200)),
+        AvatarPart(id: "face.robot", name: "Automate", slot: .face, emoji: "🤖", symbolName: "cpu.fill", rarity: .uncommon, requiredLevel: 6, price: Price(coins: 500)),
+        AvatarPart(id: "face.ghost", name: "Spectre", slot: .face, emoji: "👻", symbolName: "moon.fill", rarity: .rare, requiredLevel: 15, price: Price(coins: 1400)),
+        AvatarPart(id: "face.alien", name: "Voyageur", slot: .face, emoji: "👾", symbolName: "sparkle", rarity: .epic, requiredLevel: 22, price: Price(coins: 2600, gems: 4)),
+        AvatarPart(id: "face.phoenix", name: "Phénix", slot: .face, emoji: "🔥", symbolName: "flame.circle.fill", rarity: .legendary, requiredLevel: 35, price: Price(coins: 5000, gems: 15))
+    ]
+
+    // MARK: Couvre-chefs
+
+    static let headgear: [AvatarPart] = [
+        AvatarPart(id: "hat.none", name: "Tête nue", slot: .headgear, symbolName: "nosign"),
+        AvatarPart(id: "hat.band", name: "Bandeau", slot: .headgear, symbolName: "bandage.fill", requiredLevel: 2),
+        AvatarPart(id: "hat.helmet", name: "Heaume", slot: .headgear, symbolName: "shield.fill", rarity: .uncommon, requiredLevel: 7, price: Price(coins: 600)),
+        AvatarPart(id: "hat.wizard", name: "Chapeau de mage", slot: .headgear, symbolName: "wand.and.stars", rarity: .rare, requiredLevel: 13, price: Price(coins: 1300)),
+        AvatarPart(id: "hat.crown", name: "Couronne", slot: .headgear, symbolName: "crown.fill", rarity: .epic, requiredLevel: 25, price: Price(coins: 3000, gems: 6)),
+        AvatarPart(id: "hat.halo", name: "Auréole", slot: .headgear, symbolName: "circle.circle.fill", rarity: .legendary, requiredLevel: 45, price: Price(coins: 7000, gems: 20))
+    ]
+
+    // MARK: Familiers
+
+    static let companions: [AvatarPart] = [
+        AvatarPart(id: "pet.none", name: "Solitaire", slot: .companion, symbolName: "nosign"),
+        AvatarPart(id: "pet.cat", name: "Chat", slot: .companion, emoji: "🐈", symbolName: "pawprint.fill", rarity: .uncommon, requiredLevel: 4, price: Price(coins: 450)),
+        AvatarPart(id: "pet.owl", name: "Chouette", slot: .companion, emoji: "🦉", symbolName: "bird.fill", rarity: .uncommon, requiredLevel: 9, price: Price(coins: 700)),
+        AvatarPart(id: "pet.slime", name: "Gluant", slot: .companion, emoji: "🟢", symbolName: "drop.fill", rarity: .rare, requiredLevel: 16, price: Price(coins: 1500)),
+        AvatarPart(id: "pet.wolf", name: "Loup", slot: .companion, emoji: "🐺", symbolName: "pawprint.circle.fill", rarity: .epic, requiredLevel: 28, price: Price(coins: 3200, gems: 8)),
+        AvatarPart(id: "pet.dragon", name: "Petit dragon", slot: .companion, emoji: "🐲", symbolName: "flame.fill", rarity: .mythic, requiredLevel: 60, price: Price(coins: 12000, gems: 60))
+    ]
+
+    // MARK: Auras
+
+    static let auras: [AvatarPart] = [
+        AvatarPart(id: "aura.none", name: "Aucune", slot: .aura, symbolName: "nosign"),
+        AvatarPart(id: "aura.spark", name: "Étincelles", slot: .aura, symbolName: "sparkles", rarity: .uncommon, requiredLevel: 5),
+        AvatarPart(id: "aura.flame", name: "Braises", slot: .aura, symbolName: "flame.fill", rarity: .rare, requiredLevel: 18, price: Price(coins: 1600)),
+        AvatarPart(id: "aura.frost", name: "Givre", slot: .aura, symbolName: "snowflake", rarity: .rare, requiredLevel: 20, price: Price(coins: 1600)),
+        AvatarPart(id: "aura.storm", name: "Orage", slot: .aura, symbolName: "bolt.fill", rarity: .epic, requiredLevel: 30, price: Price(coins: 3400, gems: 8)),
+        AvatarPart(id: "aura.cosmos", name: "Cosmos", slot: .aura, symbolName: "moon.stars.fill", rarity: .legendary, requiredLevel: 50, price: Price(coins: 8000, gems: 25))
+    ]
+
+    // MARK: Cadres
+
+    static let frames: [AvatarPart] = [
+        AvatarPart(id: "frame.simple", name: "Cercle simple", slot: .frame, symbolName: "circle"),
+        AvatarPart(id: "frame.dashed", name: "Pointillés", slot: .frame, symbolName: "circle.dashed", requiredLevel: 3),
+        AvatarPart(id: "frame.hex", name: "Hexagone", slot: .frame, symbolName: "hexagon", rarity: .uncommon, requiredLevel: 11, price: Price(coins: 800)),
+        AvatarPart(id: "frame.laurel", name: "Laurier", slot: .frame, symbolName: "laurel.leading", rarity: .rare, requiredLevel: 21, price: Price(coins: 1800)),
+        AvatarPart(id: "frame.seal", name: "Sceau", slot: .frame, symbolName: "seal", rarity: .epic, requiredLevel: 33, price: Price(coins: 3600, gems: 9)),
+        AvatarPart(id: "frame.infinity", name: "Infini", slot: .frame, symbolName: "infinity", rarity: .mythic, requiredLevel: 70, price: Price(coins: 15000, gems: 80))
+    ]
+}

--- a/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Gamification/DailyQuests.swift
+++ b/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Gamification/DailyQuests.swift
@@ -1,0 +1,311 @@
+import Foundation
+
+// MARK: - Quest model
+
+public enum QuestKind: String, Codable, CaseIterable, Sendable {
+    case completeTasks
+    case completeHighPriority
+    case focusMinutes
+    case completeInArea
+    case completeBeforeNoon
+    case clearOverdue
+    case defeatBoss
+    case completeHabit
+    case scheduleBlocks
+    case planTomorrow
+    case completeDifficult
+    case noSnooze
+    case writeNote
+    case comboChain
+
+    public var symbolName: String {
+        switch self {
+        case .completeTasks: return "checkmark.circle.fill"
+        case .completeHighPriority: return "flame.fill"
+        case .focusMinutes: return "timer"
+        case .completeInArea: return "circle.hexagongrid.fill"
+        case .completeBeforeNoon: return "sunrise.fill"
+        case .clearOverdue: return "exclamationmark.triangle.fill"
+        case .defeatBoss: return "crown.fill"
+        case .completeHabit: return "repeat.circle.fill"
+        case .scheduleBlocks: return "calendar.badge.plus"
+        case .planTomorrow: return "moon.stars.fill"
+        case .completeDifficult: return "bolt.shield.fill"
+        case .noSnooze: return "hand.raised.fill"
+        case .writeNote: return "square.and.pencil"
+        case .comboChain: return "bolt.fill"
+        }
+    }
+}
+
+public enum QuestPeriod: String, Codable, CaseIterable, Sendable {
+    case daily
+    case weekly
+
+    public var label: String {
+        switch self {
+        case .daily: return "Quêtes du jour"
+        case .weekly: return "Défi de la semaine"
+        }
+    }
+}
+
+public struct QuestTemplate: Sendable, Equatable {
+    public let kind: QuestKind
+    public let title: String
+    public let detail: String
+    public let baseTarget: Int
+    public let rarity: Rarity
+    /// Le domaine concerné, pour les quêtes ciblées.
+    public let lifeArea: LifeArea?
+
+    public init(
+        kind: QuestKind,
+        title: String,
+        detail: String,
+        baseTarget: Int,
+        rarity: Rarity = .common,
+        lifeArea: LifeArea? = nil
+    ) {
+        self.kind = kind
+        self.title = title
+        self.detail = detail
+        self.baseTarget = baseTarget
+        self.rarity = rarity
+        self.lifeArea = lifeArea
+    }
+}
+
+public struct GeneratedQuest: Identifiable, Sendable, Equatable {
+    public let id: String
+    public let kind: QuestKind
+    public let period: QuestPeriod
+    public let title: String
+    public let detail: String
+    public let target: Int
+    public let rarity: Rarity
+    public let lifeArea: LifeArea?
+    public let xpReward: Int
+    public let coinReward: Int
+    public let gemReward: Int
+    public let symbolName: String
+
+    public init(
+        id: String,
+        kind: QuestKind,
+        period: QuestPeriod,
+        title: String,
+        detail: String,
+        target: Int,
+        rarity: Rarity,
+        lifeArea: LifeArea?,
+        xpReward: Int,
+        coinReward: Int,
+        gemReward: Int,
+        symbolName: String
+    ) {
+        self.id = id
+        self.kind = kind
+        self.period = period
+        self.title = title
+        self.detail = detail
+        self.target = target
+        self.rarity = rarity
+        self.lifeArea = lifeArea
+        self.xpReward = xpReward
+        self.coinReward = coinReward
+        self.gemReward = gemReward
+        self.symbolName = symbolName
+    }
+
+    public func progressFraction(_ value: Int) -> Double {
+        guard target > 0 else { return 1 }
+        return min(1, Double(value) / Double(target))
+    }
+}
+
+// MARK: - Generator
+
+/// Génère le tableau de quêtes. Déterministe : le même jour et le même niveau
+/// produisent toujours les mêmes quêtes, ce qui évite qu'un rafraîchissement
+/// de vue rebatte les cartes.
+public enum QuestGenerator {
+
+    public static let dailyTemplates: [QuestTemplate] = [
+        QuestTemplate(kind: .completeTasks, title: "Trois pour commencer",
+                      detail: "Accomplir %d quêtes aujourd'hui.", baseTarget: 3),
+        QuestTemplate(kind: .completeTasks, title: "Journée productive",
+                      detail: "Accomplir %d quêtes aujourd'hui.", baseTarget: 5, rarity: .uncommon),
+        QuestTemplate(kind: .completeHighPriority, title: "Droit au but",
+                      detail: "Boucler %d quête(s) de priorité P1 ou P2.", baseTarget: 1, rarity: .uncommon),
+        QuestTemplate(kind: .focusMinutes, title: "Plongée profonde",
+                      detail: "Cumuler %d minutes de concentration.", baseTarget: 25),
+        QuestTemplate(kind: .focusMinutes, title: "Session longue",
+                      detail: "Cumuler %d minutes de concentration.", baseTarget: 50, rarity: .rare),
+        QuestTemplate(kind: .completeBeforeNoon, title: "Lève-tôt",
+                      detail: "Accomplir %d quête(s) avant midi.", baseTarget: 2, rarity: .uncommon),
+        QuestTemplate(kind: .clearOverdue, title: "Nettoyage de printemps",
+                      detail: "Traiter %d quête(s) en retard.", baseTarget: 1, rarity: .uncommon),
+        QuestTemplate(kind: .defeatBoss, title: "Face au colosse",
+                      detail: "Vaincre %d boss.", baseTarget: 1, rarity: .rare),
+        QuestTemplate(kind: .completeHabit, title: "Rituel du jour",
+                      detail: "Valider %d habitude(s).", baseTarget: 2),
+        QuestTemplate(kind: .scheduleBlocks, title: "Journée orchestrée",
+                      detail: "Placer %d bloc(s) dans le calendrier.", baseTarget: 2),
+        QuestTemplate(kind: .planTomorrow, title: "Un pas d'avance",
+                      detail: "Planifier %d quête(s) pour demain.", baseTarget: 3),
+        QuestTemplate(kind: .completeDifficult, title: "Sortir de sa zone",
+                      detail: "Accomplir %d quête(s) ardue(s) ou plus.", baseTarget: 1, rarity: .rare),
+        QuestTemplate(kind: .writeNote, title: "Tenir la chronique",
+                      detail: "Écrire %d note de journal.", baseTarget: 1),
+        QuestTemplate(kind: .comboChain, title: "Enchaînement",
+                      detail: "Atteindre un combo de %d.", baseTarget: 3, rarity: .rare)
+    ]
+
+    public static let weeklyTemplates: [QuestTemplate] = [
+        QuestTemplate(kind: .completeTasks, title: "Semaine chargée",
+                      detail: "Accomplir %d quêtes cette semaine.", baseTarget: 25, rarity: .rare),
+        QuestTemplate(kind: .focusMinutes, title: "Cinq heures de flux",
+                      detail: "Cumuler %d minutes de concentration.", baseTarget: 300, rarity: .epic),
+        QuestTemplate(kind: .defeatBoss, title: "Chasse hebdomadaire",
+                      detail: "Vaincre %d boss.", baseTarget: 3, rarity: .epic),
+        QuestTemplate(kind: .completeHighPriority, title: "L'essentiel d'abord",
+                      detail: "Boucler %d quêtes prioritaires.", baseTarget: 7, rarity: .rare),
+        QuestTemplate(kind: .completeHabit, title: "Constance",
+                      detail: "Valider %d habitudes.", baseTarget: 12, rarity: .rare)
+    ]
+
+    /// Trois quêtes quotidiennes + un défi hebdomadaire.
+    public static func generate(
+        for date: Date,
+        playerLevel: Int,
+        preferredAreas: [LifeArea] = [],
+        calendar: Calendar = .questly()
+    ) -> [GeneratedQuest] {
+        var quests = daily(for: date, playerLevel: playerLevel, preferredAreas: preferredAreas, calendar: calendar)
+        quests.append(weekly(for: date, playerLevel: playerLevel, calendar: calendar))
+        return quests
+    }
+
+    public static func daily(
+        for date: Date,
+        playerLevel: Int,
+        preferredAreas: [LifeArea] = [],
+        count: Int = 3,
+        calendar: Calendar = .questly()
+    ) -> [GeneratedQuest] {
+        let daySeed = seed(for: calendar.startOfDay(for: date), salt: 0x5175_6573)
+        var rng = SeededRandom(seed: daySeed)
+        var pool = dailyTemplates
+        var chosen: [QuestTemplate] = []
+
+        // Une quête ciblée sur un domaine délaissé, si l'app en connaît.
+        if let area = preferredAreas.first {
+            chosen.append(QuestTemplate(
+                kind: .completeInArea,
+                title: "Cap sur \(area.label)",
+                detail: "Accomplir %d quête(s) du domaine \(area.label).",
+                baseTarget: 2,
+                rarity: .uncommon,
+                lifeArea: area
+            ))
+        }
+
+        while chosen.count < count && !pool.isEmpty {
+            let index = Int(rng.next(upperBound: UInt64(pool.count)))
+            let template = pool.remove(at: index)
+            if chosen.contains(where: { $0.kind == template.kind }) { continue }
+            chosen.append(template)
+        }
+
+        let dayKey = Self.dayKey(date, calendar: calendar)
+        return chosen.enumerated().map { offset, template in
+            build(template: template, period: .daily, playerLevel: playerLevel, idSuffix: "\(dayKey).\(offset)")
+        }
+    }
+
+    public static func weekly(
+        for date: Date,
+        playerLevel: Int,
+        calendar: Calendar = .questly()
+    ) -> GeneratedQuest {
+        let weekStart = calendar.startOfWeek(date)
+        var rng = SeededRandom(seed: seed(for: weekStart, salt: 0x5765_656B))
+        let index = Int(rng.next(upperBound: UInt64(weeklyTemplates.count)))
+        let template = weeklyTemplates[index]
+        let key = Self.dayKey(weekStart, calendar: calendar)
+        return build(template: template, period: .weekly, playerLevel: playerLevel, idSuffix: "w.\(key)")
+    }
+
+    // MARK: Helpers
+
+    static func build(
+        template: QuestTemplate,
+        period: QuestPeriod,
+        playerLevel: Int,
+        idSuffix: String
+    ) -> GeneratedQuest {
+        // La cible croît doucement avec le niveau, plafonnée pour rester tenable.
+        let scale = 1.0 + min(Double(playerLevel - 1) * 0.03, 1.0)
+        let target = max(1, Int((Double(template.baseTarget) * scale).rounded()))
+
+        let rarityBoost = Double(template.rarity.rawValue + 1)
+        let periodBoost = period == .weekly ? 4.0 : 1.0
+        let xp = Int((40.0 * rarityBoost * periodBoost).rounded())
+        let coins = Int((15.0 * rarityBoost * periodBoost).rounded())
+        let gems = period == .weekly ? max(1, template.rarity.rawValue) : (template.rarity >= .rare ? 1 : 0)
+
+        return GeneratedQuest(
+            id: "\(template.kind.rawValue).\(idSuffix)",
+            kind: template.kind,
+            period: period,
+            title: template.title,
+            detail: String(format: template.detail, target),
+            target: target,
+            rarity: template.rarity,
+            lifeArea: template.lifeArea,
+            xpReward: xp,
+            coinReward: coins,
+            gemReward: gems,
+            symbolName: template.kind.symbolName
+        )
+    }
+
+    static func dayKey(_ date: Date, calendar: Calendar) -> String {
+        let c = calendar.dateComponents([.year, .month, .day], from: date)
+        return String(format: "%04d%02d%02d", c.year ?? 0, c.month ?? 0, c.day ?? 0)
+    }
+
+    static func seed(for date: Date, salt: UInt64) -> UInt64 {
+        let days = UInt64(bitPattern: Int64(date.timeIntervalSince1970 / 86400))
+        return days &* 0x9E37_79B9_7F4A_7C15 &+ salt
+    }
+}
+
+// MARK: - Deterministic RNG
+
+/// Générateur SplitMix64 : reproductible, rapide, sans dépendance système.
+public struct SeededRandom: RandomNumberGenerator, Sendable {
+    private var state: UInt64
+
+    public init(seed: UInt64) {
+        self.state = seed == 0 ? 0x9E37_79B9_7F4A_7C15 : seed
+    }
+
+    public mutating func next() -> UInt64 {
+        state = state &+ 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+
+    public mutating func next(upperBound: UInt64) -> UInt64 {
+        guard upperBound > 0 else { return 0 }
+        return next() % upperBound
+    }
+
+    public mutating func nextDouble() -> Double {
+        Double(next() >> 11) * (1.0 / 9_007_199_254_740_992.0)
+    }
+}

--- a/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Gamification/Economy.swift
+++ b/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Gamification/Economy.swift
@@ -1,0 +1,349 @@
+import Foundation
+
+// MARK: - Currencies
+
+public struct Wallet: Sendable, Equatable, Codable {
+    public var coins: Int
+    public var gems: Int
+
+    public init(coins: Int = 0, gems: Int = 0) {
+        self.coins = coins
+        self.gems = gems
+    }
+
+    public func canAfford(_ price: Price) -> Bool {
+        coins >= price.coins && gems >= price.gems
+    }
+
+    public mutating func spend(_ price: Price) -> Bool {
+        guard canAfford(price) else { return false }
+        coins -= price.coins
+        gems -= price.gems
+        return true
+    }
+
+    public mutating func earn(coins: Int = 0, gems: Int = 0) {
+        self.coins += max(0, coins)
+        self.gems += max(0, gems)
+    }
+}
+
+public struct Price: Sendable, Equatable, Hashable, Codable {
+    public var coins: Int
+    public var gems: Int
+
+    public init(coins: Int = 0, gems: Int = 0) {
+        self.coins = coins
+        self.gems = gems
+    }
+
+    public static let free = Price()
+    public var isFree: Bool { coins == 0 && gems == 0 }
+}
+
+// MARK: - Shop
+
+public enum ShopCategory: String, CaseIterable, Sendable, Identifiable {
+    case consumable
+    case theme
+    case avatar
+    case chest
+    case utility
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .consumable: return "Potions"
+        case .theme: return "Ambiances"
+        case .avatar: return "Apparence"
+        case .chest: return "Coffres"
+        case .utility: return "Confort"
+        }
+    }
+
+    public var symbolName: String {
+        switch self {
+        case .consumable: return "flask.fill"
+        case .theme: return "paintpalette.fill"
+        case .avatar: return "person.crop.circle.fill"
+        case .chest: return "shippingbox.fill"
+        case .utility: return "gearshape.fill"
+        }
+    }
+}
+
+public enum ShopEffect: Sendable, Equatable, Codable, Hashable {
+    case xpBoost(multiplier: Double, hours: Int)
+    case streakFreeze(count: Int)
+    case restDayToken(count: Int)
+    case unlockTheme(id: String)
+    case unlockAvatarPart(id: String)
+    case openChest(tier: Int)
+    case coinPouch(amount: Int)
+}
+
+public struct ShopItem: Identifiable, Sendable, Equatable {
+    public let id: String
+    public let name: String
+    public let detail: String
+    public let symbolName: String
+    public let rarity: Rarity
+    public let category: ShopCategory
+    public let price: Price
+    public let effect: ShopEffect
+    /// Niveau minimum requis pour voir l'objet en boutique.
+    public let requiredLevel: Int
+    /// Un objet consommable peut être racheté indéfiniment.
+    public let isConsumable: Bool
+
+    public init(
+        id: String,
+        name: String,
+        detail: String,
+        symbolName: String,
+        rarity: Rarity,
+        category: ShopCategory,
+        price: Price,
+        effect: ShopEffect,
+        requiredLevel: Int = 1,
+        isConsumable: Bool = false
+    ) {
+        self.id = id
+        self.name = name
+        self.detail = detail
+        self.symbolName = symbolName
+        self.rarity = rarity
+        self.category = category
+        self.price = price
+        self.effect = effect
+        self.requiredLevel = requiredLevel
+        self.isConsumable = isConsumable
+    }
+}
+
+public enum ShopCatalog {
+
+    public static let all: [ShopItem] = consumables + themes + avatarItems + chests + utilities
+
+    public static func item(id: String) -> ShopItem? {
+        all.first { $0.id == id }
+    }
+
+    public static func available(forLevel level: Int) -> [ShopItem] {
+        all.filter { $0.requiredLevel <= level }
+    }
+
+    static let consumables: [ShopItem] = [
+        ShopItem(id: "potion.xp.small", name: "Fiole d'expérience",
+                 detail: "×1,5 XP pendant 2 heures.",
+                 symbolName: "flask.fill", rarity: .common, category: .consumable,
+                 price: Price(coins: 150), effect: .xpBoost(multiplier: 1.5, hours: 2),
+                 isConsumable: true),
+        ShopItem(id: "potion.xp.large", name: "Élixir d'expérience",
+                 detail: "×2 XP pendant 4 heures.",
+                 symbolName: "testtube.2", rarity: .rare, category: .consumable,
+                 price: Price(coins: 600, gems: 2), effect: .xpBoost(multiplier: 2.0, hours: 4),
+                 requiredLevel: 8, isConsumable: true),
+        ShopItem(id: "freeze.single", name: "Gel de série",
+                 detail: "Protège la série pour une journée manquée.",
+                 symbolName: "snowflake", rarity: .uncommon, category: .consumable,
+                 price: Price(coins: 250), effect: .streakFreeze(count: 1),
+                 isConsumable: true),
+        ShopItem(id: "freeze.triple", name: "Trio de gels",
+                 detail: "Trois journées de protection d'un coup.",
+                 symbolName: "snowflake.circle.fill", rarity: .rare, category: .consumable,
+                 price: Price(coins: 650), effect: .streakFreeze(count: 3),
+                 requiredLevel: 5, isConsumable: true),
+        ShopItem(id: "restday", name: "Jour de repos",
+                 detail: "Un jour neutre, sans culpabilité, qui ne casse rien.",
+                 symbolName: "moon.zzz.fill", rarity: .uncommon, category: .consumable,
+                 price: Price(coins: 300), effect: .restDayToken(count: 1),
+                 isConsumable: true)
+    ]
+
+    static let themes: [ShopItem] = [
+        ShopItem(id: "theme.nebula", name: "Nébuleuse",
+                 detail: "Violets profonds et poussière d'étoiles.",
+                 symbolName: "sparkles", rarity: .common, category: .theme,
+                 price: .free, effect: .unlockTheme(id: "nebula")),
+        ShopItem(id: "theme.aurora", name: "Aurore",
+                 detail: "Roses et oranges de lever de soleil.",
+                 symbolName: "sunrise.fill", rarity: .uncommon, category: .theme,
+                 price: Price(coins: 800), effect: .unlockTheme(id: "aurora"), requiredLevel: 3),
+        ShopItem(id: "theme.forest", name: "Sylve",
+                 detail: "Émeraude et mousse, pour rester calme.",
+                 symbolName: "leaf.fill", rarity: .uncommon, category: .theme,
+                 price: Price(coins: 800), effect: .unlockTheme(id: "forest"), requiredLevel: 5),
+        ShopItem(id: "theme.ocean", name: "Abysse",
+                 detail: "Bleus profonds et reflets turquoise.",
+                 symbolName: "water.waves", rarity: .rare, category: .theme,
+                 price: Price(coins: 1500), effect: .unlockTheme(id: "ocean"), requiredLevel: 10),
+        ShopItem(id: "theme.ember", name: "Braise",
+                 detail: "Ambre et charbon ardent.",
+                 symbolName: "flame.fill", rarity: .rare, category: .theme,
+                 price: Price(coins: 1500), effect: .unlockTheme(id: "ember"), requiredLevel: 14),
+        ShopItem(id: "theme.ink", name: "Encre",
+                 detail: "Monochrome absolu, pour les puristes.",
+                 symbolName: "circle.lefthalf.filled", rarity: .epic, category: .theme,
+                 price: Price(coins: 2500, gems: 5), effect: .unlockTheme(id: "ink"), requiredLevel: 20),
+        ShopItem(id: "theme.candy", name: "Guimauve",
+                 detail: "Pastels sucrés et coins arrondis.",
+                 symbolName: "birthday.cake.fill", rarity: .epic, category: .theme,
+                 price: Price(coins: 2500, gems: 5), effect: .unlockTheme(id: "candy"), requiredLevel: 25),
+        ShopItem(id: "theme.gold", name: "Âge d'or",
+                 detail: "Or liquide sur noir. Réservé aux légendes.",
+                 symbolName: "crown.fill", rarity: .legendary, category: .theme,
+                 price: Price(coins: 6000, gems: 25), effect: .unlockTheme(id: "gold"), requiredLevel: 40)
+    ]
+
+    static let avatarItems: [ShopItem] = AvatarCatalog.purchasableParts.map { part in
+        ShopItem(
+            id: "avatar.\(part.id)",
+            name: part.name,
+            detail: part.slot.label,
+            symbolName: part.symbolName,
+            rarity: part.rarity,
+            category: .avatar,
+            price: part.price,
+            effect: .unlockAvatarPart(id: part.id),
+            requiredLevel: part.requiredLevel
+        )
+    }
+
+    static let chests: [ShopItem] = [
+        ShopItem(id: "chest.wood", name: "Coffre de bois",
+                 detail: "Un butin modeste, mais garanti.",
+                 symbolName: "shippingbox.fill", rarity: .common, category: .chest,
+                 price: Price(coins: 200), effect: .openChest(tier: 1), isConsumable: true),
+        ShopItem(id: "chest.silver", name: "Coffre d'argent",
+                 detail: "De meilleures chances de rareté.",
+                 symbolName: "shippingbox.circle.fill", rarity: .rare, category: .chest,
+                 price: Price(coins: 750), effect: .openChest(tier: 2), requiredLevel: 8, isConsumable: true),
+        ShopItem(id: "chest.gold", name: "Coffre doré",
+                 detail: "Du légendaire à portée de main.",
+                 symbolName: "cube.transparent.fill", rarity: .legendary, category: .chest,
+                 price: Price(coins: 2000, gems: 3), effect: .openChest(tier: 3), requiredLevel: 18, isConsumable: true)
+    ]
+
+    static let utilities: [ShopItem] = [
+        ShopItem(id: "pouch.small", name: "Bourse d'appoint",
+                 detail: "Convertit 1 gemme en 400 pièces.",
+                 symbolName: "bag.fill", rarity: .common, category: .utility,
+                 price: Price(gems: 1), effect: .coinPouch(amount: 400), isConsumable: true)
+    ]
+}
+
+// MARK: - Loot
+
+public struct LootDrop: Identifiable, Sendable, Equatable {
+    public let id: String
+    public let name: String
+    public let symbolName: String
+    public let rarity: Rarity
+    public let effect: ShopEffect
+
+    public init(id: String, name: String, symbolName: String, rarity: Rarity, effect: ShopEffect) {
+        self.id = id
+        self.name = name
+        self.symbolName = symbolName
+        self.rarity = rarity
+        self.effect = effect
+    }
+}
+
+public enum LootEngine {
+
+    /// Tire une rareté selon les poids, avec un bonus de palier pour les
+    /// coffres de meilleure qualité.
+    public static func rollRarity(tier: Int, rng: inout SeededRandom) -> Rarity {
+        let bonus = Double(max(0, tier - 1))
+        let weights = Rarity.allCases.map { rarity -> Double in
+            // Les coffres supérieurs poussent la distribution vers le haut.
+            let shift = pow(1.0 + 0.55 * bonus, Double(rarity.rawValue))
+            return rarity.lootWeight * shift
+        }
+        let total = weights.reduce(0, +)
+        var roll = rng.nextDouble() * total
+        for (index, weight) in weights.enumerated() {
+            roll -= weight
+            if roll <= 0 { return Rarity.allCases[index] }
+        }
+        return .common
+    }
+
+    /// Ouvre un coffre : 1 à 3 objets selon le palier.
+    public static func openChest(tier: Int, seed: UInt64) -> [LootDrop] {
+        var rng = SeededRandom(seed: seed)
+        let count = min(3, max(1, tier))
+        return (0..<count).map { index in
+            let rarity = rollRarity(tier: tier, rng: &rng)
+            return drop(for: rarity, index: index, rng: &rng)
+        }
+    }
+
+    static func drop(for rarity: Rarity, index: Int, rng: inout SeededRandom) -> LootDrop {
+        let coinAmount = coinValue(for: rarity)
+        let choice = rng.next(upperBound: 100)
+
+        if choice < 45 {
+            return LootDrop(
+                id: "loot.coins.\(rarity.rawValue).\(index)",
+                name: "\(coinAmount) pièces",
+                symbolName: "dollarsign.circle.fill",
+                rarity: rarity,
+                effect: .coinPouch(amount: coinAmount)
+            )
+        }
+        if choice < 65 {
+            let count = max(1, rarity.rawValue)
+            return LootDrop(
+                id: "loot.freeze.\(rarity.rawValue).\(index)",
+                name: count > 1 ? "\(count) gels de série" : "Gel de série",
+                symbolName: "snowflake",
+                rarity: rarity,
+                effect: .streakFreeze(count: count)
+            )
+        }
+        if choice < 85 {
+            let multiplier = 1.25 + Double(rarity.rawValue) * 0.25
+            let hours = 1 + rarity.rawValue
+            return LootDrop(
+                id: "loot.boost.\(rarity.rawValue).\(index)",
+                name: "Potion ×\(String(format: "%.2f", multiplier))",
+                symbolName: "flask.fill",
+                rarity: rarity,
+                effect: .xpBoost(multiplier: multiplier, hours: hours)
+            )
+        }
+        // Objet cosmétique : on pioche dans les pièces d'avatar de cette rareté.
+        let parts = AvatarCatalog.parts.filter { $0.rarity == rarity }
+        if let part = parts.isEmpty ? nil : parts[Int(rng.next(upperBound: UInt64(parts.count)))] {
+            return LootDrop(
+                id: "loot.part.\(part.id)",
+                name: part.name,
+                symbolName: part.symbolName,
+                rarity: rarity,
+                effect: .unlockAvatarPart(id: part.id)
+            )
+        }
+        return LootDrop(
+            id: "loot.coins.fallback.\(index)",
+            name: "\(coinAmount) pièces",
+            symbolName: "dollarsign.circle.fill",
+            rarity: rarity,
+            effect: .coinPouch(amount: coinAmount)
+        )
+    }
+
+    static func coinValue(for rarity: Rarity) -> Int {
+        switch rarity {
+        case .common: return 60
+        case .uncommon: return 150
+        case .rare: return 400
+        case .epic: return 900
+        case .legendary: return 2000
+        case .mythic: return 5000
+        }
+    }
+}

--- a/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Gamification/LevelCurve.swift
+++ b/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Gamification/LevelCurve.swift
@@ -1,0 +1,237 @@
+import Foundation
+
+/// Courbe de progression du héros.
+///
+/// Le coût d'un niveau suit `100 · n^1.32`, ce qui donne une montée rapide au
+/// début (niveau 2 en une journée motivée) puis un palier de plus en plus long,
+/// sans jamais devenir décourageant.
+public enum LevelCurve {
+    public static let minLevel = 1
+    public static let maxLevel = 999
+
+    /// XP nécessaire pour passer de `level` à `level + 1`.
+    public static func xpToAdvance(from level: Int) -> Int {
+        guard level >= minLevel else { return 0 }
+        guard level < maxLevel else { return 0 }
+        return Int((100.0 * pow(Double(level), 1.32)).rounded())
+    }
+
+    /// XP cumulé nécessaire pour atteindre `level`. Le niveau 1 démarre à 0.
+    public static func totalXP(toReach level: Int) -> Int {
+        let clamped = min(max(level, minLevel), maxLevel)
+        return cumulativeTable[clamped - 1]
+    }
+
+    /// Niveau correspondant à un total d'XP donné.
+    public static func level(forTotalXP xp: Int) -> Int {
+        guard xp > 0 else { return minLevel }
+        // Recherche dichotomique dans la table cumulée.
+        var low = 0
+        var high = cumulativeTable.count - 1
+        while low < high {
+            let mid = (low + high + 1) / 2
+            if cumulativeTable[mid] <= xp { low = mid } else { high = mid - 1 }
+        }
+        return low + 1
+    }
+
+    /// Détail de la progression : utile pour la barre d'XP et l'anneau de niveau.
+    public static func progress(forTotalXP xp: Int) -> LevelProgress {
+        let level = level(forTotalXP: xp)
+        let floorXP = totalXP(toReach: level)
+        let needed = xpToAdvance(from: level)
+        let into = max(0, xp - floorXP)
+        let fraction: Double
+        if needed <= 0 {
+            fraction = 1
+        } else {
+            fraction = min(1, max(0, Double(into) / Double(needed)))
+        }
+        return LevelProgress(
+            level: level,
+            totalXP: xp,
+            xpIntoLevel: into,
+            xpRequiredForLevel: needed,
+            fraction: fraction,
+            rank: Rank.forLevel(level)
+        )
+    }
+
+    /// Table cumulée pré-calculée : `cumulativeTable[i]` = XP total du niveau `i + 1`.
+    private static let cumulativeTable: [Int] = {
+        var table = [Int]()
+        table.reserveCapacity(maxLevel)
+        var running = 0
+        for level in minLevel...maxLevel {
+            table.append(running)
+            running += Int((100.0 * pow(Double(level), 1.32)).rounded())
+        }
+        return table
+    }()
+}
+
+// MARK: - Level progress
+
+public struct LevelProgress: Equatable, Sendable {
+    public let level: Int
+    public let totalXP: Int
+    public let xpIntoLevel: Int
+    public let xpRequiredForLevel: Int
+    public let fraction: Double
+    public let rank: Rank
+
+    public init(
+        level: Int,
+        totalXP: Int,
+        xpIntoLevel: Int,
+        xpRequiredForLevel: Int,
+        fraction: Double,
+        rank: Rank
+    ) {
+        self.level = level
+        self.totalXP = totalXP
+        self.xpIntoLevel = xpIntoLevel
+        self.xpRequiredForLevel = xpRequiredForLevel
+        self.fraction = fraction
+        self.rank = rank
+    }
+
+    public var xpRemaining: Int { max(0, xpRequiredForLevel - xpIntoLevel) }
+
+    public static let zero = LevelProgress(
+        level: 1, totalXP: 0, xpIntoLevel: 0,
+        xpRequiredForLevel: LevelCurve.xpToAdvance(from: 1),
+        fraction: 0, rank: .novice
+    )
+}
+
+// MARK: - Ranks
+
+/// Titres honorifiques débloqués tous les 5 niveaux.
+public enum Rank: Int, CaseIterable, Codable, Sendable, Identifiable, Comparable {
+    case novice = 0
+    case apprentice
+    case squire
+    case adventurer
+    case knight
+    case veteran
+    case champion
+    case master
+    case grandMaster
+    case hero
+    case legend
+    case myth
+    case ascendant
+    case eternal
+
+    public var id: Int { rawValue }
+
+    public var title: String {
+        switch self {
+        case .novice: return "Novice"
+        case .apprentice: return "Apprenti·e"
+        case .squire: return "Écuyer·ère"
+        case .adventurer: return "Aventurier·ère"
+        case .knight: return "Chevalier·ère"
+        case .veteran: return "Vétéran·e"
+        case .champion: return "Champion·ne"
+        case .master: return "Maître"
+        case .grandMaster: return "Grand Maître"
+        case .hero: return "Héros"
+        case .legend: return "Légende"
+        case .myth: return "Mythe"
+        case .ascendant: return "Ascendant·e"
+        case .eternal: return "Éternel·le"
+        }
+    }
+
+    public var symbolName: String {
+        switch self {
+        case .novice: return "leaf"
+        case .apprentice: return "book.closed.fill"
+        case .squire: return "shield.fill"
+        case .adventurer: return "map.fill"
+        case .knight: return "shield.lefthalf.filled.badge.checkmark"
+        case .veteran: return "medal.fill"
+        case .champion: return "trophy.fill"
+        case .master: return "crown.fill"
+        case .grandMaster: return "seal.fill"
+        case .hero: return "star.circle.fill"
+        case .legend: return "flame.fill"
+        case .myth: return "sparkles"
+        case .ascendant: return "moon.stars.fill"
+        case .eternal: return "infinity"
+        }
+    }
+
+    public var hex: String {
+        switch self {
+        case .novice: return "9CA3AF"
+        case .apprentice: return "7DD3FC"
+        case .squire: return "38BDF8"
+        case .adventurer: return "34D399"
+        case .knight: return "22C55E"
+        case .veteran: return "FACC15"
+        case .champion: return "FB923C"
+        case .master: return "F97316"
+        case .grandMaster: return "EF4444"
+        case .hero: return "EC4899"
+        case .legend: return "A855F7"
+        case .myth: return "8B5CF6"
+        case .ascendant: return "6366F1"
+        case .eternal: return "F5D0FE"
+        }
+    }
+
+    /// Niveau minimum requis pour ce rang.
+    public var minimumLevel: Int { rawValue * 5 + 1 }
+
+    public static func forLevel(_ level: Int) -> Rank {
+        let index = max(0, (level - 1) / 5)
+        let clamped = min(index, Rank.allCases.count - 1)
+        return Rank(rawValue: clamped) ?? .novice
+    }
+
+    public static func < (lhs: Rank, rhs: Rank) -> Bool { lhs.rawValue < rhs.rawValue }
+}
+
+// MARK: - Attribute levels
+
+/// Progression d'un attribut (domaine de vie). Courbe plus douce que la
+/// progression globale : on veut voir les attributs bouger souvent.
+public enum AttributeCurve {
+    public static let maxLevel = 100
+
+    public static func xpToAdvance(from level: Int) -> Int {
+        guard level >= 1, level < maxLevel else { return 0 }
+        return 60 + (level - 1) * 40
+    }
+
+    public static func totalXP(toReach level: Int) -> Int {
+        let clamped = min(max(level, 1), maxLevel)
+        var total = 0
+        for l in 1..<clamped { total += xpToAdvance(from: l) }
+        return total
+    }
+
+    public static func level(forTotalXP xp: Int) -> Int {
+        var level = 1
+        var remaining = xp
+        while level < maxLevel {
+            let cost = xpToAdvance(from: level)
+            if remaining < cost { break }
+            remaining -= cost
+            level += 1
+        }
+        return level
+    }
+
+    public static func progress(forTotalXP xp: Int) -> (level: Int, into: Int, required: Int, fraction: Double) {
+        let level = level(forTotalXP: xp)
+        let floorXP = totalXP(toReach: level)
+        let required = xpToAdvance(from: level)
+        let into = max(0, xp - floorXP)
+        let fraction = required > 0 ? min(1, Double(into) / Double(required)) : 1
+        return (level, into, required, fraction)
+    }
+}

--- a/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Gamification/StreakEngine.swift
+++ b/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Gamification/StreakEngine.swift
@@ -1,0 +1,232 @@
+import Foundation
+
+/// État complet de la série de jours actifs.
+public struct StreakState: Equatable, Sendable {
+    public var current: Int
+    public var longest: Int
+    public var lastActiveDay: Date?
+    /// Jours sauvés par un jeton de protection lors de ce calcul.
+    public var freezesConsumed: Int
+    /// `true` si la série tient encore mais qu'aucune tâche n'a été validée aujourd'hui.
+    public var isAtRisk: Bool
+    /// Nombre total de jours actifs enregistrés.
+    public var totalActiveDays: Int
+
+    public init(
+        current: Int = 0,
+        longest: Int = 0,
+        lastActiveDay: Date? = nil,
+        freezesConsumed: Int = 0,
+        isAtRisk: Bool = false,
+        totalActiveDays: Int = 0
+    ) {
+        self.current = current
+        self.longest = longest
+        self.lastActiveDay = lastActiveDay
+        self.freezesConsumed = freezesConsumed
+        self.isAtRisk = isAtRisk
+        self.totalActiveDays = totalActiveDays
+    }
+
+    public static let empty = StreakState()
+
+    /// Paliers de série qui déclenchent une célébration.
+    public var milestoneReached: Int? {
+        let milestones = [3, 7, 14, 21, 30, 50, 75, 100, 150, 200, 365, 500, 1000]
+        return milestones.contains(current) ? current : nil
+    }
+}
+
+/// Calcule les séries à partir de l'historique d'activité.
+///
+/// Trois soupapes évitent la spirale de culpabilité qui tue les apps de
+/// productivité : le jour en cours ne casse jamais la série (grâce jusqu'à
+/// minuit), les jours de repos choisis sont neutres, et les jetons de
+/// protection comblent automatiquement un trou isolé.
+public enum StreakEngine {
+
+    public struct Configuration: Sendable, Equatable {
+        /// Jours de la semaine neutres (1 = dimanche … 7 = samedi).
+        public var restWeekdays: Set<Int>
+        /// Jetons de protection disponibles.
+        public var availableFreezes: Int
+        /// Un jeton ne peut combler qu'un trou d'au plus N jours.
+        public var maxGapPerFreeze: Int
+
+        public init(
+            restWeekdays: Set<Int> = [],
+            availableFreezes: Int = 0,
+            maxGapPerFreeze: Int = 1
+        ) {
+            self.restWeekdays = restWeekdays
+            self.availableFreezes = availableFreezes
+            self.maxGapPerFreeze = maxGapPerFreeze
+        }
+
+        public static let `default` = Configuration()
+    }
+
+    /// - Parameter activeDays: dates (normalisées au début de journée) où au
+    ///   moins une quête a été accomplie.
+    public static func evaluate(
+        activeDays: Set<Date>,
+        today: Date,
+        configuration: Configuration = .default,
+        calendar: Calendar = .questly()
+    ) -> StreakState {
+        let normalized = Set(activeDays.map { calendar.startOfDay(for: $0) })
+        guard !normalized.isEmpty else {
+            return StreakState(current: 0, longest: 0, lastActiveDay: nil, freezesConsumed: 0, isAtRisk: false, totalActiveDays: 0)
+        }
+
+        let todayStart = calendar.startOfDay(for: today)
+        let lastActive = normalized.max()
+
+        // --- Série courante -------------------------------------------------
+        var current = 0
+        var freezesLeft = configuration.availableFreezes
+        var freezesConsumed = 0
+        var cursor = todayStart
+        var isAtRisk = false
+
+        if !normalized.contains(todayStart) {
+            // Le jour en cours n'est pas encore validé : on ne le compte pas,
+            // mais il ne casse pas la série tant qu'il n'est pas terminé.
+            if !isRestDay(todayStart, configuration: configuration, calendar: calendar) {
+                isAtRisk = true
+            }
+            cursor = todayStart.adding(days: -1, calendar: calendar)
+        }
+
+        var guardCounter = 0
+        let hardLimit = 4000
+        while guardCounter < hardLimit {
+            guardCounter += 1
+            if normalized.contains(cursor) {
+                current += 1
+                cursor = cursor.adding(days: -1, calendar: calendar)
+                continue
+            }
+            if isRestDay(cursor, configuration: configuration, calendar: calendar) {
+                // Jour de repos : neutre, on saute sans casser ni compter.
+                cursor = cursor.adding(days: -1, calendar: calendar)
+                continue
+            }
+            // Un trou : on tente un jeton de protection, à condition qu'il
+            // reste de l'activité avant le trou.
+            if freezesLeft > 0, hasActivity(before: cursor, in: normalized) {
+                freezesLeft -= 1
+                freezesConsumed += 1
+                cursor = cursor.adding(days: -1, calendar: calendar)
+                continue
+            }
+            break
+        }
+
+        // --- Meilleure série -------------------------------------------------
+        let longest = longestRun(
+            days: normalized,
+            configuration: configuration,
+            calendar: calendar
+        )
+
+        return StreakState(
+            current: current,
+            longest: max(longest, current),
+            lastActiveDay: lastActive,
+            freezesConsumed: freezesConsumed,
+            isAtRisk: isAtRisk && current > 0,
+            totalActiveDays: normalized.count
+        )
+    }
+
+    /// Meilleure série historique (sans jetons : l'histoire ne se réécrit pas).
+    static func longestRun(
+        days: Set<Date>,
+        configuration: Configuration,
+        calendar: Calendar
+    ) -> Int {
+        let sorted = days.sorted()
+        guard let first = sorted.first else { return 0 }
+
+        var best = 0
+        var run = 0
+        var cursor = first
+
+        guard let last = sorted.last else { return 0 }
+        var guardCounter = 0
+        while cursor <= last && guardCounter < 20000 {
+            guardCounter += 1
+            if days.contains(cursor) {
+                run += 1
+                best = max(best, run)
+            } else if isRestDay(cursor, configuration: configuration, calendar: calendar) {
+                // neutre
+            } else {
+                run = 0
+            }
+            cursor = cursor.adding(days: 1, calendar: calendar)
+        }
+        return best
+    }
+
+    static func isRestDay(_ date: Date, configuration: Configuration, calendar: Calendar) -> Bool {
+        guard !configuration.restWeekdays.isEmpty else { return false }
+        return configuration.restWeekdays.contains(calendar.component(.weekday, from: date))
+    }
+
+    static func hasActivity(before date: Date, in days: Set<Date>) -> Bool {
+        days.contains { $0 < date }
+    }
+
+    /// Carte de chaleur annuelle : intensité 0…1 par jour.
+    public static func heatmap(
+        completionsByDay: [Date: Int],
+        from start: Date,
+        to end: Date,
+        calendar: Calendar = .questly()
+    ) -> [HeatmapCell] {
+        let normalized = Dictionary(
+            completionsByDay.map { (calendar.startOfDay(for: $0.key), $0.value) },
+            uniquingKeysWith: { $0 + $1 }
+        )
+        let maxValue = max(normalized.values.max() ?? 0, 1)
+        var cells: [HeatmapCell] = []
+        var cursor = calendar.startOfDay(for: start)
+        let last = calendar.startOfDay(for: end)
+        var guardCounter = 0
+        while cursor <= last && guardCounter < 1200 {
+            guardCounter += 1
+            let count = normalized[cursor] ?? 0
+            cells.append(HeatmapCell(
+                date: cursor,
+                count: count,
+                intensity: count == 0 ? 0 : min(1, Double(count) / Double(maxValue))
+            ))
+            cursor = cursor.adding(days: 1, calendar: calendar)
+        }
+        return cells
+    }
+}
+
+public struct HeatmapCell: Identifiable, Equatable, Sendable {
+    public var id: Date { date }
+    public let date: Date
+    public let count: Int
+    public let intensity: Double
+
+    public init(date: Date, count: Int, intensity: Double) {
+        self.date = date
+        self.count = count
+        self.intensity = intensity
+    }
+
+    /// Niveau discret 0…4, comme la grille de contributions GitHub.
+    public var level: Int {
+        if count == 0 { return 0 }
+        if intensity <= 0.25 { return 1 }
+        if intensity <= 0.5 { return 2 }
+        if intensity <= 0.75 { return 3 }
+        return 4
+    }
+}

--- a/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Gamification/XPEngine.swift
+++ b/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Gamification/XPEngine.swift
@@ -1,0 +1,404 @@
+import Foundation
+
+// MARK: - Inputs
+
+/// Photographie d'une tâche au moment où elle est accomplie.
+/// `QuestlyKit` ne connaît pas SwiftData : le layer app fournit ce descripteur.
+public struct XPTaskDescriptor: Sendable, Equatable {
+    public var difficulty: Difficulty
+    public var priority: Priority
+    public var estimatedMinutes: Int?
+    public var completedSubtaskCount: Int
+    public var totalSubtaskCount: Int
+    public var dueDate: Date?
+    public var hasTimeComponent: Bool
+    public var isBoss: Bool
+    public var lifeArea: LifeArea?
+    public var focusedMinutes: Int
+    public var isHabit: Bool
+
+    public init(
+        difficulty: Difficulty = .medium,
+        priority: Priority = .p4,
+        estimatedMinutes: Int? = nil,
+        completedSubtaskCount: Int = 0,
+        totalSubtaskCount: Int = 0,
+        dueDate: Date? = nil,
+        hasTimeComponent: Bool = false,
+        isBoss: Bool = false,
+        lifeArea: LifeArea? = nil,
+        focusedMinutes: Int = 0,
+        isHabit: Bool = false
+    ) {
+        self.difficulty = difficulty
+        self.priority = priority
+        self.estimatedMinutes = estimatedMinutes
+        self.completedSubtaskCount = completedSubtaskCount
+        self.totalSubtaskCount = totalSubtaskCount
+        self.dueDate = dueDate
+        self.hasTimeComponent = hasTimeComponent
+        self.isBoss = isBoss
+        self.lifeArea = lifeArea
+        self.focusedMinutes = focusedMinutes
+        self.isHabit = isHabit
+    }
+}
+
+/// Contexte du joueur au moment de la validation.
+public struct XPContext: Sendable, Equatable {
+    /// Série de jours consécutifs en cours.
+    public var streakDays: Int
+    /// Nombre de tâches validées dans la fenêtre de combo (5 minutes).
+    public var comboCount: Int
+    /// Multiplicateur actif acheté en boutique (1.0 = aucun).
+    public var boostMultiplier: Double
+    /// Première tâche de la journée : petit bonus d'élan.
+    public var isFirstCompletionOfDay: Bool
+    /// La tâche fait partie des quêtes du jour.
+    public var isDailyQuestTarget: Bool
+    /// Date de validation.
+    public var completionDate: Date
+
+    public init(
+        streakDays: Int = 0,
+        comboCount: Int = 1,
+        boostMultiplier: Double = 1.0,
+        isFirstCompletionOfDay: Bool = false,
+        isDailyQuestTarget: Bool = false,
+        completionDate: Date = Date()
+    ) {
+        self.streakDays = streakDays
+        self.comboCount = comboCount
+        self.boostMultiplier = boostMultiplier
+        self.isFirstCompletionOfDay = isFirstCompletionOfDay
+        self.isDailyQuestTarget = isDailyQuestTarget
+        self.completionDate = completionDate
+    }
+}
+
+// MARK: - Output
+
+public struct XPBreakdownLine: Sendable, Equatable, Identifiable {
+    public let id: String
+    public let label: String
+    public let detail: String
+    public let symbolName: String
+    /// `true` pour un bonus, `false` pour un malus — pilote la couleur.
+    public let isPositive: Bool
+
+    public init(id: String, label: String, detail: String, symbolName: String, isPositive: Bool = true) {
+        self.id = id
+        self.label = label
+        self.detail = detail
+        self.symbolName = symbolName
+        self.isPositive = isPositive
+    }
+}
+
+public struct XPAward: Sendable, Equatable {
+    public var totalXP: Int
+    public var coins: Int
+    public var gems: Int
+    public var attributeXP: Int
+    public var lifeArea: LifeArea?
+    public var multiplier: Double
+    public var breakdown: [XPBreakdownLine]
+
+    public init(
+        totalXP: Int,
+        coins: Int,
+        gems: Int,
+        attributeXP: Int,
+        lifeArea: LifeArea?,
+        multiplier: Double,
+        breakdown: [XPBreakdownLine]
+    ) {
+        self.totalXP = totalXP
+        self.coins = coins
+        self.gems = gems
+        self.attributeXP = attributeXP
+        self.lifeArea = lifeArea
+        self.multiplier = multiplier
+        self.breakdown = breakdown
+    }
+
+    public static let none = XPAward(
+        totalXP: 0, coins: 0, gems: 0, attributeXP: 0,
+        lifeArea: nil, multiplier: 1, breakdown: []
+    )
+}
+
+// MARK: - Engine
+
+/// Calcule les récompenses. Toutes les règles du jeu vivent ici, en un seul
+/// endroit, sans dépendance à l'UI ni à la base de données.
+public enum XPEngine {
+
+    /// Plafond du multiplicateur de série : +30 % à 30 jours.
+    public static let maxStreakBonus = 0.30
+    /// Plafond du combo : +25 % à 6 tâches enchaînées.
+    public static let maxComboBonus = 0.25
+    /// Fenêtre pendant laquelle deux validations comptent dans le même combo.
+    public static let comboWindow: TimeInterval = 5 * 60
+
+    public static func award(
+        for task: XPTaskDescriptor,
+        context: XPContext,
+        calendar: Calendar = .questly()
+    ) -> XPAward {
+        var lines: [XPBreakdownLine] = []
+
+        // 1. Base : la difficulté.
+        let base = Double(task.difficulty.baseXP)
+        lines.append(XPBreakdownLine(
+            id: "base",
+            label: task.difficulty.label,
+            detail: "+\(Int(base)) XP",
+            symbolName: task.difficulty.symbolName
+        ))
+
+        // 2. Bonus additifs.
+        var flatBonus = 0.0
+
+        let subtaskBonus = min(Double(task.completedSubtaskCount) * 2.0, 20.0)
+        if subtaskBonus > 0 {
+            flatBonus += subtaskBonus
+            lines.append(XPBreakdownLine(
+                id: "subtasks",
+                label: "\(task.completedSubtaskCount) sous-quête(s)",
+                detail: "+\(Int(subtaskBonus)) XP",
+                symbolName: "checklist"
+            ))
+        }
+
+        if let minutes = task.estimatedMinutes, minutes > 0 {
+            let durationBonus = min(Double(minutes) / 10.0, 25.0)
+            flatBonus += durationBonus
+            lines.append(XPBreakdownLine(
+                id: "duration",
+                label: "Durée \(DurationFormatter.short(minutes: minutes))",
+                detail: "+\(Int(durationBonus)) XP",
+                symbolName: "hourglass"
+            ))
+        }
+
+        if task.focusedMinutes > 0 {
+            let focusBonus = min(Double(task.focusedMinutes) / 5.0, 40.0)
+            flatBonus += focusBonus
+            lines.append(XPBreakdownLine(
+                id: "focus",
+                label: "\(task.focusedMinutes) min de concentration",
+                detail: "+\(Int(focusBonus)) XP",
+                symbolName: "timer"
+            ))
+        }
+
+        var subtotal = base + flatBonus
+
+        // 3. Multiplicateurs.
+        var multiplier = 1.0
+
+        multiplier *= task.priority.xpMultiplier
+        if task.priority != .p4 {
+            lines.append(XPBreakdownLine(
+                id: "priority",
+                label: "Priorité \(task.priority.shortLabel)",
+                detail: "×\(format(task.priority.xpMultiplier))",
+                symbolName: task.priority.symbolName
+            ))
+        }
+
+        let timing = timingMultiplier(for: task, at: context.completionDate, calendar: calendar)
+        if timing.value != 1.0 {
+            multiplier *= timing.value
+            lines.append(XPBreakdownLine(
+                id: "timing",
+                label: timing.label,
+                detail: "×\(format(timing.value))",
+                symbolName: timing.symbol,
+                isPositive: timing.value >= 1.0
+            ))
+        }
+
+        let streakMult = streakMultiplier(days: context.streakDays)
+        if streakMult > 1.0 {
+            multiplier *= streakMult
+            lines.append(XPBreakdownLine(
+                id: "streak",
+                label: "Série de \(context.streakDays) jours",
+                detail: "×\(format(streakMult))",
+                symbolName: "flame.fill"
+            ))
+        }
+
+        let comboMult = comboMultiplier(count: context.comboCount)
+        if comboMult > 1.0 {
+            multiplier *= comboMult
+            lines.append(XPBreakdownLine(
+                id: "combo",
+                label: "Combo ×\(context.comboCount)",
+                detail: "×\(format(comboMult))",
+                symbolName: "bolt.fill"
+            ))
+        }
+
+        if task.isBoss {
+            multiplier *= 2.0
+            lines.append(XPBreakdownLine(
+                id: "boss",
+                label: "Boss vaincu",
+                detail: "×2",
+                symbolName: "crown.fill"
+            ))
+        }
+
+        if context.boostMultiplier > 1.0 {
+            multiplier *= context.boostMultiplier
+            lines.append(XPBreakdownLine(
+                id: "boost",
+                label: "Potion d'expérience",
+                detail: "×\(format(context.boostMultiplier))",
+                symbolName: "flask.fill"
+            ))
+        }
+
+        if context.isFirstCompletionOfDay {
+            subtotal += 10
+            lines.append(XPBreakdownLine(
+                id: "firstOfDay",
+                label: "Premier pas du jour",
+                detail: "+10 XP",
+                symbolName: "sunrise.fill"
+            ))
+        }
+
+        if context.isDailyQuestTarget {
+            multiplier *= 1.15
+            lines.append(XPBreakdownLine(
+                id: "dailyQuest",
+                label: "Quête du jour",
+                detail: "×1,15",
+                symbolName: "scroll.fill"
+            ))
+        }
+
+        let total = max(1, Int((subtotal * multiplier).rounded()))
+
+        // 4. Monnaies.
+        let coins = max(1, Int((Double(total) / 4.0).rounded()))
+        let gems = gemReward(for: task, total: total)
+
+        // 5. XP d'attribut : 60 % de l'XP, arrondi.
+        let attributeXP = task.lifeArea == nil ? 0 : max(1, Int((Double(total) * 0.6).rounded()))
+
+        return XPAward(
+            totalXP: total,
+            coins: coins,
+            gems: gems,
+            attributeXP: attributeXP,
+            lifeArea: task.lifeArea,
+            multiplier: multiplier,
+            breakdown: lines
+        )
+    }
+
+    /// Aperçu affiché sur la fiche d'une tâche avant validation.
+    public static func previewXP(for task: XPTaskDescriptor) -> Int {
+        award(for: task, context: XPContext(completionDate: task.dueDate ?? Date())).totalXP
+    }
+
+    public static func streakMultiplier(days: Int) -> Double {
+        guard days > 1 else { return 1.0 }
+        return 1.0 + min(Double(days), 30.0) * 0.01
+    }
+
+    public static func comboMultiplier(count: Int) -> Double {
+        guard count > 1 else { return 1.0 }
+        return 1.0 + min(Double(count - 1), 5.0) * 0.05
+    }
+
+    /// Bonus de ponctualité / malus de retard.
+    static func timingMultiplier(
+        for task: XPTaskDescriptor,
+        at date: Date,
+        calendar: Calendar
+    ) -> (value: Double, label: String, symbol: String) {
+        guard let due = task.dueDate else { return (1.0, "", "") }
+
+        if task.hasTimeComponent {
+            if date <= due {
+                let hoursEarly = due.timeIntervalSince(date) / 3600
+                if hoursEarly >= 24 { return (1.20, "En avance", "hare.fill") }
+                return (1.15, "Dans les temps", "checkmark.circle.fill")
+            }
+            let hoursLate = date.timeIntervalSince(due) / 3600
+            if hoursLate <= 1 { return (1.0, "", "") }
+            return (0.85, "En retard", "tortoise.fill")
+        }
+
+        let dayDelta = calendar.daysBetween(date, calendar.startOfDay(due))
+        if dayDelta > 0 { return (1.20, "En avance de \(dayDelta) j", "hare.fill") }
+        if dayDelta == 0 { return (1.15, "Le jour dit", "checkmark.circle.fill") }
+        return (0.85, "En retard de \(-dayDelta) j", "tortoise.fill")
+    }
+
+    /// Les gemmes sont rares : boss, tâches légendaires, longues sessions.
+    static func gemReward(for task: XPTaskDescriptor, total: Int) -> Int {
+        var gems = 0
+        if task.isBoss { gems += 3 }
+        if task.difficulty == .legendary { gems += 2 }
+        else if task.difficulty == .epic { gems += 1 }
+        if task.focusedMinutes >= 90 { gems += 1 }
+        if total >= 250 { gems += 1 }
+        return gems
+    }
+
+    private static func format(_ value: Double) -> String {
+        let rounded = (value * 100).rounded() / 100
+        if rounded == rounded.rounded() { return String(Int(rounded)) }
+        return String(format: "%.2f", rounded).replacingOccurrences(of: ".", with: ",")
+    }
+}
+
+// MARK: - Combo tracking
+
+/// Suit les validations rapprochées pour alimenter le multiplicateur de combo.
+public struct ComboTracker: Sendable, Equatable {
+    public private(set) var count: Int
+    public private(set) var lastCompletion: Date?
+
+    public init(count: Int = 0, lastCompletion: Date? = nil) {
+        self.count = count
+        self.lastCompletion = lastCompletion
+    }
+
+    /// Enregistre une validation et renvoie la taille du combo qui en résulte.
+    @discardableResult
+    public mutating func register(at date: Date) -> Int {
+        if let last = lastCompletion, date.timeIntervalSince(last) <= XPEngine.comboWindow {
+            count += 1
+        } else {
+            count = 1
+        }
+        lastCompletion = date
+        return count
+    }
+
+    /// Le combo est-il encore actif à l'instant `date` ?
+    public func isActive(at date: Date) -> Bool {
+        guard let last = lastCompletion else { return false }
+        return date.timeIntervalSince(last) <= XPEngine.comboWindow && count > 1
+    }
+
+    /// Secondes restantes avant expiration du combo.
+    public func remainingSeconds(at date: Date) -> Int {
+        guard let last = lastCompletion else { return 0 }
+        let remaining = XPEngine.comboWindow - date.timeIntervalSince(last)
+        return max(0, Int(remaining.rounded()))
+    }
+
+    public mutating func reset() {
+        count = 0
+        lastCompletion = nil
+    }
+}

--- a/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Parsing/NaturalLanguageParser.swift
+++ b/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Parsing/NaturalLanguageParser.swift
@@ -1,0 +1,755 @@
+import Foundation
+
+/// Analyseur de saisie rapide, bilingue français / anglais.
+///
+/// Conventions retenues (documentées dans l'écran d'aide de l'app) :
+/// - `#étiquette`, `@contexte`, `+projet`
+/// - `p1`…`p4` ou `!1`…`!4` pour la priorité, `urgent` → P1
+/// - `*facile`, `*ardu`, `*épique`, `*légendaire` pour la difficulté
+/// - `%corps`, `%esprit`… pour le domaine de vie
+/// - `!boss` pour marquer un boss
+/// - `9h`, `14h30`, `14:30`, `2pm` sont des **heures**
+/// - `30min`, `2 heures`, `pendant 1h30` sont des **durées**
+public enum NaturalLanguageParser {
+
+    // MARK: - Entrée principale
+
+    public static func parse(
+        _ input: String,
+        reference: Date = Date(),
+        calendar: Calendar = .questly()
+    ) -> ParsedInput {
+        var result = ParsedInput()
+        let ns = input as NSString
+        var consumed: [NSRange] = []
+
+        // L'ordre compte : la récurrence avale « tous les lundis » avant que le
+        // parseur de dates ne voie « lundi ».
+        parseRecurrence(ns, &consumed, &result, calendar: calendar)
+        parseReminder(ns, &consumed, &result)
+        parseDuration(ns, &consumed, &result)
+        let time = parseTime(ns, &consumed, &result)
+        let day = parseDate(ns, &consumed, &result, reference: reference, calendar: calendar)
+        parsePriority(ns, &consumed, &result)
+        parseDifficulty(ns, &consumed, &result)
+        parseArea(ns, &consumed, &result)
+        parseBoss(ns, &consumed, &result)
+        parseTags(ns, &consumed, &result)
+        parseProject(ns, &consumed, &result)
+
+        applyDueDate(day: day, time: time, reference: reference, calendar: calendar, into: &result)
+
+        // « chaque lundi 9 h » sans date explicite : l'échéance est la première
+        // occurrence réelle de la règle, pas demain matin.
+        if let rule = result.recurrence, day == nil {
+            applyFirstOccurrence(of: rule, time: time, reference: reference, calendar: calendar, into: &result)
+        }
+
+        // Domaine déduit des étiquettes si rien d'explicite.
+        if result.lifeArea == nil {
+            result.lifeArea = inferArea(from: result.tags, title: input)
+        }
+
+        result.title = cleanTitle(ns, consumed: consumed)
+        result.tokens.sort { $0.location < $1.location }
+        return result
+    }
+
+    // MARK: - Récurrence
+
+    static func parseRecurrence(
+        _ ns: NSString,
+        _ consumed: inout [NSRange],
+        _ result: inout ParsedInput,
+        calendar: Calendar
+    ) {
+        // « tous les 2 jours », « toutes les 3 semaines », « every 2 weeks »
+        if let m = firstMatch(
+            #"\b(?:tou(?:s|tes)\s+les|every|chaque)\s+(\d+)\s*(jours?|semaines?|mois|ans?|années?|days?|weeks?|months?|years?)\b"#,
+            in: ns, avoiding: consumed
+        ) {
+            let count = Int(group(m, 1, ns)) ?? 1
+            let unit = group(m, 2, ns).lowercased()
+            let frequency = frequencyFor(unit: unit)
+            result.recurrence = RecurrenceRule(frequency: frequency, interval: count)
+            record(.recurrence, m.range, ns, display: result.recurrence?.humanDescription(calendar: calendar) ?? "", into: &result, consumed: &consumed)
+            return
+        }
+
+        // « chaque lundi », « tous les lundis », « every monday »
+        if let m = firstMatch(
+            #"\b(?:chaque|tous\s+les|toutes\s+les|every)\s+(lundis?|mardis?|mercredis?|jeudis?|vendredis?|samedis?|dimanches?|mondays?|tuesdays?|wednesdays?|thursdays?|fridays?|saturdays?|sundays?)\b"#,
+            in: ns, avoiding: consumed
+        ) {
+            let name = group(m, 1, ns).lowercased()
+            if let weekday = weekdayNumber(for: name) {
+                result.recurrence = RecurrenceRule(frequency: .weekly, weekdays: [weekday])
+                record(.recurrence, m.range, ns, display: result.recurrence?.humanDescription(calendar: calendar) ?? "", into: &result, consumed: &consumed)
+                return
+            }
+        }
+
+        // « tous les 15 du mois »
+        if let m = firstMatch(
+            #"\b(?:tous\s+les|le)\s+(\d{1,2})\s+du\s+mois\b"#,
+            in: ns, avoiding: consumed
+        ) {
+            let day = Int(group(m, 1, ns)) ?? 1
+            result.recurrence = RecurrenceRule(frequency: .monthly, daysOfMonth: [day])
+            record(.recurrence, m.range, ns, display: result.recurrence?.humanDescription(calendar: calendar) ?? "", into: &result, consumed: &consumed)
+            return
+        }
+
+        struct SimplePattern {
+            let regex: String
+            let rule: RecurrenceRule
+        }
+
+        let simple: [SimplePattern] = [
+            SimplePattern(regex: #"\b(?:en\s+semaine|jours?\s+ouvr[ée]s?|weekdays?)\b"#, rule: .weekdaysOnly),
+            SimplePattern(regex: #"\b(?:le\s+week-?ends?|les\s+week-?ends|weekends?)\b"#, rule: .weekendsOnly),
+            SimplePattern(regex: #"\b(?:tous\s+les\s+jours|chaque\s+jour|quotidien(?:ne)?|every\s*day|daily)\b"#, rule: .daily),
+            SimplePattern(regex: #"\b(?:toutes\s+les\s+semaines|chaque\s+semaine|hebdo(?:madaire)?|every\s*week|weekly)\b"#, rule: .weekly),
+            SimplePattern(regex: #"\b(?:tous\s+les\s+mois|chaque\s+mois|mensuel(?:le)?|every\s*month|monthly)\b"#, rule: .monthly),
+            SimplePattern(regex: #"\b(?:tous\s+les\s+ans|chaque\s+ann[ée]e|annuel(?:le)?|every\s*year|yearly|annually)\b"#, rule: .yearly)
+        ]
+
+        for pattern in simple {
+            if let m = firstMatch(pattern.regex, in: ns, avoiding: consumed) {
+                result.recurrence = pattern.rule
+                record(.recurrence, m.range, ns, display: pattern.rule.humanDescription(calendar: calendar), into: &result, consumed: &consumed)
+                return
+            }
+        }
+    }
+
+    static func frequencyFor(unit: String) -> RecurrenceRule.Frequency {
+        if unit.hasPrefix("sem") || unit.hasPrefix("week") { return .weekly }
+        if unit.hasPrefix("mois") || unit.hasPrefix("month") { return .monthly }
+        if unit.hasPrefix("an") || unit.hasPrefix("ann") || unit.hasPrefix("year") { return .yearly }
+        return .daily
+    }
+
+    // MARK: - Rappel
+
+    static func parseReminder(_ ns: NSString, _ consumed: inout [NSRange], _ result: inout ParsedInput) {
+        guard let m = firstMatch(
+            #"\b(?:rappel|rappelle[- ]moi|remind(?:er)?)\s*(\d+)\s*(m|min|mins|minutes?|h|heures?|hours?)\s*(?:avant|before)?\b"#,
+            in: ns, avoiding: consumed
+        ) else { return }
+        let value = Int(group(m, 1, ns)) ?? 0
+        let unit = group(m, 2, ns).lowercased()
+        let minutes = unit.hasPrefix("h") ? value * 60 : value
+        guard minutes > 0 else { return }
+        result.reminderMinutesBefore = minutes
+        record(.reminder, m.range, ns, display: "Rappel \(DurationFormatter.short(minutes: minutes)) avant", into: &result, consumed: &consumed)
+    }
+
+    // MARK: - Durée
+
+    static func parseDuration(_ ns: NSString, _ consumed: inout [NSRange], _ result: inout ParsedInput) {
+        // Durée explicite : « pendant 1h30 », « pour 45 min », « for 2 hours »
+        if let m = firstMatch(
+            #"\b(?:pendant|pour|dur[ée]e\s*(?:de)?|dure|for|~|≈)\s*(\d{1,3})\s*(h|heures?|hrs?|hours?|m|min|mins|minutes?)\s*(\d{1,2})?\b"#,
+            in: ns, avoiding: consumed
+        ) {
+            let value = Int(group(m, 1, ns)) ?? 0
+            let unit = group(m, 2, ns).lowercased()
+            let extra = Int(group(m, 3, ns)) ?? 0
+            let minutes = unit.hasPrefix("h") ? value * 60 + extra : value
+            if minutes > 0 {
+                result.durationMinutes = minutes
+                record(.duration, m.range, ns, display: DurationFormatter.short(minutes: minutes), into: &result, consumed: &consumed)
+                return
+            }
+        }
+
+        // Durée en minutes : « 30min », « 45 m »
+        if let m = firstMatch(
+            #"\b(\d{1,3})\s*(?:min|mins|minutes?|m)\b"#,
+            in: ns, avoiding: consumed
+        ) {
+            let minutes = Int(group(m, 1, ns)) ?? 0
+            if minutes > 0 {
+                result.durationMinutes = minutes
+                record(.duration, m.range, ns, display: DurationFormatter.short(minutes: minutes), into: &result, consumed: &consumed)
+                return
+            }
+        }
+
+        // Durée en heures écrites en toutes lettres : « 2 heures », « 3 hours »
+        if let m = firstMatch(
+            #"\b(\d{1,2})\s*(?:heures?|hours?|hrs?)\b"#,
+            in: ns, avoiding: consumed
+        ) {
+            let hours = Int(group(m, 1, ns)) ?? 0
+            if hours > 0 {
+                result.durationMinutes = hours * 60
+                record(.duration, m.range, ns, display: DurationFormatter.short(minutes: hours * 60), into: &result, consumed: &consumed)
+            }
+        }
+    }
+
+    // MARK: - Heure
+
+    struct TimeOfDay: Equatable {
+        var hour: Int
+        var minute: Int
+        /// « ce soir », « ce matin » désignent explicitement aujourd'hui, même
+        /// si l'heure est déjà passée.
+        var forcesToday: Bool = false
+    }
+
+    static func parseTime(_ ns: NSString, _ consumed: inout [NSRange], _ result: inout ParsedInput) -> TimeOfDay? {
+        // am / pm
+        if let m = firstMatch(#"\b(\d{1,2})(?:[:h\.](\d{2}))?\s*(am|pm)\b"#, in: ns, avoiding: consumed) {
+            var hour = Int(group(m, 1, ns)) ?? 0
+            let minute = Int(group(m, 2, ns)) ?? 0
+            let suffix = group(m, 3, ns).lowercased()
+            if suffix == "pm" && hour < 12 { hour += 12 }
+            if suffix == "am" && hour == 12 { hour = 0 }
+            if let time = validate(hour: hour, minute: minute) {
+                record(.time, m.range, ns, display: displayTime(time), into: &result, consumed: &consumed)
+                return time
+            }
+        }
+
+        // Format français : 9h, 14h30 — éventuellement précédé de « à »/« vers »
+        if let m = firstMatch(#"\b(?:[àa]|vers|at)?\s*(\d{1,2})\s*h\s*(\d{2})?\b"#, in: ns, avoiding: consumed) {
+            let hour = Int(group(m, 1, ns)) ?? 0
+            let minute = Int(group(m, 2, ns)) ?? 0
+            if let time = validate(hour: hour, minute: minute) {
+                record(.time, m.range, ns, display: displayTime(time), into: &result, consumed: &consumed)
+                return time
+            }
+        }
+
+        // Format 24 h avec deux-points : 14:30
+        if let m = firstMatch(#"\b(?:[àa]|vers|at)?\s*(\d{1,2}):(\d{2})\b"#, in: ns, avoiding: consumed) {
+            let hour = Int(group(m, 1, ns)) ?? 0
+            let minute = Int(group(m, 2, ns)) ?? 0
+            if let time = validate(hour: hour, minute: minute) {
+                record(.time, m.range, ns, display: displayTime(time), into: &result, consumed: &consumed)
+                return time
+            }
+        }
+
+        // Moments de la journée
+        let moments: [(String, TimeOfDay)] = [
+            (#"\b(?:ce\s+)?matin\b|\bmorning\b"#, TimeOfDay(hour: 9, minute: 0, forcesToday: true)),
+            (#"\b(?:ce\s+)?midi\b|\bnoon\b"#, TimeOfDay(hour: 12, minute: 0, forcesToday: true)),
+            (#"\b(?:cet\s+)?apr[èe]s-midi\b|\bafternoon\b"#, TimeOfDay(hour: 15, minute: 0, forcesToday: true)),
+            (#"\b(?:ce\s+)?soir\b|\bevening\b|\btonight\b"#, TimeOfDay(hour: 19, minute: 0, forcesToday: true)),
+            (#"\b(?:cette\s+)?nuit\b|\bnight\b"#, TimeOfDay(hour: 22, minute: 0, forcesToday: true))
+        ]
+        for (pattern, time) in moments {
+            if let m = firstMatch(pattern, in: ns, avoiding: consumed) {
+                record(.time, m.range, ns, display: displayTime(time), into: &result, consumed: &consumed)
+                return time
+            }
+        }
+
+        return nil
+    }
+
+    static func validate(hour: Int, minute: Int) -> TimeOfDay? {
+        guard (0...23).contains(hour), (0...59).contains(minute) else { return nil }
+        return TimeOfDay(hour: hour, minute: minute)
+    }
+
+    static func displayTime(_ time: TimeOfDay) -> String {
+        String(format: "%02d:%02d", time.hour, time.minute)
+    }
+
+    // MARK: - Date
+
+    struct DayResult: Equatable {
+        var date: Date
+        var label: String
+    }
+
+    static func parseDate(
+        _ ns: NSString,
+        _ consumed: inout [NSRange],
+        _ result: inout ParsedInput,
+        reference: Date,
+        calendar: Calendar
+    ) -> DayResult? {
+        let today = calendar.startOfDay(for: reference)
+
+        // « dans 3 jours », « in 2 weeks »
+        if let m = firstMatch(
+            #"\b(?:dans|in)\s+(\d{1,3})\s*(jours?|semaines?|mois|ans?|années?|days?|weeks?|months?|years?)\b"#,
+            in: ns, avoiding: consumed
+        ) {
+            let value = Int(group(m, 1, ns)) ?? 0
+            let unit = group(m, 2, ns).lowercased()
+            var date = today
+            if unit.hasPrefix("sem") || unit.hasPrefix("week") {
+                date = calendar.date(byAdding: .weekOfYear, value: value, to: today) ?? today
+            } else if unit.hasPrefix("mois") || unit.hasPrefix("month") {
+                date = calendar.date(byAdding: .month, value: value, to: today) ?? today
+            } else if unit.hasPrefix("an") || unit.hasPrefix("ann") || unit.hasPrefix("year") {
+                date = calendar.date(byAdding: .year, value: value, to: today) ?? today
+            } else {
+                date = today.adding(days: value, calendar: calendar)
+            }
+            let day = DayResult(date: date, label: shortDate(date, calendar: calendar))
+            record(.date, m.range, ns, display: day.label, into: &result, consumed: &consumed)
+            return day
+        }
+
+        // Mots-clés relatifs
+        let relatives: [(String, Int)] = [
+            (#"\bapr[èe]s[- ]demain\b|\bday\s+after\s+tomorrow\b"#, 2),
+            (#"\bdemain\b|\btomorrow\b|\btmr\b"#, 1),
+            (#"\baujourd'?hui\b|\bauj\b|\btoday\b|\bce\s+soir\b|\btonight\b"#, 0)
+        ]
+        for (pattern, offset) in relatives {
+            if let m = firstMatch(pattern, in: ns, avoiding: consumed) {
+                let date = today.adding(days: offset, calendar: calendar)
+                let day = DayResult(date: date, label: relativeLabel(offset: offset, date: date, calendar: calendar))
+                record(.date, m.range, ns, display: day.label, into: &result, consumed: &consumed)
+                return day
+            }
+        }
+
+        // « la semaine prochaine », « le mois prochain »
+        if let m = firstMatch(#"\b(?:la\s+)?semaine\s+pro(?:chaine)?\b|\bnext\s+week\b"#, in: ns, avoiding: consumed) {
+            let date = calendar.startOfWeek(calendar.date(byAdding: .weekOfYear, value: 1, to: today) ?? today)
+            let day = DayResult(date: date, label: shortDate(date, calendar: calendar))
+            record(.date, m.range, ns, display: day.label, into: &result, consumed: &consumed)
+            return day
+        }
+        if let m = firstMatch(#"\b(?:le\s+)?mois\s+prochain\b|\bnext\s+month\b"#, in: ns, avoiding: consumed) {
+            let date = calendar.startOfMonth(calendar.date(byAdding: .month, value: 1, to: today) ?? today)
+            let day = DayResult(date: date, label: shortDate(date, calendar: calendar))
+            record(.date, m.range, ns, display: day.label, into: &result, consumed: &consumed)
+            return day
+        }
+        if let m = firstMatch(#"\b(?:ce\s+)?week-?end\b|\bthis\s+weekend\b"#, in: ns, avoiding: consumed) {
+            let date = nextWeekday(6 + 1, from: today, calendar: calendar, forceNext: false) // samedi
+            let day = DayResult(date: date, label: shortDate(date, calendar: calendar))
+            record(.date, m.range, ns, display: day.label, into: &result, consumed: &consumed)
+            return day
+        }
+        if let m = firstMatch(#"\bfin\s+du\s+mois\b|\bend\s+of\s+(?:the\s+)?month\b"#, in: ns, avoiding: consumed) {
+            let date = calendar.startOfDay(for: calendar.endOfMonth(today))
+            let day = DayResult(date: date, label: shortDate(date, calendar: calendar))
+            record(.date, m.range, ns, display: day.label, into: &result, consumed: &consumed)
+            return day
+        }
+
+        // Jours de la semaine, avec ou sans « prochain »
+        if let m = firstMatch(
+            #"\b(?:(next)\s+)?(lundi|mardi|mercredi|jeudi|vendredi|samedi|dimanche|monday|tuesday|wednesday|thursday|friday|saturday|sunday)(?:\s+(prochain))?\b"#,
+            in: ns, avoiding: consumed
+        ) {
+            let name = group(m, 2, ns).lowercased()
+            let forceNext = !group(m, 1, ns).isEmpty || !group(m, 3, ns).isEmpty
+            if let weekday = weekdayNumber(for: name) {
+                let date = nextWeekday(weekday, from: today, calendar: calendar, forceNext: forceNext)
+                let day = DayResult(date: date, label: shortDate(date, calendar: calendar))
+                record(.date, m.range, ns, display: day.label, into: &result, consumed: &consumed)
+                return day
+            }
+        }
+
+        // « 3 mars », « le 1er avril », « march 3 »
+        if let m = firstMatch(
+            #"\b(?:le\s+)?(\d{1,2})\s*(?:er)?\s+(janvier|février|fevrier|mars|avril|mai|juin|juillet|août|aout|septembre|octobre|novembre|décembre|decembre|january|february|march|april|may|june|july|august|september|october|november|december)\b(?:\s+(\d{4}))?"#,
+            in: ns, avoiding: consumed
+        ) {
+            let dayNumber = Int(group(m, 1, ns)) ?? 1
+            let monthName = group(m, 2, ns).lowercased()
+            let year = Int(group(m, 3, ns))
+            if let month = monthNumber(for: monthName),
+               let date = buildDate(day: dayNumber, month: month, year: year, reference: today, calendar: calendar) {
+                let day = DayResult(date: date, label: shortDate(date, calendar: calendar))
+                record(.date, m.range, ns, display: day.label, into: &result, consumed: &consumed)
+                return day
+            }
+        }
+
+        // Format numérique jour/mois — convention française.
+        if let m = firstMatch(#"\b(\d{1,2})[/\.](\d{1,2})(?:[/\.](\d{2,4}))?\b"#, in: ns, avoiding: consumed) {
+            let dayNumber = Int(group(m, 1, ns)) ?? 1
+            let month = Int(group(m, 2, ns)) ?? 1
+            var year = Int(group(m, 3, ns))
+            if let y = year, y < 100 { year = 2000 + y }
+            if let date = buildDate(day: dayNumber, month: month, year: year, reference: today, calendar: calendar) {
+                let day = DayResult(date: date, label: shortDate(date, calendar: calendar))
+                record(.date, m.range, ns, display: day.label, into: &result, consumed: &consumed)
+                return day
+            }
+        }
+
+        return nil
+    }
+
+    static func buildDate(day: Int, month: Int, year: Int?, reference: Date, calendar: Calendar) -> Date? {
+        guard (1...31).contains(day), (1...12).contains(month) else { return nil }
+        var comps = DateComponents()
+        comps.day = day
+        comps.month = month
+        comps.year = year ?? calendar.component(.year, from: reference)
+        guard var date = calendar.date(from: comps) else { return nil }
+        // Sans année explicite, une date déjà passée bascule sur l'an prochain.
+        if year == nil, date < calendar.startOfDay(for: reference) {
+            comps.year = (comps.year ?? 0) + 1
+            date = calendar.date(from: comps) ?? date
+        }
+        return calendar.startOfDay(for: date)
+    }
+
+    /// Prochaine occurrence d'un jour de semaine. Aujourd'hui compte, sauf si
+    /// l'utilisateur a précisé « prochain » / « next ».
+    static func nextWeekday(_ weekday: Int, from date: Date, calendar: Calendar, forceNext: Bool) -> Date {
+        let current = calendar.component(.weekday, from: date)
+        var delta = (weekday - current + 7) % 7
+        if delta == 0 && forceNext { delta = 7 }
+        return date.adding(days: delta, calendar: calendar)
+    }
+
+    // MARK: - Priorité, difficulté, domaine, boss
+
+    static func parsePriority(_ ns: NSString, _ consumed: inout [NSRange], _ result: inout ParsedInput) {
+        if let m = firstMatch(#"(?:^|\s)(?:!|p)([1-4])\b"#, in: ns, avoiding: consumed) {
+            if let value = Int(group(m, 1, ns)), let priority = Priority(rawValue: value) {
+                result.priority = priority
+                record(.priority, m.range, ns, display: priority.label, into: &result, consumed: &consumed)
+                return
+            }
+        }
+        if let m = firstMatch(#"\b(urgent|urgente|critique|asap)\b"#, in: ns, avoiding: consumed) {
+            result.priority = .p1
+            record(.priority, m.range, ns, display: Priority.p1.label, into: &result, consumed: &consumed)
+            return
+        }
+        if let m = firstMatch(#"\b(important|importante)\b"#, in: ns, avoiding: consumed) {
+            result.priority = .p2
+            record(.priority, m.range, ns, display: Priority.p2.label, into: &result, consumed: &consumed)
+        }
+    }
+
+    static func parseDifficulty(_ ns: NSString, _ consumed: inout [NSRange], _ result: inout ParsedInput) {
+        guard let m = firstMatch(
+            #"\*(broutille|trivial|facile|easy|normal|moyen|ardu|ardue|difficile|hard|[ée]pique|epic|l[ée]gendaire|legendary)\b"#,
+            in: ns, avoiding: consumed
+        ) else { return }
+        let word = group(m, 1, ns).lowercased()
+        let difficulty: Difficulty
+        switch word {
+        case "broutille", "trivial": difficulty = .trivial
+        case "facile", "easy": difficulty = .easy
+        case "normal", "moyen": difficulty = .medium
+        case "ardu", "ardue", "difficile", "hard": difficulty = .hard
+        case "épique", "epique", "epic": difficulty = .epic
+        default: difficulty = .legendary
+        }
+        result.difficulty = difficulty
+        record(.difficulty, m.range, ns, display: difficulty.label, into: &result, consumed: &consumed)
+    }
+
+    static func parseArea(_ ns: NSString, _ consumed: inout [NSRange], _ result: inout ParsedInput) {
+        guard let m = firstMatch(
+            #"%(corps|body|esprit|mind|cœur|coeur|heart|œuvre|oeuvre|craft|fortune|wealth|foyer|home)\b"#,
+            in: ns, avoiding: consumed
+        ) else { return }
+        let word = group(m, 1, ns).lowercased()
+        let area: LifeArea?
+        switch word {
+        case "corps", "body": area = .body
+        case "esprit", "mind": area = .mind
+        case "cœur", "coeur", "heart": area = .heart
+        case "œuvre", "oeuvre", "craft": area = .craft
+        case "fortune", "wealth": area = .wealth
+        case "foyer", "home": area = .home
+        default: area = nil
+        }
+        guard let area else { return }
+        result.lifeArea = area
+        record(.area, m.range, ns, display: area.label, into: &result, consumed: &consumed)
+    }
+
+    static func parseBoss(_ ns: NSString, _ consumed: inout [NSRange], _ result: inout ParsedInput) {
+        guard let m = firstMatch(#"(?:!boss|👑)"#, in: ns, avoiding: consumed) else { return }
+        result.isBoss = true
+        record(.boss, m.range, ns, display: "Boss", into: &result, consumed: &consumed)
+    }
+
+    static func parseTags(_ ns: NSString, _ consumed: inout [NSRange], _ result: inout ParsedInput) {
+        for pattern in [#"#([\p{L}\p{N}_\-]+)"#, #"@([\p{L}\p{N}_\-]+)"#] {
+            var searchRange = NSRange(location: 0, length: ns.length)
+            while let m = regex(pattern).firstMatch(in: ns as String, options: [], range: searchRange) {
+                let next = NSRange(
+                    location: m.range.location + m.range.length,
+                    length: max(0, ns.length - (m.range.location + m.range.length))
+                )
+                if !overlaps(m.range, consumed) {
+                    let tag = group(m, 1, ns)
+                    if !tag.isEmpty && !result.tags.contains(tag.lowercased()) {
+                        result.tags.append(tag.lowercased())
+                        record(.tag, m.range, ns, display: "#\(tag)", into: &result, consumed: &consumed)
+                    }
+                }
+                if next.length <= 0 { break }
+                searchRange = next
+            }
+        }
+    }
+
+    static func parseProject(_ ns: NSString, _ consumed: inout [NSRange], _ result: inout ParsedInput) {
+        guard let m = firstMatch(#"\+([\p{L}\p{N}_\-]+)"#, in: ns, avoiding: consumed) else { return }
+        let name = group(m, 1, ns)
+        guard !name.isEmpty else { return }
+        result.project = name
+        record(.project, m.range, ns, display: name, into: &result, consumed: &consumed)
+    }
+
+    // MARK: - Assemblage de l'échéance
+
+    static func applyDueDate(
+        day: DayResult?,
+        time: TimeOfDay?,
+        reference: Date,
+        calendar: Calendar,
+        into result: inout ParsedInput
+    ) {
+        switch (day, time) {
+        case (nil, nil):
+            return
+        case (let day?, nil):
+            result.dueDate = calendar.startOfDay(for: day.date)
+            result.hasTime = false
+        case (nil, let time?):
+            var candidate = calendar.setting(hour: time.hour, minute: time.minute, of: reference)
+            // Une heure déjà passée vise le lendemain, comme dans Todoist —
+            // sauf si l'utilisateur a explicitement dit « ce soir ».
+            if candidate <= reference && !time.forcesToday {
+                candidate = candidate.adding(days: 1, calendar: calendar)
+            }
+            result.dueDate = candidate
+            result.hasTime = true
+        case (let day?, let time?):
+            result.dueDate = calendar.setting(hour: time.hour, minute: time.minute, of: day.date)
+            result.hasTime = true
+        }
+    }
+
+    static func applyFirstOccurrence(
+        of rule: RecurrenceRule,
+        time: TimeOfDay?,
+        reference: Date,
+        calendar: Calendar,
+        into result: inout ParsedInput
+    ) {
+        let anchor = calendar.startOfDay(for: reference)
+        var cursor = anchor
+        for _ in 0..<400 {
+            if RecurrenceEngine.matches(rule: rule, date: cursor, anchor: anchor, calendar: calendar) {
+                if let time {
+                    let candidate = calendar.setting(hour: time.hour, minute: time.minute, of: cursor)
+                    if candidate >= reference || time.forcesToday {
+                        result.dueDate = candidate
+                        result.hasTime = true
+                        return
+                    }
+                } else {
+                    result.dueDate = cursor
+                    result.hasTime = false
+                    return
+                }
+            }
+            cursor = cursor.adding(days: 1, calendar: calendar)
+        }
+    }
+
+    // MARK: - Déduction du domaine
+
+    static let areaKeywords: [LifeArea: [String]] = [
+        .body: ["sport", "gym", "muscu", "course", "courir", "running", "yoga", "santé", "sante", "médecin", "medecin",
+                "dentiste", "sommeil", "marche", "vélo", "velo", "natation", "workout", "health", "run"],
+        .mind: ["lecture", "lire", "cours", "étude", "etude", "révision", "revision", "apprendre", "formation",
+                "podcast", "méditation", "meditation", "study", "read", "learn", "duolingo"],
+        .heart: ["famille", "ami", "amis", "appeler", "appel", "anniversaire", "cadeau", "couple", "dîner", "diner",
+                 "call", "family", "friend", "date", "thérapie", "therapie"],
+        .craft: ["projet", "code", "dev", "design", "écrire", "ecrire", "réunion", "reunion", "client", "boulot",
+                 "travail", "work", "meeting", "deck", "rapport", "présentation", "presentation"],
+        .wealth: ["facture", "impôt", "impot", "banque", "budget", "épargne", "epargne", "assurance", "devis",
+                  "paiement", "invoice", "tax", "money", "salaire", "compta"],
+        .home: ["courses", "ménage", "menage", "vaisselle", "lessive", "ranger", "rangement", "cuisine", "jardin",
+                "bricolage", "poubelle", "aspirateur", "groceries", "clean", "laundry"]
+    ]
+
+    static func inferArea(from tags: [String], title: String) -> LifeArea? {
+        let haystack = (tags + [title.lowercased()]).joined(separator: " ")
+            .folding(options: .diacriticInsensitive, locale: Locale(identifier: "fr_FR"))
+        for area in LifeArea.allCases {
+            guard let keywords = areaKeywords[area] else { continue }
+            for keyword in keywords {
+                let normalized = keyword.folding(options: .diacriticInsensitive, locale: Locale(identifier: "fr_FR"))
+                if haystack.contains(normalized) { return area }
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Outils regex
+
+    private static let cache = RegexCache()
+
+    static func regex(_ pattern: String) -> NSRegularExpression {
+        cache.regex(for: pattern)
+    }
+
+    static func firstMatch(_ pattern: String, in ns: NSString, avoiding consumed: [NSRange]) -> NSTextCheckingResult? {
+        let full = NSRange(location: 0, length: ns.length)
+        let matches = regex(pattern).matches(in: ns as String, options: [], range: full)
+        return matches.first { !overlaps($0.range, consumed) }
+    }
+
+    static func overlaps(_ range: NSRange, _ ranges: [NSRange]) -> Bool {
+        ranges.contains { NSIntersectionRange($0, range).length > 0 }
+    }
+
+    static func group(_ match: NSTextCheckingResult, _ index: Int, _ ns: NSString) -> String {
+        guard index < match.numberOfRanges else { return "" }
+        let range = match.range(at: index)
+        guard range.location != NSNotFound, range.length > 0 else { return "" }
+        return ns.substring(with: range)
+    }
+
+    static func record(
+        _ kind: ParsedToken.Kind,
+        _ range: NSRange,
+        _ ns: NSString,
+        display: String,
+        into result: inout ParsedInput,
+        consumed: inout [NSRange]
+    ) {
+        let text = ns.substring(with: range)
+        result.tokens.append(ParsedToken(
+            kind: kind,
+            text: text,
+            display: display,
+            location: range.location,
+            length: range.length
+        ))
+        consumed.append(range)
+    }
+
+    static func cleanTitle(_ ns: NSString, consumed: [NSRange]) -> String {
+        let mutable = NSMutableString(string: ns as String)
+        for range in consumed.sorted(by: { $0.location > $1.location }) {
+            guard range.location + range.length <= mutable.length else { continue }
+            mutable.replaceCharacters(in: range, with: " ")
+        }
+        let collapsed = regex(#"\s{2,}"#).stringByReplacingMatches(
+            in: mutable as String,
+            options: [],
+            range: NSRange(location: 0, length: mutable.length),
+            withTemplate: " "
+        )
+        return collapsed
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: " ,;:-—–"))
+    }
+
+    // MARK: - Libellés
+
+    static func weekdayNumber(for name: String) -> Int? {
+        let normalized = name
+            .folding(options: .diacriticInsensitive, locale: Locale(identifier: "fr_FR"))
+            .lowercased()
+        let table: [(String, Int)] = [
+            ("dimanche", 1), ("sunday", 1),
+            ("lundi", 2), ("monday", 2),
+            ("mardi", 3), ("tuesday", 3),
+            ("mercredi", 4), ("wednesday", 4),
+            ("jeudi", 5), ("thursday", 5),
+            ("vendredi", 6), ("friday", 6),
+            ("samedi", 7), ("saturday", 7)
+        ]
+        for (key, value) in table where normalized.hasPrefix(key) {
+            return value
+        }
+        return nil
+    }
+
+    static func monthNumber(for name: String) -> Int? {
+        let normalized = name
+            .folding(options: .diacriticInsensitive, locale: Locale(identifier: "fr_FR"))
+            .lowercased()
+        let table: [(String, Int)] = [
+            ("janvier", 1), ("january", 1),
+            ("fevrier", 2), ("february", 2),
+            ("mars", 3), ("march", 3),
+            ("avril", 4), ("april", 4),
+            ("mai", 5), ("may", 5),
+            ("juin", 6), ("june", 6),
+            ("juillet", 7), ("july", 7),
+            ("aout", 8), ("august", 8),
+            ("septembre", 9), ("september", 9),
+            ("octobre", 10), ("october", 10),
+            ("novembre", 11), ("november", 11),
+            ("decembre", 12), ("december", 12)
+        ]
+        for (key, value) in table where normalized == key {
+            return value
+        }
+        return nil
+    }
+
+    static func relativeLabel(offset: Int, date: Date, calendar: Calendar) -> String {
+        switch offset {
+        case 0: return "Aujourd'hui"
+        case 1: return "Demain"
+        case 2: return "Après-demain"
+        default: return shortDate(date, calendar: calendar)
+        }
+    }
+
+    static func shortDate(_ date: Date, calendar: Calendar) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = Locale(identifier: "fr_FR")
+        formatter.timeZone = calendar.timeZone
+        formatter.dateFormat = "EEE d MMM"
+        return formatter.string(from: date).capitalizedFirstLetter
+    }
+}
+
+// MARK: - Cache de regex
+
+/// Compiler une `NSRegularExpression` coûte cher : on les garde en mémoire.
+final class RegexCache: @unchecked Sendable {
+    private var storage: [String: NSRegularExpression] = [:]
+    private let lock = NSLock()
+
+    /// Motif de repli, syntaxiquement valide et qui ne matche jamais rien.
+    private static let neverMatching: NSRegularExpression = {
+        // Un littéral simple : sa compilation ne peut pas échouer.
+        (try? NSRegularExpression(pattern: "\\bZZZ_NO_MATCH_ZZZ\\b", options: []))!
+    }()
+
+    func regex(for pattern: String) -> NSRegularExpression {
+        lock.lock()
+        defer { lock.unlock() }
+        if let existing = storage[pattern] { return existing }
+        // Les motifs sont des littéraux du code : un échec ici est un bug de
+        // développement. On retombe sur un motif inerte plutôt que de faire
+        // tomber l'app entre les mains de l'utilisateur.
+        let created = (try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]))
+            ?? RegexCache.neverMatching
+        storage[pattern] = created
+        return created
+    }
+}
+
+public extension String {
+    var capitalizedFirstLetter: String {
+        guard let first else { return self }
+        return String(first).uppercased() + dropFirst()
+    }
+}

--- a/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Parsing/ParsedInput.swift
+++ b/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Parsing/ParsedInput.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+/// Un fragment reconnu dans la saisie, avec sa position : l'UI s'en sert pour
+/// surligner en direct ce qui a été compris.
+public struct ParsedToken: Identifiable, Equatable, Sendable {
+    public enum Kind: String, Sendable {
+        case date
+        case time
+        case duration
+        case priority
+        case tag
+        case project
+        case recurrence
+        case reminder
+        case difficulty
+        case area
+        case boss
+    }
+
+    public let id: String
+    public let kind: Kind
+    /// Texte exact repéré dans la saisie.
+    public let text: String
+    /// Ce que l'app en a compris, prêt à afficher (« demain 14:00 »).
+    public let display: String
+    public let location: Int
+    public let length: Int
+
+    public init(kind: Kind, text: String, display: String, location: Int, length: Int) {
+        self.id = "\(kind.rawValue).\(location).\(length)"
+        self.kind = kind
+        self.text = text
+        self.display = display
+        self.location = location
+        self.length = length
+    }
+
+    public var symbolName: String {
+        switch kind {
+        case .date: return "calendar"
+        case .time: return "clock"
+        case .duration: return "hourglass"
+        case .priority: return "flag.fill"
+        case .tag: return "number"
+        case .project: return "folder.fill"
+        case .recurrence: return "repeat"
+        case .reminder: return "bell.fill"
+        case .difficulty: return "bolt.shield.fill"
+        case .area: return "circle.hexagongrid.fill"
+        case .boss: return "crown.fill"
+        }
+    }
+
+    public var hex: String {
+        switch kind {
+        case .date, .time: return "5E9BFF"
+        case .duration: return "64D2FF"
+        case .priority: return "FF9F0A"
+        case .tag: return "BF5AF2"
+        case .project: return "30D158"
+        case .recurrence: return "5E5CE6"
+        case .reminder: return "FF375F"
+        case .difficulty: return "FFD60A"
+        case .area: return "FF7AC6"
+        case .boss: return "F472B6"
+        }
+    }
+}
+
+/// Résultat complet de l'analyse d'une saisie rapide.
+public struct ParsedInput: Equatable, Sendable {
+    public var title: String
+    public var dueDate: Date?
+    /// `false` = échéance « toute la journée ».
+    public var hasTime: Bool
+    public var durationMinutes: Int?
+    public var priority: Priority?
+    public var difficulty: Difficulty?
+    public var lifeArea: LifeArea?
+    public var tags: [String]
+    public var project: String?
+    public var recurrence: RecurrenceRule?
+    public var reminderMinutesBefore: Int?
+    public var isBoss: Bool
+    public var tokens: [ParsedToken]
+
+    public init(
+        title: String = "",
+        dueDate: Date? = nil,
+        hasTime: Bool = false,
+        durationMinutes: Int? = nil,
+        priority: Priority? = nil,
+        difficulty: Difficulty? = nil,
+        lifeArea: LifeArea? = nil,
+        tags: [String] = [],
+        project: String? = nil,
+        recurrence: RecurrenceRule? = nil,
+        reminderMinutesBefore: Int? = nil,
+        isBoss: Bool = false,
+        tokens: [ParsedToken] = []
+    ) {
+        self.title = title
+        self.dueDate = dueDate
+        self.hasTime = hasTime
+        self.durationMinutes = durationMinutes
+        self.priority = priority
+        self.difficulty = difficulty
+        self.lifeArea = lifeArea
+        self.tags = tags
+        self.project = project
+        self.recurrence = recurrence
+        self.reminderMinutesBefore = reminderMinutesBefore
+        self.isBoss = isBoss
+        self.tokens = tokens
+    }
+
+    public var isEmpty: Bool { title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+
+    /// A-t-on compris autre chose que du texte brut ?
+    public var hasMetadata: Bool { !tokens.isEmpty }
+}

--- a/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Recurrence/RecurrenceRule.swift
+++ b/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Recurrence/RecurrenceRule.swift
@@ -1,0 +1,448 @@
+import Foundation
+
+/// Règle de répétition d'une quête.
+///
+/// Volontairement plus simple qu'une RRULE iCalendar complète, mais elle couvre
+/// tout ce qu'une todo-list demande : intervalles, jours de semaine, jour du
+/// mois (avec « dernier jour »), fins de série, et le mode « X jours après
+/// l'accomplissement » qui manque à la plupart des apps.
+public struct RecurrenceRule: Codable, Hashable, Sendable {
+
+    public enum Frequency: String, Codable, CaseIterable, Sendable, Identifiable {
+        case daily
+        case weekly
+        case monthly
+        case yearly
+
+        public var id: String { rawValue }
+
+        public var label: String {
+            switch self {
+            case .daily: return "Jour"
+            case .weekly: return "Semaine"
+            case .monthly: return "Mois"
+            case .yearly: return "Année"
+            }
+        }
+
+        public var pluralLabel: String {
+            switch self {
+            case .daily: return "jours"
+            case .weekly: return "semaines"
+            case .monthly: return "mois"
+            case .yearly: return "ans"
+            }
+        }
+    }
+
+    public enum Ending: Codable, Hashable, Sendable {
+        case never
+        case afterOccurrences(Int)
+        case onDate(Date)
+    }
+
+    public enum Mode: String, Codable, CaseIterable, Sendable {
+        /// Le calendrier fixe commande : rater une occurrence ne décale rien.
+        case fixed
+        /// La prochaine échéance part de la date d'accomplissement.
+        case afterCompletion
+
+        public var label: String {
+            switch self {
+            case .fixed: return "Date fixe"
+            case .afterCompletion: return "Après accomplissement"
+            }
+        }
+    }
+
+    public var frequency: Frequency
+    /// Toutes les N unités. Toujours ≥ 1.
+    public var interval: Int
+    /// 1 = dimanche … 7 = samedi. Vide : on reprend le jour de l'ancre.
+    public var weekdays: Set<Int>
+    /// 1…31, ou -1 pour « dernier jour du mois ». Vide : jour de l'ancre.
+    public var daysOfMonth: Set<Int>
+    /// 1…12. Vide : mois de l'ancre (utile en fréquence annuelle).
+    public var monthsOfYear: Set<Int>
+    public var ending: Ending
+    public var mode: Mode
+    /// Ignore samedi et dimanche (« en semaine »).
+    public var skipWeekends: Bool
+
+    public init(
+        frequency: Frequency = .daily,
+        interval: Int = 1,
+        weekdays: Set<Int> = [],
+        daysOfMonth: Set<Int> = [],
+        monthsOfYear: Set<Int> = [],
+        ending: Ending = .never,
+        mode: Mode = .fixed,
+        skipWeekends: Bool = false
+    ) {
+        self.frequency = frequency
+        self.interval = max(1, interval)
+        self.weekdays = weekdays
+        self.daysOfMonth = daysOfMonth
+        self.monthsOfYear = monthsOfYear
+        self.ending = ending
+        self.mode = mode
+        self.skipWeekends = skipWeekends
+    }
+
+    // MARK: Presets
+
+    public static let daily = RecurrenceRule(frequency: .daily)
+    public static let weekly = RecurrenceRule(frequency: .weekly)
+    public static let monthly = RecurrenceRule(frequency: .monthly)
+    public static let yearly = RecurrenceRule(frequency: .yearly)
+    public static let weekdaysOnly = RecurrenceRule(frequency: .daily, skipWeekends: true)
+    public static let weekendsOnly = RecurrenceRule(frequency: .weekly, weekdays: [1, 7])
+
+    // MARK: Description
+
+    /// Formulation naturelle en français, affichée sur la fiche de quête.
+    public func humanDescription(calendar: Calendar = .questly()) -> String {
+        var parts: [String] = []
+
+        switch frequency {
+        case .daily:
+            if skipWeekends {
+                parts.append(interval == 1 ? "Chaque jour ouvré" : "Tous les \(interval) jours ouvrés")
+            } else {
+                parts.append(interval == 1 ? "Chaque jour" : "Tous les \(interval) jours")
+            }
+        case .weekly:
+            let base = interval == 1 ? "Chaque semaine" : "Toutes les \(interval) semaines"
+            if weekdays.isEmpty {
+                parts.append(base)
+            } else {
+                parts.append("\(base), le \(Self.weekdayList(weekdays, calendar: calendar))")
+            }
+        case .monthly:
+            let base = interval == 1 ? "Chaque mois" : "Tous les \(interval) mois"
+            if daysOfMonth.isEmpty {
+                parts.append(base)
+            } else if daysOfMonth == [-1] {
+                parts.append("\(base), le dernier jour")
+            } else {
+                let days = daysOfMonth.sorted().map { $0 == -1 ? "dernier" : ($0 == 1 ? "1er" : "\($0)") }
+                parts.append("\(base), le \(days.joined(separator: ", "))")
+            }
+        case .yearly:
+            let base = interval == 1 ? "Chaque année" : "Tous les \(interval) ans"
+            if monthsOfYear.isEmpty {
+                parts.append(base)
+            } else {
+                let months = monthsOfYear.sorted().map { Self.monthName($0, calendar: calendar) }
+                parts.append("\(base), en \(months.joined(separator: ", "))")
+            }
+        }
+
+        if mode == .afterCompletion {
+            parts.append("à partir de l'accomplissement")
+        }
+
+        switch ending {
+        case .never:
+            break
+        case .afterOccurrences(let n):
+            parts.append("· \(n) fois")
+        case .onDate(let date):
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "fr_FR")
+            formatter.dateFormat = "d MMM yyyy"
+            parts.append("· jusqu'au \(formatter.string(from: date))")
+        }
+
+        return parts.joined(separator: " ")
+    }
+
+    static func weekdayList(_ days: Set<Int>, calendar: Calendar) -> String {
+        let names = ["dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi"]
+        let sorted = days.sorted { orderIndex($0, firstWeekday: calendar.firstWeekday) < orderIndex($1, firstWeekday: calendar.firstWeekday) }
+        let labels = sorted.compactMap { day -> String? in
+            guard day >= 1, day <= 7 else { return nil }
+            return names[day - 1]
+        }
+        if labels.count <= 1 { return labels.first ?? "" }
+        return labels.dropLast().joined(separator: ", ") + " et " + (labels.last ?? "")
+    }
+
+    static func orderIndex(_ weekday: Int, firstWeekday: Int) -> Int {
+        ((weekday - firstWeekday) + 7) % 7
+    }
+
+    static func monthName(_ month: Int, calendar: Calendar) -> String {
+        let names = ["janvier", "février", "mars", "avril", "mai", "juin",
+                     "juillet", "août", "septembre", "octobre", "novembre", "décembre"]
+        guard month >= 1, month <= 12 else { return "" }
+        return names[month - 1]
+    }
+}
+
+// MARK: - Engine
+
+public enum RecurrenceEngine {
+
+    /// Nombre maximum de jours balayés pour trouver une occurrence.
+    /// 10 ans couvre largement les règles réalistes tout en bornant le coût.
+    public static let scanLimitDays = 3_700
+
+    /// Le jour `date` fait-il partie de la série ?
+    public static func matches(
+        rule: RecurrenceRule,
+        date: Date,
+        anchor: Date,
+        calendar: Calendar = .questly()
+    ) -> Bool {
+        let day = calendar.startOfDay(for: date)
+        let anchorDay = calendar.startOfDay(for: anchor)
+        guard day >= anchorDay else { return false }
+
+        if rule.skipWeekends && calendar.isWeekend(day) { return false }
+
+        switch rule.frequency {
+        case .daily:
+            if rule.skipWeekends {
+                // « Tous les N jours ouvrés » : on compte en jours ouvrés.
+                guard rule.interval > 1 else { return true }
+                let businessDays = businessDayCount(from: anchorDay, to: day, calendar: calendar)
+                return businessDays % rule.interval == 0
+            }
+            let delta = calendar.daysBetween(anchorDay, day)
+            return delta % rule.interval == 0
+
+        case .weekly:
+            let weekday = calendar.component(.weekday, from: day)
+            let targetDays = rule.weekdays.isEmpty
+                ? [calendar.component(.weekday, from: anchorDay)]
+                : Array(rule.weekdays)
+            guard targetDays.contains(weekday) else { return false }
+            guard rule.interval > 1 else { return true }
+            let anchorWeek = calendar.startOfWeek(anchorDay)
+            let currentWeek = calendar.startOfWeek(day)
+            let weeks = calendar.daysBetween(anchorWeek, currentWeek) / 7
+            return weeks % rule.interval == 0
+
+        case .monthly:
+            guard matchesDayOfMonth(rule: rule, day: day, anchorDay: anchorDay, calendar: calendar) else { return false }
+            guard rule.interval > 1 else { return true }
+            let months = monthCount(from: anchorDay, to: day, calendar: calendar)
+            return months % rule.interval == 0
+
+        case .yearly:
+            let month = calendar.component(.month, from: day)
+            let targetMonths = rule.monthsOfYear.isEmpty
+                ? [calendar.component(.month, from: anchorDay)]
+                : Array(rule.monthsOfYear)
+            guard targetMonths.contains(month) else { return false }
+            guard matchesDayOfMonth(rule: rule, day: day, anchorDay: anchorDay, calendar: calendar) else { return false }
+            guard rule.interval > 1 else { return true }
+            let years = calendar.component(.year, from: day) - calendar.component(.year, from: anchorDay)
+            return years % rule.interval == 0
+        }
+    }
+
+    /// Prochaine occurrence strictement postérieure à `date`.
+    public static func nextDate(
+        rule: RecurrenceRule,
+        after date: Date,
+        anchor: Date,
+        calendar: Calendar = .questly()
+    ) -> Date? {
+        if rule.mode == .afterCompletion {
+            return nextAfterCompletion(rule: rule, completedAt: date, anchor: anchor, calendar: calendar)
+        }
+
+        let anchorTime = calendar.dateComponents([.hour, .minute, .second], from: anchor)
+        var cursor = calendar.startOfDay(for: max(date, anchor))
+        let occurrencesSeen = countOccurrences(rule: rule, from: anchor, upTo: date, calendar: calendar)
+
+        for _ in 0..<scanLimitDays {
+            if matches(rule: rule, date: cursor, anchor: anchor, calendar: calendar) {
+                let candidate = calendar.date(
+                    bySettingHour: anchorTime.hour ?? 0,
+                    minute: anchorTime.minute ?? 0,
+                    second: anchorTime.second ?? 0,
+                    of: cursor
+                ) ?? cursor
+
+                if candidate > date {
+                    switch rule.ending {
+                    case .never:
+                        return candidate
+                    case .onDate(let end):
+                        return candidate <= calendar.endOfDay(end) ? candidate : nil
+                    case .afterOccurrences(let limit):
+                        return occurrencesSeen < limit ? candidate : nil
+                    }
+                }
+            }
+            cursor = cursor.adding(days: 1, calendar: calendar)
+
+            if case .onDate(let end) = rule.ending, cursor > calendar.endOfDay(end) {
+                return nil
+            }
+        }
+        return nil
+    }
+
+    /// Toutes les occurrences dans un intervalle — utilisé par le calendrier
+    /// pour afficher les répétitions sans les matérialiser en base.
+    ///
+    /// - Important: `start` et `end` sont des instants précis, pas des jours.
+    ///   Une occurrence à 9 h le 20 mars n'est pas incluse si `end` vaut
+    ///   « 20 mars 00:00 » ; passer `calendar.endOfDay(...)` pour raisonner
+    ///   en journées entières.
+    public static func occurrences(
+        rule: RecurrenceRule,
+        anchor: Date,
+        from start: Date,
+        to end: Date,
+        calendar: Calendar = .questly(),
+        limit: Int = 500
+    ) -> [Date] {
+        guard end >= start else { return [] }
+        let anchorTime = calendar.dateComponents([.hour, .minute, .second], from: anchor)
+        var results: [Date] = []
+        var cursor = calendar.startOfDay(for: max(start, anchor))
+        let lastDay = calendar.startOfDay(for: end)
+        var index = countOccurrences(rule: rule, from: anchor, upTo: cursor.addingTimeInterval(-1), calendar: calendar)
+        var guardCounter = 0
+
+        while cursor <= lastDay && results.count < limit && guardCounter < scanLimitDays {
+            guardCounter += 1
+            if matches(rule: rule, date: cursor, anchor: anchor, calendar: calendar) {
+                if case .afterOccurrences(let maxCount) = rule.ending, index >= maxCount { break }
+                if case .onDate(let endDate) = rule.ending, cursor > calendar.endOfDay(endDate) { break }
+                let occurrence = calendar.date(
+                    bySettingHour: anchorTime.hour ?? 0,
+                    minute: anchorTime.minute ?? 0,
+                    second: anchorTime.second ?? 0,
+                    of: cursor
+                ) ?? cursor
+                if occurrence >= start && occurrence <= end {
+                    results.append(occurrence)
+                }
+                index += 1
+            }
+            cursor = cursor.adding(days: 1, calendar: calendar)
+        }
+        return results
+    }
+
+    /// Mode « après accomplissement » : on repart de la date de validation.
+    static func nextAfterCompletion(
+        rule: RecurrenceRule,
+        completedAt: Date,
+        anchor: Date,
+        calendar: Calendar = .questly()
+    ) -> Date? {
+        let component: Calendar.Component
+        switch rule.frequency {
+        case .daily: component = .day
+        case .weekly: component = .weekOfYear
+        case .monthly: component = .month
+        case .yearly: component = .year
+        }
+        guard var next = calendar.date(byAdding: component, value: rule.interval, to: completedAt) else { return nil }
+
+        if rule.skipWeekends {
+            var guardCounter = 0
+            while calendar.isWeekend(next) && guardCounter < 7 {
+                guardCounter += 1
+                next = next.adding(days: 1, calendar: calendar)
+            }
+        }
+
+        // On conserve l'heure de l'ancre pour ne pas faire dériver le rappel.
+        let anchorTime = calendar.dateComponents([.hour, .minute, .second], from: anchor)
+        next = calendar.date(
+            bySettingHour: anchorTime.hour ?? 0,
+            minute: anchorTime.minute ?? 0,
+            second: anchorTime.second ?? 0,
+            of: next
+        ) ?? next
+
+        if case .onDate(let end) = rule.ending, next > calendar.endOfDay(end) { return nil }
+        return next
+    }
+
+    /// Nombre d'occurrences déjà survenues entre l'ancre et `date` incluse.
+    public static func countOccurrences(
+        rule: RecurrenceRule,
+        from anchor: Date,
+        upTo date: Date,
+        calendar: Calendar = .questly()
+    ) -> Int {
+        guard date >= anchor else { return 0 }
+        let anchorTime = calendar.dateComponents([.hour, .minute, .second], from: anchor)
+        var count = 0
+        var cursor = calendar.startOfDay(for: anchor)
+        let lastDay = calendar.startOfDay(for: date)
+        var guardCounter = 0
+        while cursor <= lastDay && guardCounter < scanLimitDays {
+            guardCounter += 1
+            if matches(rule: rule, date: cursor, anchor: anchor, calendar: calendar) {
+                let occurrence = calendar.date(
+                    bySettingHour: anchorTime.hour ?? 0,
+                    minute: anchorTime.minute ?? 0,
+                    second: anchorTime.second ?? 0,
+                    of: cursor
+                ) ?? cursor
+                if occurrence <= date { count += 1 }
+            }
+            cursor = cursor.adding(days: 1, calendar: calendar)
+        }
+        return count
+    }
+
+    // MARK: Helpers
+
+    static func matchesDayOfMonth(
+        rule: RecurrenceRule,
+        day: Date,
+        anchorDay: Date,
+        calendar: Calendar
+    ) -> Bool {
+        let dayNumber = calendar.component(.day, from: day)
+        let daysInMonth = calendar.numberOfDaysInMonth(day)
+
+        let targets: [Int]
+        if rule.daysOfMonth.isEmpty {
+            targets = [calendar.component(.day, from: anchorDay)]
+        } else {
+            targets = Array(rule.daysOfMonth)
+        }
+
+        for target in targets {
+            if target == -1 {
+                if dayNumber == daysInMonth { return true }
+                continue
+            }
+            if target == dayNumber { return true }
+            // Report sur le dernier jour quand le mois est trop court
+            // (le 31 devient le 28/29 février).
+            if target > daysInMonth && dayNumber == daysInMonth { return true }
+        }
+        return false
+    }
+
+    static func monthCount(from start: Date, to end: Date, calendar: Calendar) -> Int {
+        let comps = calendar.dateComponents([.month], from: calendar.startOfMonth(start), to: calendar.startOfMonth(end))
+        return abs(comps.month ?? 0)
+    }
+
+    static func businessDayCount(from start: Date, to end: Date, calendar: Calendar) -> Int {
+        guard end > start else { return 0 }
+        var count = 0
+        var cursor = start
+        var guardCounter = 0
+        while cursor < end && guardCounter < scanLimitDays {
+            guardCounter += 1
+            cursor = cursor.adding(days: 1, calendar: calendar)
+            if !calendar.isWeekend(cursor) { count += 1 }
+        }
+        return count
+    }
+}

--- a/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Scheduling/ScheduleEngine.swift
+++ b/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Scheduling/ScheduleEngine.swift
@@ -1,0 +1,368 @@
+import Foundation
+
+// MARK: - Types
+
+public struct TimeSlot: Identifiable, Equatable, Sendable {
+    public let start: Date
+    public let end: Date
+
+    public var id: String { "\(start.timeIntervalSince1970)-\(end.timeIntervalSince1970)" }
+    public var minutes: Int { max(0, Int(end.timeIntervalSince(start) / 60)) }
+
+    public init(start: Date, end: Date) {
+        self.start = start
+        self.end = end
+    }
+
+    public func overlaps(_ other: TimeSlot) -> Bool {
+        start < other.end && other.start < end
+    }
+}
+
+public struct BusyInterval: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let start: Date
+    public let end: Date
+    public let title: String
+
+    public init(id: String = UUID().uuidString, start: Date, end: Date, title: String = "") {
+        self.id = id
+        self.start = start
+        self.end = end
+        self.title = title
+    }
+}
+
+/// Plage de travail par défaut de l'utilisateur.
+public struct WorkingHours: Equatable, Sendable, Codable {
+    /// Minutes depuis minuit.
+    public var startMinute: Int
+    public var endMinute: Int
+    /// Jours travaillés (1 = dimanche … 7 = samedi).
+    public var weekdays: Set<Int>
+    /// Fenêtre de pointe où l'énergie est au maximum.
+    public var peakStartMinute: Int
+    public var peakEndMinute: Int
+
+    public init(
+        startMinute: Int = 9 * 60,
+        endMinute: Int = 18 * 60,
+        weekdays: Set<Int> = [2, 3, 4, 5, 6],
+        peakStartMinute: Int = 9 * 60,
+        peakEndMinute: Int = 12 * 60
+    ) {
+        self.startMinute = startMinute
+        self.endMinute = endMinute
+        self.weekdays = weekdays
+        self.peakStartMinute = peakStartMinute
+        self.peakEndMinute = peakEndMinute
+    }
+
+    public static let `default` = WorkingHours()
+
+    public func isWorkingDay(_ date: Date, calendar: Calendar) -> Bool {
+        weekdays.contains(calendar.component(.weekday, from: date))
+    }
+}
+
+/// Une tâche candidate à la planification automatique.
+public struct PlannableTask: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let title: String
+    public let estimatedMinutes: Int
+    public let priority: Priority
+    public let difficulty: Difficulty
+    public let energy: EnergyLevel
+    public let dueDate: Date?
+    public let isBoss: Bool
+
+    public init(
+        id: String,
+        title: String,
+        estimatedMinutes: Int,
+        priority: Priority = .p4,
+        difficulty: Difficulty = .medium,
+        energy: EnergyLevel = .medium,
+        dueDate: Date? = nil,
+        isBoss: Bool = false
+    ) {
+        self.id = id
+        self.title = title
+        self.estimatedMinutes = max(5, estimatedMinutes)
+        self.priority = priority
+        self.difficulty = difficulty
+        self.energy = energy
+        self.dueDate = dueDate
+        self.isBoss = isBoss
+    }
+}
+
+public struct PlannedBlock: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let taskID: String
+    public let title: String
+    public let start: Date
+    public let end: Date
+    /// Explication affichée à l'utilisateur (« placé au pic d'énergie »).
+    public let rationale: String
+
+    public init(taskID: String, title: String, start: Date, end: Date, rationale: String) {
+        self.id = "\(taskID)-\(start.timeIntervalSince1970)"
+        self.taskID = taskID
+        self.title = title
+        self.start = start
+        self.end = end
+        self.rationale = rationale
+    }
+}
+
+public struct PlanResult: Equatable, Sendable {
+    public let blocks: [PlannedBlock]
+    public let unplaced: [PlannableTask]
+    public let usedMinutes: Int
+    public let freeMinutes: Int
+
+    public init(blocks: [PlannedBlock], unplaced: [PlannableTask], usedMinutes: Int, freeMinutes: Int) {
+        self.blocks = blocks
+        self.unplaced = unplaced
+        self.usedMinutes = usedMinutes
+        self.freeMinutes = freeMinutes
+    }
+}
+
+// MARK: - Engine
+
+/// Trouve les trous dans une journée et y range les quêtes intelligemment.
+public enum ScheduleEngine {
+
+    /// Fusionne les occupations qui se chevauchent.
+    public static func merge(_ intervals: [BusyInterval]) -> [TimeSlot] {
+        let sorted = intervals
+            .filter { $0.end > $0.start }
+            .sorted { $0.start < $1.start }
+        var merged: [TimeSlot] = []
+        for interval in sorted {
+            if let last = merged.last, interval.start <= last.end {
+                if interval.end > last.end {
+                    merged[merged.count - 1] = TimeSlot(start: last.start, end: interval.end)
+                }
+            } else {
+                merged.append(TimeSlot(start: interval.start, end: interval.end))
+            }
+        }
+        return merged
+    }
+
+    /// Créneaux libres d'une journée, dans les heures de travail.
+    public static func freeSlots(
+        on day: Date,
+        busy: [BusyInterval],
+        workingHours: WorkingHours = .default,
+        minimumMinutes: Int = 15,
+        bufferMinutes: Int = 0,
+        notBefore: Date? = nil,
+        calendar: Calendar = .questly()
+    ) -> [TimeSlot] {
+        let dayStart = calendar.startOfDay(for: day)
+        var windowStart = dayStart.adding(minutes: workingHours.startMinute)
+        let windowEnd = dayStart.adding(minutes: workingHours.endMinute)
+
+        if let notBefore, notBefore > windowStart, calendar.isSameDay(notBefore, day) {
+            windowStart = notBefore
+        }
+        guard windowEnd > windowStart else { return [] }
+
+        let occupied = merge(busy.filter { $0.end > windowStart && $0.start < windowEnd })
+        var slots: [TimeSlot] = []
+        var cursor = windowStart
+
+        for block in occupied {
+            let blockStart = max(block.start, windowStart)
+            if blockStart > cursor {
+                let end = min(blockStart, windowEnd).addingTimeInterval(TimeInterval(-bufferMinutes * 60))
+                if end > cursor {
+                    slots.append(TimeSlot(start: cursor, end: end))
+                }
+            }
+            cursor = max(cursor, min(block.end, windowEnd).addingTimeInterval(TimeInterval(bufferMinutes * 60)))
+        }
+
+        if cursor < windowEnd {
+            slots.append(TimeSlot(start: cursor, end: windowEnd))
+        }
+
+        return slots.filter { $0.minutes >= minimumMinutes }
+    }
+
+    /// Range les tâches dans les trous de la journée.
+    ///
+    /// Heuristique : échéance la plus proche d'abord, puis priorité, puis
+    /// difficulté. Les tâches exigeantes visent la fenêtre de pointe ; les
+    /// petites tâches bouchent les trous restants.
+    public static func autoPlan(
+        tasks: [PlannableTask],
+        on day: Date,
+        busy: [BusyInterval],
+        workingHours: WorkingHours = .default,
+        bufferMinutes: Int = 5,
+        notBefore: Date? = nil,
+        calendar: Calendar = .questly()
+    ) -> PlanResult {
+        var slots = freeSlots(
+            on: day,
+            busy: busy,
+            workingHours: workingHours,
+            minimumMinutes: 10,
+            bufferMinutes: 0,
+            notBefore: notBefore,
+            calendar: calendar
+        )
+        let totalFree = slots.reduce(0) { $0 + $1.minutes }
+
+        let ordered = tasks.sorted(by: rankTasks)
+        var blocks: [PlannedBlock] = []
+        var unplaced: [PlannableTask] = []
+        var used = 0
+
+        let dayStart = calendar.startOfDay(for: day)
+        let peakStart = dayStart.adding(minutes: workingHours.peakStartMinute)
+        let peakEnd = dayStart.adding(minutes: workingHours.peakEndMinute)
+
+        for task in ordered {
+            let needed = task.estimatedMinutes
+            let wantsPeak = task.energy == .high || task.difficulty.rawValue >= Difficulty.hard.rawValue || task.isBoss
+
+            // On cherche d'abord un créneau dans la fenêtre de pointe.
+            var chosenIndex: Int?
+            if wantsPeak {
+                chosenIndex = slots.firstIndex { slot in
+                    slot.minutes >= needed && slot.start < peakEnd && slot.end > peakStart
+                }
+            }
+            if chosenIndex == nil {
+                chosenIndex = slots.firstIndex { $0.minutes >= needed }
+            }
+
+            guard let index = chosenIndex else {
+                unplaced.append(task)
+                continue
+            }
+
+            let slot = slots[index]
+            var start = slot.start
+            if wantsPeak, slot.start < peakStart, slot.end >= peakStart.addingTimeInterval(TimeInterval(needed * 60)) {
+                start = peakStart
+            }
+            let end = start.addingTimeInterval(TimeInterval(needed * 60))
+
+            blocks.append(PlannedBlock(
+                taskID: task.id,
+                title: task.title,
+                start: start,
+                end: end,
+                rationale: rationale(for: task, start: start, peakStart: peakStart, peakEnd: peakEnd)
+            ))
+            used += needed
+
+            // On reconstruit les morceaux de créneau restants.
+            var replacements: [TimeSlot] = []
+            if start > slot.start {
+                replacements.append(TimeSlot(start: slot.start, end: start))
+            }
+            let resumeAt = end.addingTimeInterval(TimeInterval(bufferMinutes * 60))
+            if resumeAt < slot.end {
+                replacements.append(TimeSlot(start: resumeAt, end: slot.end))
+            }
+            slots.remove(at: index)
+            slots.insert(contentsOf: replacements.filter { $0.minutes >= 10 }, at: index)
+            slots.sort { $0.start < $1.start }
+        }
+
+        return PlanResult(
+            blocks: blocks.sorted { $0.start < $1.start },
+            unplaced: unplaced,
+            usedMinutes: used,
+            freeMinutes: max(0, totalFree - used)
+        )
+    }
+
+    static func rankTasks(_ a: PlannableTask, _ b: PlannableTask) -> Bool {
+        // 1. Échéance
+        switch (a.dueDate, b.dueDate) {
+        case (let x?, let y?) where x != y:
+            return x < y
+        case (nil, .some):
+            return false
+        case (.some, nil):
+            return true
+        default:
+            break
+        }
+        // 2. Priorité
+        if a.priority != b.priority { return a.priority.urgencyScore > b.priority.urgencyScore }
+        // 3. Boss d'abord
+        if a.isBoss != b.isBoss { return a.isBoss }
+        // 4. Difficulté décroissante : on attaque le gros le matin.
+        if a.difficulty != b.difficulty { return a.difficulty.rawValue > b.difficulty.rawValue }
+        // 5. Stabilité
+        return a.id < b.id
+    }
+
+    static func rationale(for task: PlannableTask, start: Date, peakStart: Date, peakEnd: Date) -> String {
+        if start >= peakStart && start < peakEnd {
+            if task.isBoss { return "Boss placé au pic d'énergie" }
+            if task.energy == .high { return "Tâche exigeante au pic d'énergie" }
+            return "Placée au meilleur moment"
+        }
+        if let due = task.dueDate {
+            let calendar = Calendar.questly()
+            if calendar.isSameDay(due, start) { return "À rendre aujourd'hui" }
+        }
+        if task.priority == .p1 { return "Priorité critique" }
+        return "Comble un créneau libre"
+    }
+
+    /// Suggère les 3 meilleurs créneaux pour une durée donnée, sur plusieurs jours.
+    public static func suggestSlots(
+        forMinutes minutes: Int,
+        startingFrom date: Date,
+        days: Int = 7,
+        busyByDay: [Date: [BusyInterval]],
+        workingHours: WorkingHours = .default,
+        limit: Int = 3,
+        calendar: Calendar = .questly()
+    ) -> [TimeSlot] {
+        var suggestions: [TimeSlot] = []
+        for offset in 0..<max(1, days) {
+            let day = calendar.startOfDay(for: date.adding(days: offset, calendar: calendar))
+            guard workingHours.isWorkingDay(day, calendar: calendar) else { continue }
+            let busy = busyByDay[day] ?? []
+            let slots = freeSlots(
+                on: day,
+                busy: busy,
+                workingHours: workingHours,
+                minimumMinutes: minutes,
+                bufferMinutes: 0,
+                notBefore: offset == 0 ? date : nil,
+                calendar: calendar
+            )
+            for slot in slots {
+                suggestions.append(TimeSlot(
+                    start: slot.start,
+                    end: slot.start.addingTimeInterval(TimeInterval(minutes * 60))
+                ))
+                if suggestions.count >= limit { return suggestions }
+            }
+        }
+        return suggestions
+    }
+
+    /// Détecte les journées surchargées : plus de tâches planifiées que d'heures.
+    public static func workloadRatio(
+        plannedMinutes: Int,
+        workingHours: WorkingHours = .default
+    ) -> Double {
+        let capacity = max(1, workingHours.endMinute - workingHours.startMinute)
+        return Double(plannedMinutes) / Double(capacity)
+    }
+}

--- a/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Stats/StatsEngine.swift
+++ b/QuestlyApp/Packages/QuestlyKit/Sources/QuestlyKit/Stats/StatsEngine.swift
@@ -1,0 +1,448 @@
+import Foundation
+
+// MARK: - Records
+
+/// Une ligne du journal d'accomplissement. L'app en fournit la liste, le
+/// moteur en tire toutes les statistiques.
+public struct CompletionRecord: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let date: Date
+    public let xp: Int
+    public let focusMinutes: Int
+    public let priority: Priority
+    public let difficulty: Difficulty
+    public let lifeArea: LifeArea?
+    public let wasOnTime: Bool
+    public let isHabit: Bool
+    public let isBoss: Bool
+
+    public init(
+        id: String = UUID().uuidString,
+        date: Date,
+        xp: Int,
+        focusMinutes: Int = 0,
+        priority: Priority = .p4,
+        difficulty: Difficulty = .medium,
+        lifeArea: LifeArea? = nil,
+        wasOnTime: Bool = true,
+        isHabit: Bool = false,
+        isBoss: Bool = false
+    ) {
+        self.id = id
+        self.date = date
+        self.xp = xp
+        self.focusMinutes = focusMinutes
+        self.priority = priority
+        self.difficulty = difficulty
+        self.lifeArea = lifeArea
+        self.wasOnTime = wasOnTime
+        self.isHabit = isHabit
+        self.isBoss = isBoss
+    }
+}
+
+public struct DailyPoint: Identifiable, Equatable, Sendable {
+    public var id: Date { date }
+    public let date: Date
+    public let completed: Int
+    public let xp: Int
+    public let focusMinutes: Int
+
+    public init(date: Date, completed: Int, xp: Int, focusMinutes: Int) {
+        self.date = date
+        self.completed = completed
+        self.xp = xp
+        self.focusMinutes = focusMinutes
+    }
+}
+
+public struct BucketPoint: Identifiable, Equatable, Sendable {
+    public var id: Int { index }
+    public let index: Int
+    public let label: String
+    public let value: Int
+
+    public init(index: Int, label: String, value: Int) {
+        self.index = index
+        self.label = label
+        self.value = value
+    }
+}
+
+// MARK: - Stats
+
+public struct ProductivityStats: Equatable, Sendable {
+    public var totalCompleted: Int
+    public var totalXP: Int
+    public var totalFocusMinutes: Int
+    public var averagePerActiveDay: Double
+    public var averageXPPerDay: Double
+    public var onTimeRate: Double
+    public var bossesDefeated: Int
+    public var habitsCompleted: Int
+    public var daily: [DailyPoint]
+    public var byWeekday: [BucketPoint]
+    public var byHour: [BucketPoint]
+    public var byArea: [LifeArea: Int]
+    public var byDifficulty: [Difficulty: Int]
+    public var byPriority: [Priority: Int]
+    public var bestWeekday: Int?
+    public var bestHour: Int?
+    public var activeDays: Int
+
+    public init(
+        totalCompleted: Int = 0,
+        totalXP: Int = 0,
+        totalFocusMinutes: Int = 0,
+        averagePerActiveDay: Double = 0,
+        averageXPPerDay: Double = 0,
+        onTimeRate: Double = 0,
+        bossesDefeated: Int = 0,
+        habitsCompleted: Int = 0,
+        daily: [DailyPoint] = [],
+        byWeekday: [BucketPoint] = [],
+        byHour: [BucketPoint] = [],
+        byArea: [LifeArea: Int] = [:],
+        byDifficulty: [Difficulty: Int] = [:],
+        byPriority: [Priority: Int] = [:],
+        bestWeekday: Int? = nil,
+        bestHour: Int? = nil,
+        activeDays: Int = 0
+    ) {
+        self.totalCompleted = totalCompleted
+        self.totalXP = totalXP
+        self.totalFocusMinutes = totalFocusMinutes
+        self.averagePerActiveDay = averagePerActiveDay
+        self.averageXPPerDay = averageXPPerDay
+        self.onTimeRate = onTimeRate
+        self.bossesDefeated = bossesDefeated
+        self.habitsCompleted = habitsCompleted
+        self.daily = daily
+        self.byWeekday = byWeekday
+        self.byHour = byHour
+        self.byArea = byArea
+        self.byDifficulty = byDifficulty
+        self.byPriority = byPriority
+        self.bestWeekday = bestWeekday
+        self.bestHour = bestHour
+        self.activeDays = activeDays
+    }
+
+    public static let empty = ProductivityStats()
+}
+
+// MARK: - Engine
+
+public enum StatsEngine {
+
+    public static let weekdayNames = ["Dim", "Lun", "Mar", "Mer", "Jeu", "Ven", "Sam"]
+    public static let weekdayFullNames = ["dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi"]
+
+    public static func compute(
+        records: [CompletionRecord],
+        from start: Date,
+        to end: Date,
+        calendar: Calendar = .questly()
+    ) -> ProductivityStats {
+        let windowStart = calendar.startOfDay(for: start)
+        let windowEnd = calendar.endOfDay(end)
+        let scoped = records.filter { $0.date >= windowStart && $0.date <= windowEnd }
+
+        guard !scoped.isEmpty else {
+            return ProductivityStats(daily: emptyDaily(from: windowStart, to: windowEnd, calendar: calendar),
+                                     byWeekday: emptyWeekdayBuckets(),
+                                     byHour: emptyHourBuckets())
+        }
+
+        var perDay: [Date: (count: Int, xp: Int, focus: Int)] = [:]
+        var weekdayCounts = [Int](repeating: 0, count: 7)
+        var hourCounts = [Int](repeating: 0, count: 24)
+        var areaCounts: [LifeArea: Int] = [:]
+        var difficultyCounts: [Difficulty: Int] = [:]
+        var priorityCounts: [Priority: Int] = [:]
+        var onTime = 0
+        var bosses = 0
+        var habits = 0
+        var totalXP = 0
+        var totalFocus = 0
+
+        for record in scoped {
+            let day = calendar.startOfDay(for: record.date)
+            var entry = perDay[day] ?? (0, 0, 0)
+            entry.count += 1
+            entry.xp += record.xp
+            entry.focus += record.focusMinutes
+            perDay[day] = entry
+
+            let weekday = calendar.component(.weekday, from: record.date) - 1
+            if weekday >= 0 && weekday < 7 { weekdayCounts[weekday] += 1 }
+            let hour = calendar.component(.hour, from: record.date)
+            if hour >= 0 && hour < 24 { hourCounts[hour] += 1 }
+
+            if let area = record.lifeArea { areaCounts[area, default: 0] += 1 }
+            difficultyCounts[record.difficulty, default: 0] += 1
+            priorityCounts[record.priority, default: 0] += 1
+
+            if record.wasOnTime { onTime += 1 }
+            if record.isBoss { bosses += 1 }
+            if record.isHabit { habits += 1 }
+            totalXP += record.xp
+            totalFocus += record.focusMinutes
+        }
+
+        let daily = daySequence(from: windowStart, to: windowEnd, calendar: calendar).map { day -> DailyPoint in
+            let entry = perDay[day] ?? (0, 0, 0)
+            return DailyPoint(date: day, completed: entry.count, xp: entry.xp, focusMinutes: entry.focus)
+        }
+
+        let spanDays = max(1, calendar.daysBetween(windowStart, windowEnd) + 1)
+        let activeDays = perDay.keys.count
+
+        return ProductivityStats(
+            totalCompleted: scoped.count,
+            totalXP: totalXP,
+            totalFocusMinutes: totalFocus,
+            averagePerActiveDay: activeDays > 0 ? Double(scoped.count) / Double(activeDays) : 0,
+            averageXPPerDay: Double(totalXP) / Double(spanDays),
+            onTimeRate: Double(onTime) / Double(scoped.count),
+            bossesDefeated: bosses,
+            habitsCompleted: habits,
+            daily: daily,
+            byWeekday: weekdayCounts.enumerated().map {
+                BucketPoint(index: $0.offset, label: weekdayNames[$0.offset], value: $0.element)
+            },
+            byHour: hourCounts.enumerated().map {
+                BucketPoint(index: $0.offset, label: String(format: "%02dh", $0.offset), value: $0.element)
+            },
+            byArea: areaCounts,
+            byDifficulty: difficultyCounts,
+            byPriority: priorityCounts,
+            bestWeekday: weekdayCounts.enumerated().max(by: { $0.element < $1.element }).flatMap { $0.element > 0 ? $0.offset : nil },
+            bestHour: hourCounts.enumerated().max(by: { $0.element < $1.element }).flatMap { $0.element > 0 ? $0.offset : nil },
+            activeDays: activeDays
+        )
+    }
+
+    /// Moyenne mobile, pour lisser la courbe d'XP.
+    public static func rollingAverage(_ points: [DailyPoint], window: Int = 7) -> [Double] {
+        guard window > 1, !points.isEmpty else { return points.map { Double($0.xp) } }
+        var output: [Double] = []
+        output.reserveCapacity(points.count)
+        for index in points.indices {
+            let lower = max(0, index - window + 1)
+            let slice = points[lower...index]
+            let sum = slice.reduce(0) { $0 + $1.xp }
+            output.append(Double(sum) / Double(slice.count))
+        }
+        return output
+    }
+
+    /// Jours estimés avant le prochain niveau au rythme actuel.
+    public static func daysToNextLevel(totalXP: Int, averageXPPerDay: Double) -> Int? {
+        guard averageXPPerDay > 0.5 else { return nil }
+        let progress = LevelCurve.progress(forTotalXP: totalXP)
+        guard progress.xpRemaining > 0 else { return 0 }
+        return Int(ceil(Double(progress.xpRemaining) / averageXPPerDay))
+    }
+
+    /// Comparaison semaine en cours / semaine précédente, en pourcentage.
+    public static func weekOverWeekChange(
+        records: [CompletionRecord],
+        reference: Date,
+        calendar: Calendar = .questly()
+    ) -> Double? {
+        let thisWeekStart = calendar.startOfWeek(reference)
+        let lastWeekStart = calendar.date(byAdding: .weekOfYear, value: -1, to: thisWeekStart) ?? thisWeekStart
+        let thisWeek = records.filter { $0.date >= thisWeekStart && $0.date <= reference }.count
+        let lastWeekEnd = calendar.date(byAdding: .day, value: calendar.daysBetween(thisWeekStart, reference), to: lastWeekStart) ?? thisWeekStart
+        let lastWeek = records.filter { $0.date >= lastWeekStart && $0.date <= lastWeekEnd }.count
+        guard lastWeek > 0 else { return thisWeek > 0 ? 1.0 : nil }
+        return (Double(thisWeek) - Double(lastWeek)) / Double(lastWeek)
+    }
+
+    // MARK: Helpers
+
+    static func daySequence(from start: Date, to end: Date, calendar: Calendar) -> [Date] {
+        var days: [Date] = []
+        var cursor = calendar.startOfDay(for: start)
+        let last = calendar.startOfDay(for: end)
+        var guardCounter = 0
+        while cursor <= last && guardCounter < 800 {
+            guardCounter += 1
+            days.append(cursor)
+            cursor = cursor.adding(days: 1, calendar: calendar)
+        }
+        return days
+    }
+
+    static func emptyDaily(from start: Date, to end: Date, calendar: Calendar) -> [DailyPoint] {
+        daySequence(from: start, to: end, calendar: calendar).map {
+            DailyPoint(date: $0, completed: 0, xp: 0, focusMinutes: 0)
+        }
+    }
+
+    static func emptyWeekdayBuckets() -> [BucketPoint] {
+        (0..<7).map { BucketPoint(index: $0, label: weekdayNames[$0], value: 0) }
+    }
+
+    static func emptyHourBuckets() -> [BucketPoint] {
+        (0..<24).map { BucketPoint(index: $0, label: String(format: "%02dh", $0), value: 0) }
+    }
+}
+
+// MARK: - Insights
+
+/// Petites phrases générées à partir des statistiques, affichées dans
+/// l'onglet Chroniques. Elles rendent les chiffres actionnables.
+public struct Insight: Identifiable, Equatable, Sendable {
+    public enum Tone: String, Sendable {
+        case positive
+        case neutral
+        case warning
+    }
+
+    public let id: String
+    public let title: String
+    public let detail: String
+    public let symbolName: String
+    public let tone: Tone
+
+    public init(id: String, title: String, detail: String, symbolName: String, tone: Tone) {
+        self.id = id
+        self.title = title
+        self.detail = detail
+        self.symbolName = symbolName
+        self.tone = tone
+    }
+}
+
+public enum InsightEngine {
+
+    public static func insights(
+        stats: ProductivityStats,
+        streak: StreakState,
+        totalXP: Int,
+        overdueCount: Int,
+        calendar: Calendar = .questly()
+    ) -> [Insight] {
+        var output: [Insight] = []
+
+        if let bestWeekday = stats.bestWeekday, stats.totalCompleted >= 10 {
+            let name = StatsEngine.weekdayFullNames[bestWeekday]
+            let value = stats.byWeekday.first { $0.index == bestWeekday }?.value ?? 0
+            let average = Double(stats.totalCompleted) / 7.0
+            let delta = average > 0 ? (Double(value) - average) / average : 0
+            if delta > 0.2 {
+                output.append(Insight(
+                    id: "bestWeekday",
+                    title: "Le \(name) est ton jour fort",
+                    detail: "\(Int(delta * 100)) % de quêtes en plus que la moyenne. Réserve-y ce qui compte.",
+                    symbolName: "calendar.badge.checkmark",
+                    tone: .positive
+                ))
+            }
+        }
+
+        if let bestHour = stats.bestHour, stats.totalCompleted >= 10 {
+            output.append(Insight(
+                id: "bestHour",
+                title: "Ton pic est vers \(bestHour) h",
+                detail: "C'est là que tu clôtures le plus de quêtes. Protège ce créneau.",
+                symbolName: "sun.max.fill",
+                tone: .positive
+            ))
+        }
+
+        if streak.current >= 3 {
+            output.append(Insight(
+                id: "streak",
+                title: "Série de \(streak.current) jours",
+                detail: "Multiplicateur d'XP actuel : ×\(String(format: "%.2f", XPEngine.streakMultiplier(days: streak.current))).",
+                symbolName: "flame.fill",
+                tone: .positive
+            ))
+        } else if streak.isAtRisk {
+            output.append(Insight(
+                id: "streakRisk",
+                title: "Ta série est en jeu",
+                detail: "Une seule quête aujourd'hui suffit à la garder en vie.",
+                symbolName: "exclamationmark.triangle.fill",
+                tone: .warning
+            ))
+        }
+
+        if overdueCount > 0 {
+            output.append(Insight(
+                id: "overdue",
+                title: "\(overdueCount) quête\(overdueCount > 1 ? "s" : "") en retard",
+                detail: overdueCount > 5
+                    ? "Reporte en masse ou allège : une liste crédible vaut mieux qu'une liste complète."
+                    : "Un petit nettoyage et tu repars propre.",
+                symbolName: "clock.badge.exclamationmark.fill",
+                tone: .warning
+            ))
+        }
+
+        if stats.onTimeRate >= 0.8 && stats.totalCompleted >= 10 {
+            output.append(Insight(
+                id: "onTime",
+                title: "\(Int(stats.onTimeRate * 100)) % dans les temps",
+                detail: "Tes estimations sont fiables. Tu peux viser plus grand.",
+                symbolName: "checkmark.seal.fill",
+                tone: .positive
+            ))
+        } else if stats.onTimeRate < 0.5 && stats.totalCompleted >= 10 {
+            output.append(Insight(
+                id: "lateOften",
+                title: "Souvent en retard",
+                detail: "Essaie d'ajouter 30 % à tes estimations, ou de découper en sous-quêtes.",
+                symbolName: "tortoise.fill",
+                tone: .warning
+            ))
+        }
+
+        if let days = StatsEngine.daysToNextLevel(totalXP: totalXP, averageXPPerDay: stats.averageXPPerDay), days > 0 {
+            output.append(Insight(
+                id: "nextLevel",
+                title: "Niveau suivant dans ~\(days) jour\(days > 1 ? "s" : "")",
+                detail: "Au rythme de \(Int(stats.averageXPPerDay)) XP par jour.",
+                symbolName: "arrow.up.forward.circle.fill",
+                tone: .neutral
+            ))
+        }
+
+        // Domaine délaissé
+        let neglected = LifeArea.allCases.filter { (stats.byArea[$0] ?? 0) == 0 }
+        if stats.totalCompleted >= 15, let area = neglected.first {
+            output.append(Insight(
+                id: "neglected.\(area.rawValue)",
+                title: "Le domaine \(area.label) dort",
+                detail: "Aucune quête accomplie sur la période. \(area.subtitle).",
+                symbolName: area.symbolName,
+                tone: .neutral
+            ))
+        }
+
+        if stats.totalFocusMinutes >= 60 {
+            let hours = stats.totalFocusMinutes / 60
+            output.append(Insight(
+                id: "focus",
+                title: "\(hours) h de concentration",
+                detail: "Soit \(stats.totalFocusMinutes) minutes arrachées aux distractions.",
+                symbolName: "timer",
+                tone: .positive
+            ))
+        }
+
+        return output
+    }
+
+    /// Le domaine le plus délaissé, utilisé pour orienter les quêtes du jour.
+    public static func neglectedAreas(stats: ProductivityStats, limit: Int = 2) -> [LifeArea] {
+        LifeArea.allCases
+            .map { ($0, stats.byArea[$0] ?? 0) }
+            .sorted { $0.1 < $1.1 }
+            .prefix(limit)
+            .map { $0.0 }
+    }
+}

--- a/QuestlyApp/Packages/QuestlyKit/Tests/QuestlyKitTests/LevelAndXPTests.swift
+++ b/QuestlyApp/Packages/QuestlyKit/Tests/QuestlyKitTests/LevelAndXPTests.swift
@@ -1,0 +1,207 @@
+import XCTest
+@testable import QuestlyKit
+
+final class LevelCurveTests: XCTestCase {
+
+    func testLevelOneStartsAtZero() {
+        XCTAssertEqual(LevelCurve.totalXP(toReach: 1), 0)
+        XCTAssertEqual(LevelCurve.level(forTotalXP: 0), 1)
+        XCTAssertEqual(LevelCurve.level(forTotalXP: -50), 1)
+    }
+
+    func testCurveIsStrictlyIncreasing() {
+        var previous = -1
+        for level in 1...200 {
+            let total = LevelCurve.totalXP(toReach: level)
+            XCTAssertGreaterThan(total, previous, "Le seuil du niveau \(level) doit dépasser le précédent")
+            previous = total
+        }
+    }
+
+    func testRoundTripBetweenTotalXPAndLevel() {
+        for level in 1...300 {
+            let threshold = LevelCurve.totalXP(toReach: level)
+            XCTAssertEqual(LevelCurve.level(forTotalXP: threshold), level,
+                           "Le seuil exact du niveau \(level) doit rendre ce niveau")
+            if level < 300 {
+                XCTAssertEqual(LevelCurve.level(forTotalXP: threshold + 1), level)
+                XCTAssertEqual(LevelCurve.level(forTotalXP: LevelCurve.totalXP(toReach: level + 1) - 1), level)
+            }
+        }
+    }
+
+    func testProgressFractionStaysInBounds() {
+        for xp in stride(from: 0, through: 50_000, by: 137) {
+            let progress = LevelCurve.progress(forTotalXP: xp)
+            XCTAssertGreaterThanOrEqual(progress.fraction, 0)
+            XCTAssertLessThanOrEqual(progress.fraction, 1)
+            XCTAssertGreaterThanOrEqual(progress.xpIntoLevel, 0)
+            XCTAssertLessThanOrEqual(progress.xpIntoLevel, progress.xpRequiredForLevel)
+        }
+    }
+
+    func testProgressAtExactThresholdIsZeroFraction() {
+        let threshold = LevelCurve.totalXP(toReach: 12)
+        let progress = LevelCurve.progress(forTotalXP: threshold)
+        XCTAssertEqual(progress.level, 12)
+        XCTAssertEqual(progress.xpIntoLevel, 0)
+        XCTAssertEqual(progress.fraction, 0, accuracy: 0.0001)
+    }
+
+    func testFirstLevelIsReachableQuickly() {
+        // Une première montée de niveau doit rester à portée d'une bonne journée.
+        XCTAssertEqual(LevelCurve.xpToAdvance(from: 1), 100)
+        XCTAssertLessThan(LevelCurve.totalXP(toReach: 3), 400)
+    }
+
+    func testRankMapping() {
+        XCTAssertEqual(Rank.forLevel(1), .novice)
+        XCTAssertEqual(Rank.forLevel(5), .novice)
+        XCTAssertEqual(Rank.forLevel(6), .apprentice)
+        XCTAssertEqual(Rank.forLevel(11), .squire)
+        XCTAssertEqual(Rank.forLevel(9999), .eternal)
+        XCTAssertEqual(Rank.novice.minimumLevel, 1)
+        XCTAssertEqual(Rank.apprentice.minimumLevel, 6)
+    }
+
+    func testAttributeCurveRoundTrip() {
+        for level in 1...80 {
+            let total = AttributeCurve.totalXP(toReach: level)
+            XCTAssertEqual(AttributeCurve.level(forTotalXP: total), level)
+        }
+        let progress = AttributeCurve.progress(forTotalXP: 0)
+        XCTAssertEqual(progress.level, 1)
+        XCTAssertEqual(progress.fraction, 0, accuracy: 0.0001)
+    }
+}
+
+final class XPEngineTests: XCTestCase {
+
+    func testBaseAwardMatchesDifficulty() {
+        let task = XPTaskDescriptor(difficulty: .medium, priority: .p4)
+        let award = XPEngine.award(for: task, context: XPContext(), calendar: testCalendar)
+        XCTAssertEqual(award.totalXP, 20)
+        XCTAssertEqual(award.coins, 5)
+        XCTAssertEqual(award.gems, 0)
+    }
+
+    func testPriorityIncreasesReward() {
+        let low = XPEngine.award(for: XPTaskDescriptor(difficulty: .medium, priority: .p4), context: XPContext(), calendar: testCalendar)
+        let high = XPEngine.award(for: XPTaskDescriptor(difficulty: .medium, priority: .p1), context: XPContext(), calendar: testCalendar)
+        XCTAssertGreaterThan(high.totalXP, low.totalXP)
+        XCTAssertEqual(high.totalXP, 30) // 20 × 1,5
+    }
+
+    func testBossDoublesReward() {
+        let normal = XPEngine.award(for: XPTaskDescriptor(difficulty: .hard), context: XPContext(), calendar: testCalendar)
+        let boss = XPEngine.award(for: XPTaskDescriptor(difficulty: .hard, isBoss: true), context: XPContext(), calendar: testCalendar)
+        XCTAssertEqual(boss.totalXP, normal.totalXP * 2)
+        XCTAssertGreaterThan(boss.gems, 0)
+    }
+
+    func testOnTimeBonusAndLatePenalty() {
+        let due = makeDate(2026, 3, 10, 12, 0)
+        let task = XPTaskDescriptor(difficulty: .medium, dueDate: due, hasTimeComponent: true)
+
+        let early = XPEngine.award(for: task, context: XPContext(completionDate: makeDate(2026, 3, 10, 10, 0)), calendar: testCalendar)
+        let late = XPEngine.award(for: task, context: XPContext(completionDate: makeDate(2026, 3, 12, 10, 0)), calendar: testCalendar)
+
+        XCTAssertGreaterThan(early.totalXP, late.totalXP)
+        XCTAssertEqual(early.totalXP, 23)  // 20 × 1,15
+        XCTAssertEqual(late.totalXP, 17)   // 20 × 0,85
+    }
+
+    func testAllDayTaskUsesDayGranularity() {
+        let due = makeDate(2026, 3, 10)
+        let task = XPTaskDescriptor(difficulty: .easy, dueDate: due, hasTimeComponent: false)
+        // Terminée le jour dit, même tard dans la soirée : pas de pénalité.
+        let award = XPEngine.award(for: task, context: XPContext(completionDate: makeDate(2026, 3, 10, 23, 30)), calendar: testCalendar)
+        XCTAssertEqual(award.totalXP, 12) // 10 × 1,15 = 11,5 arrondi
+    }
+
+    func testStreakMultiplierIsCappedAt30Percent() {
+        XCTAssertEqual(XPEngine.streakMultiplier(days: 0), 1.0)
+        XCTAssertEqual(XPEngine.streakMultiplier(days: 1), 1.0)
+        XCTAssertEqual(XPEngine.streakMultiplier(days: 10), 1.10, accuracy: 0.0001)
+        XCTAssertEqual(XPEngine.streakMultiplier(days: 30), 1.30, accuracy: 0.0001)
+        XCTAssertEqual(XPEngine.streakMultiplier(days: 400), 1.30, accuracy: 0.0001)
+    }
+
+    func testComboMultiplierIsCapped() {
+        XCTAssertEqual(XPEngine.comboMultiplier(count: 1), 1.0)
+        XCTAssertEqual(XPEngine.comboMultiplier(count: 3), 1.10, accuracy: 0.0001)
+        XCTAssertEqual(XPEngine.comboMultiplier(count: 6), 1.25, accuracy: 0.0001)
+        XCTAssertEqual(XPEngine.comboMultiplier(count: 100), 1.25, accuracy: 0.0001)
+    }
+
+    func testBreakdownExplainsEveryBonus() {
+        let task = XPTaskDescriptor(
+            difficulty: .hard,
+            priority: .p1,
+            estimatedMinutes: 60,
+            completedSubtaskCount: 3,
+            totalSubtaskCount: 3,
+            isBoss: true,
+            focusedMinutes: 45
+        )
+        let context = XPContext(streakDays: 12, comboCount: 3, boostMultiplier: 1.5, isFirstCompletionOfDay: true)
+        let award = XPEngine.award(for: task, context: context, calendar: testCalendar)
+
+        let ids = Set(award.breakdown.map(\.id))
+        XCTAssertTrue(ids.contains("base"))
+        XCTAssertTrue(ids.contains("subtasks"))
+        XCTAssertTrue(ids.contains("duration"))
+        XCTAssertTrue(ids.contains("focus"))
+        XCTAssertTrue(ids.contains("priority"))
+        XCTAssertTrue(ids.contains("streak"))
+        XCTAssertTrue(ids.contains("combo"))
+        XCTAssertTrue(ids.contains("boss"))
+        XCTAssertTrue(ids.contains("boost"))
+        XCTAssertTrue(ids.contains("firstOfDay"))
+        XCTAssertGreaterThan(award.totalXP, 100)
+    }
+
+    func testAttributeXPOnlyWhenAreaKnown() {
+        let withArea = XPEngine.award(for: XPTaskDescriptor(lifeArea: .body), context: XPContext(), calendar: testCalendar)
+        let without = XPEngine.award(for: XPTaskDescriptor(), context: XPContext(), calendar: testCalendar)
+        XCTAssertGreaterThan(withArea.attributeXP, 0)
+        XCTAssertEqual(withArea.lifeArea, .body)
+        XCTAssertEqual(without.attributeXP, 0)
+    }
+
+    func testAwardNeverDropsBelowOne() {
+        let task = XPTaskDescriptor(difficulty: .trivial, priority: .p4, dueDate: makeDate(2020, 1, 1), hasTimeComponent: true)
+        let award = XPEngine.award(for: task, context: XPContext(completionDate: makeDate(2026, 1, 1)), calendar: testCalendar)
+        XCTAssertGreaterThanOrEqual(award.totalXP, 1)
+        XCTAssertGreaterThanOrEqual(award.coins, 1)
+    }
+}
+
+final class ComboTrackerTests: XCTestCase {
+
+    func testComboGrowsInsideWindow() {
+        var tracker = ComboTracker()
+        let start = makeDate(2026, 5, 4, 9, 0)
+        XCTAssertEqual(tracker.register(at: start), 1)
+        XCTAssertEqual(tracker.register(at: start.addingTimeInterval(60)), 2)
+        XCTAssertEqual(tracker.register(at: start.addingTimeInterval(200)), 3)
+        XCTAssertTrue(tracker.isActive(at: start.addingTimeInterval(210)))
+    }
+
+    func testComboResetsAfterWindow() {
+        var tracker = ComboTracker()
+        let start = makeDate(2026, 5, 4, 9, 0)
+        _ = tracker.register(at: start)
+        _ = tracker.register(at: start.addingTimeInterval(60))
+        XCTAssertEqual(tracker.register(at: start.addingTimeInterval(60 + 400)), 1)
+        XCTAssertFalse(tracker.isActive(at: start.addingTimeInterval(60 + 400)))
+    }
+
+    func testRemainingSecondsCountsDown() {
+        var tracker = ComboTracker()
+        let start = makeDate(2026, 5, 4, 9, 0)
+        _ = tracker.register(at: start)
+        XCTAssertEqual(tracker.remainingSeconds(at: start.addingTimeInterval(60)), 240)
+        XCTAssertEqual(tracker.remainingSeconds(at: start.addingTimeInterval(999)), 0)
+    }
+}

--- a/QuestlyApp/Packages/QuestlyKit/Tests/QuestlyKitTests/ParserTests.swift
+++ b/QuestlyApp/Packages/QuestlyKit/Tests/QuestlyKitTests/ParserTests.swift
@@ -1,0 +1,340 @@
+import XCTest
+@testable import QuestlyKit
+
+final class NaturalLanguageParserTests: XCTestCase {
+
+    /// Mercredi 4 mars 2026, 10 h 00.
+    let reference = makeDate(2026, 3, 4, 10, 0)
+
+    func parse(_ text: String) -> ParsedInput {
+        NaturalLanguageParser.parse(text, reference: reference, calendar: testCalendar)
+    }
+
+    // MARK: Texte simple
+
+    func testPlainTextKeepsTitleIntact() {
+        let result = parse("Réfléchir à la suite")
+        XCTAssertEqual(result.title, "Réfléchir à la suite")
+        XCTAssertNil(result.dueDate)
+        XCTAssertFalse(result.hasMetadata)
+    }
+
+    func testEmptyInput() {
+        let result = parse("   ")
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: Dates relatives
+
+    func testTomorrow() {
+        let result = parse("Acheter du pain demain")
+        XCTAssertEqual(result.title, "Acheter du pain")
+        XCTAssertEqual(formattedDay(result.dueDate!), "2026-03-05")
+        XCTAssertFalse(result.hasTime)
+    }
+
+    func testToday() {
+        let result = parse("Ranger le bureau aujourd'hui")
+        XCTAssertEqual(formattedDay(result.dueDate!), "2026-03-04")
+        XCTAssertEqual(result.title, "Ranger le bureau")
+    }
+
+    func testDayAfterTomorrow() {
+        XCTAssertEqual(formattedDay(parse("Relire après-demain").dueDate!), "2026-03-06")
+    }
+
+    func testInNDays() {
+        XCTAssertEqual(formattedDay(parse("Relancer dans 3 jours").dueDate!), "2026-03-07")
+        XCTAssertEqual(formattedDay(parse("Bilan dans 2 semaines").dueDate!), "2026-03-18")
+        XCTAssertEqual(formattedDay(parse("Renouveler dans 1 mois").dueDate!), "2026-04-04")
+    }
+
+    func testEnglishRelativeDates() {
+        XCTAssertEqual(formattedDay(parse("Call mom tomorrow").dueDate!), "2026-03-05")
+        XCTAssertEqual(formattedDay(parse("Ship it in 5 days").dueDate!), "2026-03-09")
+    }
+
+    func testWeekdayPicksNextOccurrence() {
+        // Mercredi 4 → samedi 7.
+        XCTAssertEqual(formattedDay(parse("Faire les courses samedi").dueDate!), "2026-03-07")
+        // Mercredi 4 → lundi 9.
+        XCTAssertEqual(formattedDay(parse("Envoyer le rapport lundi").dueDate!), "2026-03-09")
+    }
+
+    func testWeekdayTodayCountsAsToday() {
+        // On est mercredi : « mercredi » veut dire aujourd'hui.
+        XCTAssertEqual(formattedDay(parse("Point équipe mercredi").dueDate!), "2026-03-04")
+        // Sauf si on précise « prochain ».
+        XCTAssertEqual(formattedDay(parse("Point équipe mercredi prochain").dueDate!), "2026-03-11")
+    }
+
+    func testNextWeekAndMonth() {
+        XCTAssertEqual(formattedDay(parse("Préparer la semaine prochaine").dueDate!), "2026-03-09")
+        XCTAssertEqual(formattedDay(parse("Payer le mois prochain").dueDate!), "2026-04-01")
+    }
+
+    func testEndOfMonth() {
+        XCTAssertEqual(formattedDay(parse("Clôturer fin du mois").dueDate!), "2026-03-31")
+    }
+
+    // MARK: Dates absolues
+
+    func testNumericDate() {
+        let result = parse("Rendez-vous 15/03")
+        XCTAssertEqual(formattedDay(result.dueDate!), "2026-03-15")
+        XCTAssertEqual(result.title, "Rendez-vous")
+    }
+
+    func testNumericDateWithYear() {
+        XCTAssertEqual(formattedDay(parse("Anniversaire 12/09/2027").dueDate!), "2027-09-12")
+    }
+
+    func testPastDateRollsToNextYear() {
+        // Le 3 mars est déjà passé : on vise l'an prochain.
+        XCTAssertEqual(formattedDay(parse("Déclarer 03/03").dueDate!), "2027-03-03")
+    }
+
+    func testWrittenMonth() {
+        XCTAssertEqual(formattedDay(parse("Réserver le 20 mars").dueDate!), "2026-03-20")
+        XCTAssertEqual(formattedDay(parse("Poisson le 1er avril").dueDate!), "2026-04-01")
+        XCTAssertEqual(formattedDay(parse("Deadline 15 december").dueDate!), "2026-12-15")
+    }
+
+    // MARK: Heures
+
+    func testTimeFrenchFormat() {
+        let result = parse("Appeler le dentiste demain 14h30")
+        XCTAssertEqual(formatted(result.dueDate!), "2026-03-05 14:30")
+        XCTAssertTrue(result.hasTime)
+        XCTAssertEqual(result.title, "Appeler le dentiste")
+    }
+
+    func testTimeWithoutMinutes() {
+        XCTAssertEqual(formatted(parse("Sport demain 18h").dueDate!), "2026-03-05 18:00")
+    }
+
+    func testTimeColonFormat() {
+        XCTAssertEqual(formatted(parse("Visio demain à 09:15").dueDate!), "2026-03-05 09:15")
+    }
+
+    func testTimeAmPm() {
+        XCTAssertEqual(formatted(parse("Standup tomorrow 9am").dueDate!), "2026-03-05 09:00")
+        XCTAssertEqual(formatted(parse("Dinner tomorrow 7:30pm").dueDate!), "2026-03-05 19:30")
+    }
+
+    func testPastTimeWithoutDateRollsToTomorrow() {
+        // Il est 10 h : « 9h » vise demain.
+        XCTAssertEqual(formatted(parse("Courir à 9h").dueDate!), "2026-03-05 09:00")
+        // Alors que 15 h tient encore aujourd'hui.
+        XCTAssertEqual(formatted(parse("Courir à 15h").dueDate!), "2026-03-04 15:00")
+    }
+
+    func testMomentsOfDayStayToday() {
+        XCTAssertEqual(formatted(parse("Sortir la poubelle ce soir").dueDate!), "2026-03-04 19:00")
+        XCTAssertEqual(formatted(parse("Réveil ce matin").dueDate!), "2026-03-04 09:00")
+    }
+
+    // MARK: Durées
+
+    func testExplicitDuration() {
+        XCTAssertEqual(parse("Réviser pendant 2h").durationMinutes, 120)
+        XCTAssertEqual(parse("Marcher pour 45 min").durationMinutes, 45)
+        XCTAssertEqual(parse("Écrire pendant 1h30").durationMinutes, 90)
+    }
+
+    func testBareMinuteDuration() {
+        XCTAssertEqual(parse("Méditer 20min").durationMinutes, 20)
+        XCTAssertEqual(parse("Pause 15 minutes").durationMinutes, 15)
+    }
+
+    func testSpelledHours() {
+        XCTAssertEqual(parse("Atelier 3 heures").durationMinutes, 180)
+    }
+
+    func testHourFormatIsATimeNotADuration() {
+        // « 14h » est une heure, pas 14 heures de travail.
+        let result = parse("Réunion 14h")
+        XCTAssertNil(result.durationMinutes)
+        XCTAssertTrue(result.hasTime)
+    }
+
+    func testDurationAndTimeTogether() {
+        let result = parse("Sport demain 18h pendant 45min")
+        XCTAssertEqual(formatted(result.dueDate!), "2026-03-05 18:00")
+        XCTAssertEqual(result.durationMinutes, 45)
+        XCTAssertEqual(result.title, "Sport")
+    }
+
+    func testMonthNameIsNotEatenByDuration() {
+        // « 12 mars » ne doit pas devenir « 12 minutes ».
+        let result = parse("Rendez-vous le 12 mars")
+        XCTAssertNil(result.durationMinutes)
+        XCTAssertEqual(formattedDay(result.dueDate!), "2026-03-12")
+    }
+
+    // MARK: Priorité, difficulté, domaine, boss
+
+    func testPriorityShorthand() {
+        XCTAssertEqual(parse("Payer le loyer p1").priority, .p1)
+        XCTAssertEqual(parse("Trier les photos !4").priority, .p4)
+        XCTAssertEqual(parse("Réparer la fuite urgent").priority, .p1)
+        XCTAssertEqual(parse("Relire le contrat important").priority, .p2)
+        XCTAssertNil(parse("Arroser les plantes").priority)
+    }
+
+    func testDifficultyMarker() {
+        XCTAssertEqual(parse("Refonte du site *épique").difficulty, .epic)
+        XCTAssertEqual(parse("Vider la boîte mail *facile").difficulty, .easy)
+        XCTAssertEqual(parse("Thèse *légendaire").difficulty, .legendary)
+    }
+
+    func testAreaMarker() {
+        XCTAssertEqual(parse("Lire 30 pages %esprit").lifeArea, .mind)
+        XCTAssertEqual(parse("Squats %corps").lifeArea, .body)
+    }
+
+    func testBossMarker() {
+        let result = parse("!boss Terminer la refonte")
+        XCTAssertTrue(result.isBoss)
+        XCTAssertEqual(result.title, "Terminer la refonte")
+    }
+
+    // MARK: Étiquettes et projets
+
+    func testTags() {
+        let result = parse("Acheter du lait #courses #maison")
+        XCTAssertEqual(result.tags, ["courses", "maison"])
+        XCTAssertEqual(result.title, "Acheter du lait")
+    }
+
+    func testContextBecomesTag() {
+        let result = parse("Imprimer le dossier @bureau")
+        XCTAssertEqual(result.tags, ["bureau"])
+        XCTAssertEqual(result.title, "Imprimer le dossier")
+    }
+
+    func testAccentedTags() {
+        XCTAssertEqual(parse("Réviser #mathématiques").tags, ["mathématiques"])
+    }
+
+    func testProject() {
+        let result = parse("Maquette d'accueil +RefonteSite")
+        XCTAssertEqual(result.project, "RefonteSite")
+        XCTAssertEqual(result.title, "Maquette d'accueil")
+    }
+
+    // MARK: Récurrence
+
+    func testDailyRecurrence() {
+        let result = parse("Boire de l'eau tous les jours")
+        XCTAssertEqual(result.recurrence?.frequency, .daily)
+        XCTAssertEqual(result.recurrence?.interval, 1)
+        XCTAssertEqual(result.title, "Boire de l'eau")
+    }
+
+    func testIntervalRecurrence() {
+        let result = parse("Arroser les plantes tous les 3 jours")
+        XCTAssertEqual(result.recurrence?.frequency, .daily)
+        XCTAssertEqual(result.recurrence?.interval, 3)
+    }
+
+    func testWeekdayRecurrenceSetsFirstOccurrence() {
+        let result = parse("Yoga chaque lundi 9h")
+        XCTAssertEqual(result.recurrence?.frequency, .weekly)
+        XCTAssertEqual(result.recurrence?.weekdays, [2])
+        // Premier lundi à venir, pas « demain ».
+        XCTAssertEqual(formatted(result.dueDate!), "2026-03-09 09:00")
+        XCTAssertEqual(result.title, "Yoga")
+    }
+
+    func testWeekdaysOnlyRecurrence() {
+        let result = parse("Revue de code en semaine")
+        XCTAssertEqual(result.recurrence, .weekdaysOnly)
+        XCTAssertEqual(formattedDay(result.dueDate!), "2026-03-04")
+    }
+
+    func testMonthlyDayOfMonth() {
+        let result = parse("Payer le loyer le 5 du mois")
+        XCTAssertEqual(result.recurrence?.frequency, .monthly)
+        XCTAssertEqual(result.recurrence?.daysOfMonth, [5])
+        XCTAssertEqual(formattedDay(result.dueDate!), "2026-03-05")
+    }
+
+    func testEnglishRecurrence() {
+        XCTAssertEqual(parse("Water plants every 2 weeks").recurrence?.interval, 2)
+        XCTAssertEqual(parse("Water plants every 2 weeks").recurrence?.frequency, .weekly)
+        XCTAssertEqual(parse("Weekly review").recurrence?.frequency, .weekly)
+    }
+
+    func testRecurrenceBeatsPlainWeekday() {
+        // « tous les lundis » ne doit pas être lu comme la date « lundi ».
+        let result = parse("Sortir les poubelles tous les lundis")
+        XCTAssertEqual(result.recurrence?.weekdays, [2])
+        XCTAssertEqual(result.title, "Sortir les poubelles")
+    }
+
+    // MARK: Rappels
+
+    func testReminderOffset() {
+        let result = parse("Visio demain 15h rappel 30min avant")
+        XCTAssertEqual(result.reminderMinutesBefore, 30)
+        XCTAssertEqual(formatted(result.dueDate!), "2026-03-05 15:00")
+        XCTAssertEqual(result.title, "Visio")
+    }
+
+    func testReminderInHours() {
+        XCTAssertEqual(parse("Train demain 8h rappel 2h avant").reminderMinutesBefore, 120)
+    }
+
+    // MARK: Déduction du domaine
+
+    func testAreaInferredFromKeywords() {
+        XCTAssertEqual(parse("Aller à la gym demain").lifeArea, .body)
+        XCTAssertEqual(parse("Payer la facture EDF").lifeArea, .wealth)
+        XCTAssertEqual(parse("Faire la vaisselle").lifeArea, .home)
+        XCTAssertEqual(parse("Réunion client jeudi").lifeArea, .craft)
+    }
+
+    func testExplicitAreaBeatsInference() {
+        XCTAssertEqual(parse("Faire la vaisselle %corps").lifeArea, .body)
+    }
+
+    // MARK: Cas composés
+
+    func testKitchenSink() {
+        let result = parse("!boss Refonte du site +Site #design p1 demain 14h pendant 2h *épique rappel 15min avant")
+        XCTAssertTrue(result.isBoss)
+        XCTAssertEqual(result.project, "Site")
+        XCTAssertEqual(result.tags, ["design"])
+        XCTAssertEqual(result.priority, .p1)
+        XCTAssertEqual(result.difficulty, .epic)
+        XCTAssertEqual(result.durationMinutes, 120)
+        XCTAssertEqual(result.reminderMinutesBefore, 15)
+        XCTAssertEqual(formatted(result.dueDate!), "2026-03-05 14:00")
+        XCTAssertEqual(result.title, "Refonte du site")
+    }
+
+    func testTokensAreOrderedAndPositioned() {
+        let text = "Courses demain #maison"
+        let result = parse(text)
+        XCTAssertEqual(result.tokens.count, 2)
+        XCTAssertEqual(result.tokens[0].kind, .date)
+        XCTAssertEqual(result.tokens[1].kind, .tag)
+        for token in result.tokens {
+            let ns = text as NSString
+            XCTAssertEqual(ns.substring(with: NSRange(location: token.location, length: token.length)), token.text)
+        }
+    }
+
+    func testTitleWhitespaceIsCollapsed() {
+        let result = parse("Ranger    le   garage   samedi")
+        XCTAssertEqual(result.title, "Ranger le garage")
+    }
+
+    func testParsingIsStable() {
+        // Deux analyses identiques donnent le même résultat.
+        let a = parse("Sport demain 18h #santé p2")
+        let b = parse("Sport demain 18h #santé p2")
+        XCTAssertEqual(a, b)
+    }
+}

--- a/QuestlyApp/Packages/QuestlyKit/Tests/QuestlyKitTests/RecurrenceTests.swift
+++ b/QuestlyApp/Packages/QuestlyKit/Tests/QuestlyKitTests/RecurrenceTests.swift
@@ -1,0 +1,283 @@
+import XCTest
+@testable import QuestlyKit
+
+final class RecurrenceTests: XCTestCase {
+
+    // MARK: Quotidien
+
+    func testDailyEveryDay() {
+        let anchor = makeDate(2026, 3, 2, 9, 0)
+        let next = RecurrenceEngine.nextDate(rule: .daily, after: anchor, anchor: anchor, calendar: testCalendar)
+        XCTAssertEqual(formatted(next!), "2026-03-03 09:00")
+    }
+
+    func testDailyKeepsAnchorTime() {
+        let anchor = makeDate(2026, 3, 2, 7, 45)
+        let next = RecurrenceEngine.nextDate(rule: .daily, after: makeDate(2026, 3, 5, 23, 0), anchor: anchor, calendar: testCalendar)
+        XCTAssertEqual(formatted(next!), "2026-03-06 07:45")
+    }
+
+    func testDailyEveryThreeDays() {
+        let anchor = makeDate(2026, 3, 2, 8, 0)
+        let rule = RecurrenceRule(frequency: .daily, interval: 3)
+        let dates = RecurrenceEngine.occurrences(
+            rule: rule, anchor: anchor,
+            from: anchor, to: testCalendar.endOfDay(makeDate(2026, 3, 20)), calendar: testCalendar
+        )
+        XCTAssertEqual(dates.map { formattedDay($0) },
+                       ["2026-03-02", "2026-03-05", "2026-03-08", "2026-03-11", "2026-03-14", "2026-03-17", "2026-03-20"])
+    }
+
+    func testWeekdaysOnlySkipsWeekend() {
+        // 2026-03-06 est un vendredi.
+        let anchor = makeDate(2026, 3, 6, 9, 0)
+        let next = RecurrenceEngine.nextDate(rule: .weekdaysOnly, after: anchor, anchor: anchor, calendar: testCalendar)
+        XCTAssertEqual(formattedDay(next!), "2026-03-09", "Après vendredi vient lundi")
+    }
+
+    func testWeekdaysOnlyNeverLandsOnWeekend() {
+        let anchor = makeDate(2026, 3, 2, 9, 0)
+        let dates = RecurrenceEngine.occurrences(
+            rule: .weekdaysOnly, anchor: anchor,
+            from: anchor, to: testCalendar.endOfDay(makeDate(2026, 3, 31)), calendar: testCalendar
+        )
+        XCTAssertEqual(dates.count, 22)
+        for date in dates {
+            XCTAssertFalse(testCalendar.isWeekend(date), "\(formattedDay(date)) ne doit pas être un week-end")
+        }
+    }
+
+    // MARK: Hebdomadaire
+
+    func testWeeklyOnSpecificDays() {
+        // Lundi (2) et jeudi (5).
+        let anchor = makeDate(2026, 3, 2, 18, 30) // lundi
+        let rule = RecurrenceRule(frequency: .weekly, weekdays: [2, 5])
+        let dates = RecurrenceEngine.occurrences(
+            rule: rule, anchor: anchor,
+            from: anchor, to: testCalendar.endOfDay(makeDate(2026, 3, 16)), calendar: testCalendar
+        )
+        XCTAssertEqual(dates.map { formattedDay($0) },
+                       ["2026-03-02", "2026-03-05", "2026-03-09", "2026-03-12", "2026-03-16"])
+        XCTAssertEqual(formatted(dates[1]), "2026-03-05 18:30", "L'heure de l'ancre est conservée")
+    }
+
+    func testWeeklyEveryTwoWeeks() {
+        let anchor = makeDate(2026, 3, 2, 9, 0) // lundi
+        let rule = RecurrenceRule(frequency: .weekly, interval: 2)
+        let dates = RecurrenceEngine.occurrences(
+            rule: rule, anchor: anchor,
+            from: anchor, to: testCalendar.endOfDay(makeDate(2026, 4, 30)), calendar: testCalendar
+        )
+        XCTAssertEqual(dates.map { formattedDay($0) },
+                       ["2026-03-02", "2026-03-16", "2026-03-30", "2026-04-13", "2026-04-27"])
+    }
+
+    func testWeeklyDefaultsToAnchorWeekday() {
+        let anchor = makeDate(2026, 3, 4, 9, 0) // mercredi
+        let next = RecurrenceEngine.nextDate(rule: .weekly, after: anchor, anchor: anchor, calendar: testCalendar)
+        XCTAssertEqual(formattedDay(next!), "2026-03-11")
+    }
+
+    // MARK: Mensuel
+
+    func testMonthlyOnAnchorDay() {
+        let anchor = makeDate(2026, 1, 15, 10, 0)
+        let dates = RecurrenceEngine.occurrences(
+            rule: .monthly, anchor: anchor,
+            from: anchor, to: testCalendar.endOfDay(makeDate(2026, 5, 30)), calendar: testCalendar
+        )
+        XCTAssertEqual(dates.map { formattedDay($0) },
+                       ["2026-01-15", "2026-02-15", "2026-03-15", "2026-04-15", "2026-05-15"])
+    }
+
+    func testMonthlyClampsToShortMonths() {
+        // Le 31 janvier doit tomber sur le 28 février (2026 n'est pas bissextile).
+        let anchor = makeDate(2026, 1, 31, 9, 0)
+        let dates = RecurrenceEngine.occurrences(
+            rule: .monthly, anchor: anchor,
+            from: anchor, to: testCalendar.endOfDay(makeDate(2026, 4, 30)), calendar: testCalendar
+        )
+        XCTAssertEqual(dates.map { formattedDay($0) },
+                       ["2026-01-31", "2026-02-28", "2026-03-31", "2026-04-30"])
+    }
+
+    func testMonthlyLastDayOfMonth() {
+        let anchor = makeDate(2026, 1, 5, 9, 0)
+        let rule = RecurrenceRule(frequency: .monthly, daysOfMonth: [-1])
+        let dates = RecurrenceEngine.occurrences(
+            rule: rule, anchor: anchor,
+            from: anchor, to: testCalendar.endOfDay(makeDate(2026, 4, 30)), calendar: testCalendar
+        )
+        XCTAssertEqual(dates.map { formattedDay($0) },
+                       ["2026-01-31", "2026-02-28", "2026-03-31", "2026-04-30"])
+    }
+
+    func testMonthlyEveryThreeMonths() {
+        let anchor = makeDate(2026, 1, 10, 9, 0)
+        let rule = RecurrenceRule(frequency: .monthly, interval: 3)
+        let dates = RecurrenceEngine.occurrences(
+            rule: rule, anchor: anchor,
+            from: anchor, to: testCalendar.endOfDay(makeDate(2026, 12, 31)), calendar: testCalendar
+        )
+        XCTAssertEqual(dates.map { formattedDay($0) },
+                       ["2026-01-10", "2026-04-10", "2026-07-10", "2026-10-10"])
+    }
+
+    // MARK: Annuel
+
+    func testYearlyOnAnchorDate() {
+        let anchor = makeDate(2026, 6, 21, 12, 0)
+        let dates = RecurrenceEngine.occurrences(
+            rule: .yearly, anchor: anchor,
+            from: anchor, to: testCalendar.endOfDay(makeDate(2029, 12, 31)), calendar: testCalendar
+        )
+        XCTAssertEqual(dates.map { formattedDay($0) },
+                       ["2026-06-21", "2027-06-21", "2028-06-21", "2029-06-21"])
+    }
+
+    func testYearlyLeapDayFallsBackToLastDay() {
+        // 29 février 2028 (bissextile) → 28 février les années normales.
+        let anchor = makeDate(2028, 2, 29, 9, 0)
+        let dates = RecurrenceEngine.occurrences(
+            rule: .yearly, anchor: anchor,
+            from: anchor, to: testCalendar.endOfDay(makeDate(2030, 12, 31)), calendar: testCalendar
+        )
+        XCTAssertEqual(dates.map { formattedDay($0) },
+                       ["2028-02-29", "2029-02-28", "2030-02-28"])
+    }
+
+    // MARK: Fins de série
+
+    func testEndingAfterOccurrences() {
+        let anchor = makeDate(2026, 3, 2, 9, 0)
+        let rule = RecurrenceRule(frequency: .daily, ending: .afterOccurrences(3))
+        let dates = RecurrenceEngine.occurrences(
+            rule: rule, anchor: anchor,
+            from: anchor, to: testCalendar.endOfDay(makeDate(2026, 3, 31)), calendar: testCalendar
+        )
+        XCTAssertEqual(dates.map { formattedDay($0) }, ["2026-03-02", "2026-03-03", "2026-03-04"])
+
+        // Après la troisième occurrence, plus rien.
+        let after = RecurrenceEngine.nextDate(rule: rule, after: makeDate(2026, 3, 4, 10, 0), anchor: anchor, calendar: testCalendar)
+        XCTAssertNil(after)
+    }
+
+    func testEndingOnDate() {
+        let anchor = makeDate(2026, 3, 2, 9, 0)
+        let rule = RecurrenceRule(frequency: .daily, ending: .onDate(makeDate(2026, 3, 5)))
+        let dates = RecurrenceEngine.occurrences(
+            rule: rule, anchor: anchor,
+            from: anchor, to: testCalendar.endOfDay(makeDate(2026, 3, 31)), calendar: testCalendar
+        )
+        XCTAssertEqual(dates.map { formattedDay($0) },
+                       ["2026-03-02", "2026-03-03", "2026-03-04", "2026-03-05"])
+        XCTAssertNil(RecurrenceEngine.nextDate(rule: rule, after: makeDate(2026, 3, 5, 10, 0), anchor: anchor, calendar: testCalendar))
+    }
+
+    // MARK: Mode « après accomplissement »
+
+    func testAfterCompletionRestartsFromCompletionDate() {
+        let anchor = makeDate(2026, 3, 2, 9, 0)
+        let rule = RecurrenceRule(frequency: .daily, interval: 7, mode: .afterCompletion)
+        // Tâche accomplie avec 5 jours de retard : la suivante part de là.
+        let next = RecurrenceEngine.nextDate(rule: rule, after: makeDate(2026, 3, 7, 20, 0), anchor: anchor, calendar: testCalendar)
+        XCTAssertEqual(formatted(next!), "2026-03-14 09:00")
+    }
+
+    func testAfterCompletionWithWeeklyInterval() {
+        let anchor = makeDate(2026, 3, 2, 18, 0)
+        let rule = RecurrenceRule(frequency: .weekly, interval: 2, mode: .afterCompletion)
+        let next = RecurrenceEngine.nextDate(rule: rule, after: makeDate(2026, 3, 10, 12, 0), anchor: anchor, calendar: testCalendar)
+        XCTAssertEqual(formatted(next!), "2026-03-24 18:00")
+    }
+
+    func testAfterCompletionSkipsWeekend() {
+        let anchor = makeDate(2026, 3, 2, 9, 0)
+        let rule = RecurrenceRule(frequency: .daily, interval: 1, mode: .afterCompletion, skipWeekends: true)
+        // Accomplie un vendredi → la suivante saute au lundi.
+        let next = RecurrenceEngine.nextDate(rule: rule, after: makeDate(2026, 3, 6, 17, 0), anchor: anchor, calendar: testCalendar)
+        XCTAssertEqual(formattedDay(next!), "2026-03-09")
+    }
+
+    // MARK: Divers
+
+    func testMatchesRejectsDatesBeforeAnchor() {
+        let anchor = makeDate(2026, 3, 10)
+        XCTAssertFalse(RecurrenceEngine.matches(rule: .daily, date: makeDate(2026, 3, 9), anchor: anchor, calendar: testCalendar))
+        XCTAssertTrue(RecurrenceEngine.matches(rule: .daily, date: makeDate(2026, 3, 10), anchor: anchor, calendar: testCalendar))
+    }
+
+    func testCountOccurrencesIsTimeAware() {
+        let anchor = makeDate(2026, 3, 2, 18, 0)
+        // À midi le 2 mars, l'occurrence de 18 h n'a pas encore eu lieu.
+        XCTAssertEqual(
+            RecurrenceEngine.countOccurrences(rule: .daily, from: anchor, upTo: makeDate(2026, 3, 2, 12, 0), calendar: testCalendar),
+            0
+        )
+        XCTAssertEqual(
+            RecurrenceEngine.countOccurrences(rule: .daily, from: anchor, upTo: makeDate(2026, 3, 2, 19, 0), calendar: testCalendar),
+            1
+        )
+        XCTAssertEqual(
+            RecurrenceEngine.countOccurrences(rule: .daily, from: anchor, upTo: makeDate(2026, 3, 5, 19, 0), calendar: testCalendar),
+            4
+        )
+    }
+
+    func testWeekendsOnlyPreset() {
+        let anchor = makeDate(2026, 3, 2, 9, 0) // lundi
+        let dates = RecurrenceEngine.occurrences(
+            rule: .weekendsOnly, anchor: anchor,
+            from: anchor, to: testCalendar.endOfDay(makeDate(2026, 3, 16)), calendar: testCalendar
+        )
+        for date in dates {
+            XCTAssertTrue(testCalendar.isWeekend(date))
+        }
+        XCTAssertEqual(dates.map { formattedDay($0) },
+                       ["2026-03-07", "2026-03-08", "2026-03-14", "2026-03-15"])
+    }
+
+    func testHumanDescriptionsAreReadable() {
+        XCTAssertEqual(RecurrenceRule.daily.humanDescription(calendar: testCalendar), "Chaque jour")
+        XCTAssertEqual(RecurrenceRule(frequency: .daily, interval: 3).humanDescription(calendar: testCalendar), "Tous les 3 jours")
+        XCTAssertEqual(RecurrenceRule.weekdaysOnly.humanDescription(calendar: testCalendar), "Chaque jour ouvré")
+        XCTAssertEqual(
+            RecurrenceRule(frequency: .weekly, weekdays: [2, 5]).humanDescription(calendar: testCalendar),
+            "Chaque semaine, le lundi et jeudi"
+        )
+        XCTAssertEqual(
+            RecurrenceRule(frequency: .monthly, daysOfMonth: [-1]).humanDescription(calendar: testCalendar),
+            "Chaque mois, le dernier jour"
+        )
+        XCTAssertTrue(
+            RecurrenceRule(frequency: .daily, ending: .afterOccurrences(5)).humanDescription(calendar: testCalendar)
+                .contains("5 fois")
+        )
+    }
+
+    func testOccurrencesRespectsLimit() {
+        let anchor = makeDate(2026, 1, 1, 9, 0)
+        let dates = RecurrenceEngine.occurrences(
+            rule: .daily, anchor: anchor,
+            from: anchor, to: testCalendar.endOfDay(makeDate(2026, 12, 31)), calendar: testCalendar, limit: 10
+        )
+        XCTAssertEqual(dates.count, 10)
+    }
+
+    func testCodableRoundTrip() throws {
+        let rule = RecurrenceRule(
+            frequency: .monthly,
+            interval: 2,
+            weekdays: [2, 4],
+            daysOfMonth: [1, -1],
+            monthsOfYear: [3, 9],
+            ending: .onDate(makeDate(2027, 1, 1)),
+            mode: .afterCompletion,
+            skipWeekends: true
+        )
+        let data = try JSONEncoder().encode(rule)
+        let decoded = try JSONDecoder().decode(RecurrenceRule.self, from: data)
+        XCTAssertEqual(rule, decoded)
+    }
+}

--- a/QuestlyApp/Packages/QuestlyKit/Tests/QuestlyKitTests/SchedulingAndStatsTests.swift
+++ b/QuestlyApp/Packages/QuestlyKit/Tests/QuestlyKitTests/SchedulingAndStatsTests.swift
@@ -1,0 +1,367 @@
+import XCTest
+@testable import QuestlyKit
+
+final class ScheduleEngineTests: XCTestCase {
+
+    let day = makeDate(2026, 3, 4) // mercredi
+
+    func busy(_ startHour: Int, _ startMinute: Int, _ endHour: Int, _ endMinute: Int, _ title: String = "") -> BusyInterval {
+        BusyInterval(
+            id: "\(title)-\(startHour):\(startMinute)",
+            start: makeDate(2026, 3, 4, startHour, startMinute),
+            end: makeDate(2026, 3, 4, endHour, endMinute),
+            title: title
+        )
+    }
+
+    func testFreeSlotsOnAnEmptyDay() {
+        let slots = ScheduleEngine.freeSlots(on: day, busy: [], calendar: testCalendar)
+        XCTAssertEqual(slots.count, 1)
+        XCTAssertEqual(formatted(slots[0].start), "2026-03-04 09:00")
+        XCTAssertEqual(formatted(slots[0].end), "2026-03-04 18:00")
+        XCTAssertEqual(slots[0].minutes, 540)
+    }
+
+    func testFreeSlotsAroundMeetings() {
+        let slots = ScheduleEngine.freeSlots(
+            on: day,
+            busy: [busy(10, 0, 11, 0, "Point"), busy(14, 0, 15, 30, "Atelier")],
+            calendar: testCalendar
+        )
+        XCTAssertEqual(slots.map { "\(formatted($0.start))→\(formatted($0.end))" }, [
+            "2026-03-04 09:00→2026-03-04 10:00",
+            "2026-03-04 11:00→2026-03-04 14:00",
+            "2026-03-04 15:30→2026-03-04 18:00"
+        ])
+    }
+
+    func testOverlappingBusyIntervalsAreMerged() {
+        let slots = ScheduleEngine.freeSlots(
+            on: day,
+            busy: [busy(10, 0, 12, 0), busy(11, 0, 13, 0), busy(12, 30, 14, 0)],
+            calendar: testCalendar
+        )
+        XCTAssertEqual(slots.count, 2)
+        XCTAssertEqual(formatted(slots[1].start), "2026-03-04 14:00")
+    }
+
+    func testMinimumSlotLengthFiltersCrumbs() {
+        let slots = ScheduleEngine.freeSlots(
+            on: day,
+            busy: [busy(9, 10, 18, 0)],
+            minimumMinutes: 15,
+            calendar: testCalendar
+        )
+        XCTAssertTrue(slots.isEmpty, "Un trou de 10 minutes ne doit pas être proposé")
+    }
+
+    func testNotBeforeTrimsThePast() {
+        let slots = ScheduleEngine.freeSlots(
+            on: day,
+            busy: [],
+            notBefore: makeDate(2026, 3, 4, 14, 30),
+            calendar: testCalendar
+        )
+        XCTAssertEqual(formatted(slots[0].start), "2026-03-04 14:30")
+    }
+
+    func testAutoPlanPlacesEverythingWhenThereIsRoom() {
+        let tasks = [
+            PlannableTask(id: "a", title: "Rapport", estimatedMinutes: 60, priority: .p1, difficulty: .hard, energy: .high),
+            PlannableTask(id: "b", title: "Mails", estimatedMinutes: 30, priority: .p3, difficulty: .easy, energy: .low),
+            PlannableTask(id: "c", title: "Appels", estimatedMinutes: 45, priority: .p2, difficulty: .medium)
+        ]
+        let plan = ScheduleEngine.autoPlan(tasks: tasks, on: day, busy: [], calendar: testCalendar)
+        XCTAssertEqual(plan.blocks.count, 3)
+        XCTAssertTrue(plan.unplaced.isEmpty)
+        XCTAssertEqual(plan.usedMinutes, 135)
+
+        // Les blocs ne se chevauchent jamais.
+        for pair in zip(plan.blocks, plan.blocks.dropFirst()) {
+            XCTAssertLessThanOrEqual(pair.0.end, pair.1.start)
+        }
+    }
+
+    func testAutoPlanPutsDemandingWorkInThePeakWindow() {
+        let tasks = [
+            PlannableTask(id: "boss", title: "Boss", estimatedMinutes: 90, difficulty: .epic, energy: .high, isBoss: true)
+        ]
+        let plan = ScheduleEngine.autoPlan(tasks: tasks, on: day, busy: [], calendar: testCalendar)
+        let block = plan.blocks[0]
+        XCTAssertGreaterThanOrEqual(block.start, makeDate(2026, 3, 4, 9, 0))
+        XCTAssertLessThan(block.start, makeDate(2026, 3, 4, 12, 0))
+        XCTAssertTrue(block.rationale.contains("pic d'énergie"))
+    }
+
+    func testAutoPlanReportsWhatDoesNotFit() {
+        let tasks = (0..<12).map {
+            PlannableTask(id: "t\($0)", title: "Tâche \($0)", estimatedMinutes: 60)
+        }
+        let plan = ScheduleEngine.autoPlan(tasks: tasks, on: day, busy: [], bufferMinutes: 0, calendar: testCalendar)
+        XCTAssertEqual(plan.blocks.count, 9, "9 heures ouvrées = 9 blocs d'une heure")
+        XCTAssertEqual(plan.unplaced.count, 3)
+    }
+
+    func testAutoPlanRespectsDeadlineOrder() {
+        let tasks = [
+            PlannableTask(id: "later", title: "Plus tard", estimatedMinutes: 60, priority: .p1, dueDate: makeDate(2026, 3, 20)),
+            PlannableTask(id: "urgent", title: "Aujourd'hui", estimatedMinutes: 60, priority: .p4, dueDate: makeDate(2026, 3, 4))
+        ]
+        let plan = ScheduleEngine.autoPlan(tasks: tasks, on: day, busy: [], calendar: testCalendar)
+        XCTAssertEqual(plan.blocks.first?.taskID, "urgent")
+    }
+
+    func testBufferIsInsertedBetweenBlocks() {
+        let tasks = [
+            PlannableTask(id: "a", title: "A", estimatedMinutes: 60),
+            PlannableTask(id: "b", title: "B", estimatedMinutes: 60)
+        ]
+        let plan = ScheduleEngine.autoPlan(tasks: tasks, on: day, busy: [], bufferMinutes: 15, calendar: testCalendar)
+        XCTAssertEqual(plan.blocks.count, 2)
+        let gap = plan.blocks[1].start.timeIntervalSince(plan.blocks[0].end) / 60
+        XCTAssertGreaterThanOrEqual(gap, 15)
+    }
+
+    func testSuggestSlotsSkipsNonWorkingDays() {
+        // Vendredi 6 mars, plein. Le week-end n'est pas travaillé → lundi 9.
+        let suggestions = ScheduleEngine.suggestSlots(
+            forMinutes: 60,
+            startingFrom: makeDate(2026, 3, 6, 17, 30),
+            days: 5,
+            busyByDay: [:],
+            limit: 2,
+            calendar: testCalendar
+        )
+        XCTAssertFalse(suggestions.isEmpty)
+        XCTAssertEqual(formattedDay(suggestions[0].start), "2026-03-09")
+    }
+
+    func testWorkloadRatio() {
+        XCTAssertEqual(ScheduleEngine.workloadRatio(plannedMinutes: 270), 0.5, accuracy: 0.001)
+        XCTAssertGreaterThan(ScheduleEngine.workloadRatio(plannedMinutes: 700), 1.0)
+    }
+}
+
+final class StatsEngineTests: XCTestCase {
+
+    func makeRecords() -> [CompletionRecord] {
+        [
+            CompletionRecord(date: makeDate(2026, 3, 2, 9, 30), xp: 20, focusMinutes: 25, priority: .p1, difficulty: .medium, lifeArea: .craft),
+            CompletionRecord(date: makeDate(2026, 3, 2, 14, 0), xp: 35, focusMinutes: 0, priority: .p2, difficulty: .hard, lifeArea: .craft),
+            CompletionRecord(date: makeDate(2026, 3, 3, 9, 15), xp: 10, focusMinutes: 50, priority: .p4, difficulty: .easy, lifeArea: .body),
+            CompletionRecord(date: makeDate(2026, 3, 4, 9, 45), xp: 60, focusMinutes: 0, priority: .p1, difficulty: .epic, lifeArea: .mind, wasOnTime: false, isBoss: true),
+            CompletionRecord(date: makeDate(2026, 3, 4, 21, 0), xp: 5, focusMinutes: 0, difficulty: .trivial, lifeArea: .home, isHabit: true)
+        ]
+    }
+
+    func testTotalsAndAverages() {
+        let stats = StatsEngine.compute(
+            records: makeRecords(),
+            from: makeDate(2026, 3, 2),
+            to: makeDate(2026, 3, 4),
+            calendar: testCalendar
+        )
+        XCTAssertEqual(stats.totalCompleted, 5)
+        XCTAssertEqual(stats.totalXP, 130)
+        XCTAssertEqual(stats.totalFocusMinutes, 75)
+        XCTAssertEqual(stats.activeDays, 3)
+        XCTAssertEqual(stats.bossesDefeated, 1)
+        XCTAssertEqual(stats.habitsCompleted, 1)
+        XCTAssertEqual(stats.onTimeRate, 0.8, accuracy: 0.001)
+        XCTAssertEqual(stats.averagePerActiveDay, 5.0 / 3.0, accuracy: 0.001)
+    }
+
+    func testDailySeriesCoversEveryDayIncludingEmptyOnes() {
+        let stats = StatsEngine.compute(
+            records: makeRecords(),
+            from: makeDate(2026, 3, 1),
+            to: makeDate(2026, 3, 5),
+            calendar: testCalendar
+        )
+        XCTAssertEqual(stats.daily.count, 5)
+        XCTAssertEqual(stats.daily[0].completed, 0)
+        XCTAssertEqual(stats.daily[1].completed, 2)
+        XCTAssertEqual(stats.daily[3].completed, 2)
+        XCTAssertEqual(stats.daily[4].completed, 0)
+    }
+
+    func testHourAndWeekdayBuckets() {
+        let stats = StatsEngine.compute(
+            records: makeRecords(),
+            from: makeDate(2026, 3, 2),
+            to: makeDate(2026, 3, 4),
+            calendar: testCalendar
+        )
+        XCTAssertEqual(stats.byHour.count, 24)
+        XCTAssertEqual(stats.byHour[9].value, 3)
+        XCTAssertEqual(stats.byHour[21].value, 1)
+        XCTAssertEqual(stats.bestHour, 9)
+
+        XCTAssertEqual(stats.byWeekday.count, 7)
+        // 2 mars 2026 est un lundi → index 1.
+        XCTAssertEqual(stats.byWeekday[1].value, 2)
+    }
+
+    func testBreakdownsByAreaAndDifficulty() {
+        let stats = StatsEngine.compute(
+            records: makeRecords(),
+            from: makeDate(2026, 3, 2),
+            to: makeDate(2026, 3, 4),
+            calendar: testCalendar
+        )
+        XCTAssertEqual(stats.byArea[.craft], 2)
+        XCTAssertEqual(stats.byArea[.body], 1)
+        XCTAssertEqual(stats.byDifficulty[.epic], 1)
+        XCTAssertEqual(stats.byPriority[.p1], 2)
+    }
+
+    func testEmptyRangeStillReturnsSkeleton() {
+        let stats = StatsEngine.compute(
+            records: [],
+            from: makeDate(2026, 3, 1),
+            to: makeDate(2026, 3, 7),
+            calendar: testCalendar
+        )
+        XCTAssertEqual(stats.totalCompleted, 0)
+        XCTAssertEqual(stats.daily.count, 7)
+        XCTAssertEqual(stats.byHour.count, 24)
+        XCTAssertNil(stats.bestHour)
+    }
+
+    func testRollingAverageSmoothsTheCurve() {
+        let points = (0..<10).map {
+            DailyPoint(date: makeDate(2026, 3, 1).adding(days: $0, calendar: testCalendar), completed: 1, xp: $0 * 10, focusMinutes: 0)
+        }
+        let averaged = StatsEngine.rollingAverage(points, window: 3)
+        XCTAssertEqual(averaged.count, 10)
+        XCTAssertEqual(averaged[0], 0, accuracy: 0.001)
+        XCTAssertEqual(averaged[2], 10, accuracy: 0.001)   // (0+10+20)/3
+        XCTAssertEqual(averaged[9], 80, accuracy: 0.001)   // (70+80+90)/3
+    }
+
+    func testDaysToNextLevel() {
+        let xp = LevelCurve.totalXP(toReach: 5)
+        let needed = LevelCurve.xpToAdvance(from: 5)
+        let days = StatsEngine.daysToNextLevel(totalXP: xp, averageXPPerDay: Double(needed) / 4.0)
+        XCTAssertEqual(days, 4)
+        XCTAssertNil(StatsEngine.daysToNextLevel(totalXP: xp, averageXPPerDay: 0))
+    }
+
+    func testWeekOverWeekChange() {
+        var records: [CompletionRecord] = []
+        // Semaine précédente : 2 quêtes le lundi 23 février.
+        records.append(CompletionRecord(date: makeDate(2026, 2, 23, 10, 0), xp: 10))
+        records.append(CompletionRecord(date: makeDate(2026, 2, 23, 11, 0), xp: 10))
+        // Semaine en cours : 3 quêtes le lundi 2 mars.
+        for hour in 9...11 {
+            records.append(CompletionRecord(date: makeDate(2026, 3, 2, hour, 0), xp: 10))
+        }
+        let change = StatsEngine.weekOverWeekChange(
+            records: records,
+            reference: makeDate(2026, 3, 4, 12, 0),
+            calendar: testCalendar
+        )
+        XCTAssertEqual(change ?? 0, 0.5, accuracy: 0.001)
+    }
+}
+
+final class InsightEngineTests: XCTestCase {
+
+    func testStreakAtRiskProducesAWarning() {
+        let insights = InsightEngine.insights(
+            stats: .empty,
+            streak: StreakState(current: 1, isAtRisk: true),
+            totalXP: 100,
+            overdueCount: 0,
+            calendar: testCalendar
+        )
+        XCTAssertTrue(insights.contains { $0.id == "streakRisk" && $0.tone == .warning })
+    }
+
+    func testOverdueInsightAdaptsItsAdvice() {
+        let few = InsightEngine.insights(stats: .empty, streak: .empty, totalXP: 0, overdueCount: 2, calendar: testCalendar)
+        let many = InsightEngine.insights(stats: .empty, streak: .empty, totalXP: 0, overdueCount: 12, calendar: testCalendar)
+        XCTAssertTrue(few.contains { $0.id == "overdue" })
+        XCTAssertNotEqual(
+            few.first { $0.id == "overdue" }?.detail,
+            many.first { $0.id == "overdue" }?.detail
+        )
+    }
+
+    func testNoInsightsWithoutData() {
+        let insights = InsightEngine.insights(stats: .empty, streak: .empty, totalXP: 0, overdueCount: 0, calendar: testCalendar)
+        XCTAssertTrue(insights.isEmpty)
+    }
+
+    func testNeglectedAreasRanking() {
+        var stats = ProductivityStats.empty
+        stats.byArea = [.body: 10, .mind: 3, .craft: 25]
+        let neglected = InsightEngine.neglectedAreas(stats: stats, limit: 2)
+        XCTAssertEqual(neglected.count, 2)
+        XCTAssertFalse(neglected.contains(.craft))
+    }
+}
+
+final class DateSupportTests: XCTestCase {
+
+    func testMonthGridAlwaysHas42Days() {
+        for month in 1...12 {
+            let grid = testCalendar.monthGrid(for: makeDate(2026, month, 15))
+            XCTAssertEqual(grid.count, 42)
+            // La grille commence toujours un lundi (firstWeekday = 2).
+            XCTAssertEqual(testCalendar.component(.weekday, from: grid[0]), 2)
+        }
+    }
+
+    func testWeekDaysStartOnMonday() {
+        let week = testCalendar.weekDays(for: makeDate(2026, 3, 4)) // mercredi
+        XCTAssertEqual(week.count, 7)
+        XCTAssertEqual(formattedDay(week[0]), "2026-03-02")
+        XCTAssertEqual(formattedDay(week[6]), "2026-03-08")
+    }
+
+    func testMinutesSinceMidnight() {
+        XCTAssertEqual(makeDate(2026, 3, 4, 14, 30).minutesSinceMidnight(calendar: testCalendar), 870)
+        XCTAssertEqual(makeDate(2026, 3, 4, 0, 0).minutesSinceMidnight(calendar: testCalendar), 0)
+    }
+
+    func testEndOfMonthHandlesEveryLength() {
+        XCTAssertEqual(formattedDay(testCalendar.endOfMonth(makeDate(2026, 2, 10))), "2026-02-28")
+        XCTAssertEqual(formattedDay(testCalendar.endOfMonth(makeDate(2028, 2, 10))), "2028-02-29")
+        XCTAssertEqual(formattedDay(testCalendar.endOfMonth(makeDate(2026, 4, 10))), "2026-04-30")
+    }
+
+    func testDurationFormatting() {
+        XCTAssertEqual(DurationFormatter.short(minutes: 90), "1 h 30")
+        XCTAssertEqual(DurationFormatter.short(minutes: 120), "2 h")
+        XCTAssertEqual(DurationFormatter.short(minutes: 45), "45 min")
+        XCTAssertEqual(DurationFormatter.short(minutes: 0), "—")
+        XCTAssertEqual(DurationFormatter.clock(seconds: 65), "01:05")
+        XCTAssertEqual(DurationFormatter.clock(seconds: 3725), "1:02:05")
+    }
+
+    func testDaylightSavingTransitionKeepsDayCount() {
+        // Passage à l'heure d'été en France : 29 mars 2026.
+        let before = makeDate(2026, 3, 28, 12, 0)
+        let after = makeDate(2026, 3, 30, 12, 0)
+        XCTAssertEqual(testCalendar.daysBetween(before, after), 2)
+        XCTAssertEqual(formattedDay(before.adding(days: 1, calendar: testCalendar)), "2026-03-29")
+        XCTAssertEqual(formattedDay(before.adding(days: 2, calendar: testCalendar)), "2026-03-30")
+    }
+
+    func testRecurrenceSurvivesDaylightSaving() {
+        // Une tâche à 9 h doit rester à 9 h après le changement d'heure.
+        let anchor = makeDate(2026, 3, 27, 9, 0)
+        let dates = RecurrenceEngine.occurrences(
+            rule: .daily, anchor: anchor,
+            from: anchor, to: testCalendar.endOfDay(makeDate(2026, 3, 31)), calendar: testCalendar
+        )
+        XCTAssertEqual(dates.map { formatted($0) }, [
+            "2026-03-27 09:00",
+            "2026-03-28 09:00",
+            "2026-03-29 09:00",
+            "2026-03-30 09:00",
+            "2026-03-31 09:00"
+        ])
+    }
+}

--- a/QuestlyApp/Packages/QuestlyKit/Tests/QuestlyKitTests/StreakAndProgressionTests.swift
+++ b/QuestlyApp/Packages/QuestlyKit/Tests/QuestlyKitTests/StreakAndProgressionTests.swift
@@ -1,0 +1,338 @@
+import XCTest
+@testable import QuestlyKit
+
+final class StreakEngineTests: XCTestCase {
+
+    func days(_ list: [String]) -> Set<Date> {
+        Set(list.map { text in
+            let parts = text.split(separator: "-").compactMap { Int($0) }
+            return makeDate(parts[0], parts[1], parts[2])
+        })
+    }
+
+    func testEmptyHistory() {
+        let state = StreakEngine.evaluate(activeDays: [], today: makeDate(2026, 3, 4), calendar: testCalendar)
+        XCTAssertEqual(state.current, 0)
+        XCTAssertEqual(state.longest, 0)
+        XCTAssertFalse(state.isAtRisk)
+    }
+
+    func testConsecutiveDaysIncludingToday() {
+        let state = StreakEngine.evaluate(
+            activeDays: days(["2026-03-02", "2026-03-03", "2026-03-04"]),
+            today: makeDate(2026, 3, 4, 20, 0),
+            calendar: testCalendar
+        )
+        XCTAssertEqual(state.current, 3)
+        XCTAssertEqual(state.longest, 3)
+        XCTAssertFalse(state.isAtRisk)
+    }
+
+    func testTodayNotYetDoneKeepsStreakButFlagsRisk() {
+        let state = StreakEngine.evaluate(
+            activeDays: days(["2026-03-02", "2026-03-03"]),
+            today: makeDate(2026, 3, 4, 9, 0),
+            calendar: testCalendar
+        )
+        XCTAssertEqual(state.current, 2, "La journée en cours ne casse pas la série")
+        XCTAssertTrue(state.isAtRisk)
+    }
+
+    func testGapBreaksStreak() {
+        let state = StreakEngine.evaluate(
+            activeDays: days(["2026-02-25", "2026-02-26", "2026-03-03", "2026-03-04"]),
+            today: makeDate(2026, 3, 4, 12, 0),
+            calendar: testCalendar
+        )
+        XCTAssertEqual(state.current, 2)
+        XCTAssertEqual(state.longest, 2)
+    }
+
+    func testFreezeBridgesASingleMissedDay() {
+        let config = StreakEngine.Configuration(availableFreezes: 1)
+        let state = StreakEngine.evaluate(
+            activeDays: days(["2026-03-01", "2026-03-02", "2026-03-04"]),
+            today: makeDate(2026, 3, 4, 12, 0),
+            configuration: config,
+            calendar: testCalendar
+        )
+        // 4 mars + (3 mars gelé) + 2 mars + 1er mars
+        XCTAssertEqual(state.current, 3)
+        XCTAssertEqual(state.freezesConsumed, 1)
+    }
+
+    func testFreezeIsNotSpentWithoutPriorActivity() {
+        let config = StreakEngine.Configuration(availableFreezes: 3)
+        let state = StreakEngine.evaluate(
+            activeDays: days(["2026-03-04"]),
+            today: makeDate(2026, 3, 4, 12, 0),
+            configuration: config,
+            calendar: testCalendar
+        )
+        XCTAssertEqual(state.current, 1)
+        XCTAssertEqual(state.freezesConsumed, 0, "Inutile de geler le vide")
+    }
+
+    func testRestDaysAreNeutral() {
+        // Samedi (7) et dimanche (1) déclarés jours de repos.
+        let config = StreakEngine.Configuration(restWeekdays: [1, 7])
+        let state = StreakEngine.evaluate(
+            activeDays: days(["2026-03-05", "2026-03-06", "2026-03-09"]), // jeu, ven, lun
+            today: makeDate(2026, 3, 9, 18, 0),
+            configuration: config,
+            calendar: testCalendar
+        )
+        XCTAssertEqual(state.current, 3, "Le week-end ne compte pas mais ne casse pas")
+    }
+
+    func testLongestStreakLooksAtWholeHistory() {
+        let state = StreakEngine.evaluate(
+            activeDays: days([
+                "2026-01-01", "2026-01-02", "2026-01-03", "2026-01-04", "2026-01-05",
+                "2026-03-03", "2026-03-04"
+            ]),
+            today: makeDate(2026, 3, 4, 12, 0),
+            calendar: testCalendar
+        )
+        XCTAssertEqual(state.current, 2)
+        XCTAssertEqual(state.longest, 5)
+        XCTAssertEqual(state.totalActiveDays, 7)
+    }
+
+    func testMilestoneDetection() {
+        let state = StreakState(current: 7)
+        XCTAssertEqual(state.milestoneReached, 7)
+        XCTAssertNil(StreakState(current: 8).milestoneReached)
+    }
+
+    func testHeatmapLevels() {
+        let cells = StreakEngine.heatmap(
+            completionsByDay: [
+                makeDate(2026, 3, 1): 1,
+                makeDate(2026, 3, 2): 4,
+                makeDate(2026, 3, 3): 8
+            ],
+            from: makeDate(2026, 3, 1),
+            to: makeDate(2026, 3, 5),
+            calendar: testCalendar
+        )
+        XCTAssertEqual(cells.count, 5)
+        XCTAssertEqual(cells[0].level, 1)
+        XCTAssertEqual(cells[2].level, 4)
+        XCTAssertEqual(cells[4].level, 0)
+        XCTAssertEqual(cells[4].count, 0)
+    }
+}
+
+final class AchievementTests: XCTestCase {
+
+    func testCatalogHasUniqueIdentifiers() {
+        let ids = AchievementCatalog.all.map(\.id)
+        XCTAssertEqual(Set(ids).count, ids.count, "Deux hauts faits partagent le même identifiant")
+        XCTAssertGreaterThan(ids.count, 40)
+    }
+
+    func testCatalogGoalsArePositive() {
+        for definition in AchievementCatalog.all {
+            XCTAssertGreaterThan(definition.goal, 0, "\(definition.id) a un objectif nul")
+            XCTAssertGreaterThan(definition.xpReward, 0, "\(definition.id) ne rapporte rien")
+        }
+    }
+
+    func testEveryCategoryIsPopulated() {
+        for category in AchievementCategory.allCases {
+            let items = AchievementCatalog.all.filter { $0.category == category }
+            XCTAssertFalse(items.isEmpty, "La catégorie \(category.label) est vide")
+        }
+    }
+
+    func testProgressEvaluation() {
+        let snapshot = PlayerSnapshot(level: 12, tasksCompleted: 60, currentStreak: 4)
+        let progress = AchievementEngine.evaluate(snapshot: snapshot)
+
+        let centurion = progress.first { $0.id == "vol.100" }
+        XCTAssertNotNil(centurion)
+        XCTAssertEqual(centurion?.value, 60)
+        XCTAssertFalse(centurion?.isUnlocked ?? true)
+        XCTAssertEqual(centurion?.fraction ?? 0, 0.6, accuracy: 0.001)
+        XCTAssertEqual(centurion?.remaining, 40)
+
+        let firstBlood = progress.first { $0.id == "first.blood" }
+        XCTAssertTrue(firstBlood?.isUnlocked ?? false)
+    }
+
+    func testNewlyUnlockedExcludesAlreadyKnown() {
+        let snapshot = PlayerSnapshot(tasksCompleted: 30)
+        let all = AchievementEngine.newlyUnlocked(snapshot: snapshot, alreadyUnlocked: [])
+        XCTAssertTrue(all.contains { $0.id == "vol.25" })
+
+        let filtered = AchievementEngine.newlyUnlocked(snapshot: snapshot, alreadyUnlocked: ["vol.25", "first.blood"])
+        XCTAssertFalse(filtered.contains { $0.id == "vol.25" })
+    }
+
+    func testBalancedAreasMetric() {
+        var counts: [LifeArea: Int] = [:]
+        for area in LifeArea.allCases { counts[area] = 12 }
+        let snapshot = PlayerSnapshot(completionsByArea: counts)
+        XCTAssertEqual(snapshot.value(for: .balancedAreas), LifeArea.allCases.count)
+        XCTAssertTrue(
+            AchievementEngine.newlyUnlocked(snapshot: snapshot, alreadyUnlocked: [])
+                .contains { $0.id == "balance.all" }
+        )
+    }
+
+    func testAlmostThereIsSortedByProgress() {
+        let snapshot = PlayerSnapshot(level: 4, tasksCompleted: 24, currentStreak: 2, focusMinutes: 10)
+        let almost = AchievementEngine.almostThere(snapshot: snapshot, limit: 3)
+        XCTAssertLessThanOrEqual(almost.count, 3)
+        for pair in zip(almost, almost.dropFirst()) {
+            XCTAssertGreaterThanOrEqual(pair.0.fraction, pair.1.fraction)
+        }
+        XCTAssertFalse(almost.contains { $0.isUnlocked })
+    }
+}
+
+final class QuestGeneratorTests: XCTestCase {
+
+    func testDailyQuestsAreDeterministic() {
+        let date = makeDate(2026, 3, 4)
+        let first = QuestGenerator.daily(for: date, playerLevel: 7, calendar: testCalendar)
+        let second = QuestGenerator.daily(for: date, playerLevel: 7, calendar: testCalendar)
+        XCTAssertEqual(first.map(\.id), second.map(\.id))
+        XCTAssertEqual(first.map(\.target), second.map(\.target))
+    }
+
+    func testDifferentDaysGiveDifferentQuests() {
+        let a = QuestGenerator.daily(for: makeDate(2026, 3, 4), playerLevel: 7, calendar: testCalendar)
+        let b = QuestGenerator.daily(for: makeDate(2026, 3, 5), playerLevel: 7, calendar: testCalendar)
+        XCTAssertNotEqual(a.map(\.id), b.map(\.id))
+    }
+
+    func testQuestKindsAreUniqueWithinADay() {
+        for offset in 0..<40 {
+            let date = makeDate(2026, 3, 4).adding(days: offset, calendar: testCalendar)
+            let quests = QuestGenerator.daily(for: date, playerLevel: 10, calendar: testCalendar)
+            let kinds = quests.map(\.kind)
+            XCTAssertEqual(Set(kinds).count, kinds.count, "Doublon de type de quête le \(formattedDay(date))")
+        }
+    }
+
+    func testPreferredAreaProducesTargetedQuest() {
+        let quests = QuestGenerator.daily(
+            for: makeDate(2026, 3, 4),
+            playerLevel: 5,
+            preferredAreas: [.body],
+            calendar: testCalendar
+        )
+        XCTAssertEqual(quests.first?.kind, .completeInArea)
+        XCTAssertEqual(quests.first?.lifeArea, .body)
+    }
+
+    func testTargetsScaleWithLevelButStayReasonable() {
+        let low = QuestGenerator.weekly(for: makeDate(2026, 3, 4), playerLevel: 1, calendar: testCalendar)
+        let high = QuestGenerator.weekly(for: makeDate(2026, 3, 4), playerLevel: 60, calendar: testCalendar)
+        XCTAssertGreaterThanOrEqual(high.target, low.target)
+        XCTAssertLessThanOrEqual(Double(high.target), Double(low.target) * 2.0)
+    }
+
+    func testWeeklyQuestIsStableAcrossTheWeek() {
+        let monday = QuestGenerator.weekly(for: makeDate(2026, 3, 2), playerLevel: 5, calendar: testCalendar)
+        let friday = QuestGenerator.weekly(for: makeDate(2026, 3, 6), playerLevel: 5, calendar: testCalendar)
+        XCTAssertEqual(monday.id, friday.id)
+    }
+
+    func testGenerateReturnsDailiesPlusWeekly() {
+        let quests = QuestGenerator.generate(for: makeDate(2026, 3, 4), playerLevel: 3, calendar: testCalendar)
+        XCTAssertEqual(quests.filter { $0.period == .daily }.count, 3)
+        XCTAssertEqual(quests.filter { $0.period == .weekly }.count, 1)
+    }
+
+    func testProgressFraction() {
+        let quest = QuestGenerator.daily(for: makeDate(2026, 3, 4), playerLevel: 1, calendar: testCalendar)[0]
+        XCTAssertEqual(quest.progressFraction(0), 0)
+        XCTAssertEqual(quest.progressFraction(quest.target), 1)
+        XCTAssertEqual(quest.progressFraction(quest.target * 5), 1)
+    }
+}
+
+final class EconomyTests: XCTestCase {
+
+    func testWalletSpending() {
+        var wallet = Wallet(coins: 100, gems: 2)
+        XCTAssertFalse(wallet.spend(Price(coins: 200)))
+        XCTAssertEqual(wallet.coins, 100)
+        XCTAssertTrue(wallet.spend(Price(coins: 80, gems: 1)))
+        XCTAssertEqual(wallet.coins, 20)
+        XCTAssertEqual(wallet.gems, 1)
+    }
+
+    func testShopCatalogIntegrity() {
+        let ids = ShopCatalog.all.map(\.id)
+        XCTAssertEqual(Set(ids).count, ids.count, "Identifiants d'objets dupliqués")
+        for item in ShopCatalog.all where item.category != .theme {
+            XCTAssertGreaterThanOrEqual(item.requiredLevel, 1)
+        }
+        XCTAssertFalse(ShopCatalog.available(forLevel: 1).isEmpty)
+        XCTAssertGreaterThan(
+            ShopCatalog.available(forLevel: 50).count,
+            ShopCatalog.available(forLevel: 1).count
+        )
+    }
+
+    func testAvatarCatalogIntegrity() {
+        let ids = AvatarCatalog.parts.map(\.id)
+        XCTAssertEqual(Set(ids).count, ids.count)
+        for slot in AvatarSlot.allCases {
+            XCTAssertFalse(AvatarCatalog.parts(in: slot).isEmpty, "Aucune pièce pour \(slot.label)")
+        }
+        // Le vestiaire de départ doit être gratuit et disponible au niveau 1.
+        for (_, id) in AvatarCatalog.defaultLoadout {
+            let part = AvatarCatalog.part(id: id)
+            XCTAssertNotNil(part, "Pièce par défaut introuvable : \(id)")
+            XCTAssertTrue(part?.isFree ?? false)
+        }
+    }
+
+    func testChestOpeningIsDeterministic() {
+        let a = LootEngine.openChest(tier: 2, seed: 42)
+        let b = LootEngine.openChest(tier: 2, seed: 42)
+        XCTAssertEqual(a.map(\.id), b.map(\.id))
+        XCTAssertEqual(a.count, 2)
+    }
+
+    func testHigherTierChestsSkewRarer() {
+        func averageRarity(tier: Int) -> Double {
+            var total = 0
+            let samples = 400
+            for seed in 0..<samples {
+                var rng = SeededRandom(seed: UInt64(seed) &+ 1)
+                total += LootEngine.rollRarity(tier: tier, rng: &rng).rawValue
+            }
+            return Double(total) / Double(samples)
+        }
+        let wood = averageRarity(tier: 1)
+        let gold = averageRarity(tier: 3)
+        XCTAssertGreaterThan(gold, wood, "Un coffre doré doit donner mieux qu'un coffre de bois")
+    }
+
+    func testSeededRandomIsReproducible() {
+        var a = SeededRandom(seed: 7)
+        var b = SeededRandom(seed: 7)
+        for _ in 0..<50 {
+            XCTAssertEqual(a.next(), b.next())
+        }
+    }
+
+    func testSeededRandomBounds() {
+        var rng = SeededRandom(seed: 1234)
+        for _ in 0..<500 {
+            let value = rng.next(upperBound: 10)
+            XCTAssertLessThan(value, 10)
+        }
+        for _ in 0..<200 {
+            let value = rng.nextDouble()
+            XCTAssertGreaterThanOrEqual(value, 0)
+            XCTAssertLessThan(value, 1)
+        }
+    }
+}

--- a/QuestlyApp/Packages/QuestlyKit/Tests/QuestlyKitTests/TestSupport.swift
+++ b/QuestlyApp/Packages/QuestlyKit/Tests/QuestlyKitTests/TestSupport.swift
@@ -1,0 +1,45 @@
+import Foundation
+import XCTest
+@testable import QuestlyKit
+
+/// Calendrier figé sur Paris : les tests ne dépendent pas du fuseau de la machine.
+let testCalendar: Calendar = .questly(timeZone: TimeZone(identifier: "Europe/Paris") ?? .current)
+
+func makeDate(
+    _ year: Int,
+    _ month: Int,
+    _ day: Int,
+    _ hour: Int = 0,
+    _ minute: Int = 0,
+    calendar: Calendar = testCalendar
+) -> Date {
+    var comps = DateComponents()
+    comps.year = year
+    comps.month = month
+    comps.day = day
+    comps.hour = hour
+    comps.minute = minute
+    comps.second = 0
+    guard let date = calendar.date(from: comps) else {
+        fatalError("Date de test invalide : \(year)-\(month)-\(day)")
+    }
+    return date
+}
+
+func formatted(_ date: Date, calendar: Calendar = testCalendar) -> String {
+    let f = DateFormatter()
+    f.calendar = calendar
+    f.timeZone = calendar.timeZone
+    f.locale = Locale(identifier: "en_US_POSIX")
+    f.dateFormat = "yyyy-MM-dd HH:mm"
+    return f.string(from: date)
+}
+
+func formattedDay(_ date: Date, calendar: Calendar = testCalendar) -> String {
+    let f = DateFormatter()
+    f.calendar = calendar
+    f.timeZone = calendar.timeZone
+    f.locale = Locale(identifier: "en_US_POSIX")
+    f.dateFormat = "yyyy-MM-dd"
+    return f.string(from: date)
+}

--- a/QuestlyApp/Questly.xcodeproj/project.pbxproj
+++ b/QuestlyApp/Questly.xcodeproj/project.pbxproj
@@ -1,0 +1,322 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		AA0000000000000000000012 /* QuestlyKit in Frameworks */ = {isa = PBXBuildFile; productRef = AA0000000000000000000011 /* QuestlyKit */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		AA0000000000000000000004 /* Questly.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Questly.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		AA0000000000000000000005 /* Questly */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Questly; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		AA0000000000000000000008 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AA0000000000000000000012 /* QuestlyKit in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		AA0000000000000000000002 = {
+			isa = PBXGroup;
+			children = (
+				AA0000000000000000000005 /* Questly */,
+				AA0000000000000000000003 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		AA0000000000000000000003 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				AA0000000000000000000004 /* Questly.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		AA0000000000000000000006 /* Questly */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AA000000000000000000000B /* Build configuration list for PBXNativeTarget "Questly" */;
+			buildPhases = (
+				AA0000000000000000000007 /* Sources */,
+				AA0000000000000000000008 /* Frameworks */,
+				AA0000000000000000000009 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				AA0000000000000000000005 /* Questly */,
+			);
+			name = Questly;
+			packageProductDependencies = (
+				AA0000000000000000000011 /* QuestlyKit */,
+			);
+			productName = Questly;
+			productReference = AA0000000000000000000004 /* Questly.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		AA0000000000000000000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1600;
+				LastUpgradeCheck = 1600;
+				TargetAttributes = {
+					AA0000000000000000000006 = {
+						CreatedOnToolsVersion = 16.0;
+					};
+				};
+			};
+			buildConfigurationList = AA000000000000000000000A /* Build configuration list for PBXProject "Questly" */;
+			compatibilityVersion = "Xcode 15.0";
+			developmentRegion = fr;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				fr,
+				en,
+				Base,
+			);
+			mainGroup = AA0000000000000000000002;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				AA0000000000000000000010 /* XCLocalSwiftPackageReference "Packages/QuestlyKit" */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = AA0000000000000000000003 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				AA0000000000000000000006 /* Questly */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		AA0000000000000000000009 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		AA0000000000000000000007 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		AA000000000000000000000C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		AA000000000000000000000D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		AA000000000000000000000E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = Questly;
+				INFOPLIST_KEY_NSCalendarsFullAccessUsageDescription = "Questly affiche tes évènements pour éviter de planifier une quête sur un créneau déjà pris.";
+				INFOPLIST_KEY_NSCalendarsUsageDescription = "Questly affiche tes évènements pour éviter de planifier une quête sur un créneau déjà pris.";
+				INFOPLIST_KEY_NSRemindersFullAccessUsageDescription = "Questly peut importer tes rappels existants comme quêtes.";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.navidjan.questly;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		AA000000000000000000000F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = Questly;
+				INFOPLIST_KEY_NSCalendarsFullAccessUsageDescription = "Questly affiche tes évènements pour éviter de planifier une quête sur un créneau déjà pris.";
+				INFOPLIST_KEY_NSCalendarsUsageDescription = "Questly affiche tes évènements pour éviter de planifier une quête sur un créneau déjà pris.";
+				INFOPLIST_KEY_NSRemindersFullAccessUsageDescription = "Questly peut importer tes rappels existants comme quêtes.";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.navidjan.questly;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		AA000000000000000000000A /* Build configuration list for PBXProject "Questly" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AA000000000000000000000C /* Debug */,
+				AA000000000000000000000D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AA000000000000000000000B /* Build configuration list for PBXNativeTarget "Questly" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AA000000000000000000000E /* Debug */,
+				AA000000000000000000000F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		AA0000000000000000000010 /* XCLocalSwiftPackageReference "Packages/QuestlyKit" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/QuestlyKit;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		AA0000000000000000000011 /* QuestlyKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = QuestlyKit;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = AA0000000000000000000001 /* Project object */;
+}

--- a/QuestlyApp/Questly.xcodeproj/xcshareddata/xcschemes/Questly.xcscheme
+++ b/QuestlyApp/Questly.xcodeproj/xcshareddata/xcschemes/Questly.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AA0000000000000000000006"
+               BuildableName = "Questly.app"
+               BlueprintName = "Questly"
+               ReferencedContainer = "container:Questly.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "QuestlyKitTests"
+               BuildableName = "QuestlyKitTests"
+               BlueprintName = "QuestlyKitTests"
+               ReferencedContainer = "container:Packages/QuestlyKit">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AA0000000000000000000006"
+            BuildableName = "Questly.app"
+            BlueprintName = "Questly"
+            ReferencedContainer = "container:Questly.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AA0000000000000000000006"
+            BuildableName = "Questly.app"
+            BlueprintName = "Questly"
+            ReferencedContainer = "container:Questly.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/QuestlyApp/Questly/App/AppContainer.swift
+++ b/QuestlyApp/Questly/App/AppContainer.swift
@@ -1,0 +1,42 @@
+import Foundation
+import SwiftData
+
+/// Conteneur SwiftData unique, partagé par l'application et par les intentions
+/// Siri / Raccourcis. Deux conteneurs sur le même fichier finiraient par se
+/// marcher dessus : on n'en crée donc qu'un seul.
+enum AppContainer {
+
+    static let schema = Schema([
+        TaskItem.self,
+        Subtask.self,
+        Project.self,
+        Tag.self,
+        TimeBlock.self,
+        PlayerProfile.self,
+        CompletionEvent.self,
+        QuestRecord.self,
+        FocusSession.self,
+        JournalEntry.self
+    ])
+
+    @MainActor
+    static let shared: ModelContainer = make()
+
+    /// Crée le conteneur, avec repli en mémoire si le disque refuse : mieux
+    /// vaut une session éphémère qu'un écran noir au lancement.
+    static func make() -> ModelContainer {
+        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
+        if let container = try? ModelContainer(for: schema, configurations: [configuration]) {
+            return container
+        }
+
+        let fallback = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        if let container = try? ModelContainer(for: schema, configurations: [fallback]) {
+            return container
+        }
+
+        // Ce cas ne peut survenir que si le schéma lui-même est invalide,
+        // ce qui serait détecté dès le premier lancement en développement.
+        fatalError("Questly : schéma SwiftData invalide.")
+    }
+}

--- a/QuestlyApp/Questly/App/QuestlyApp.swift
+++ b/QuestlyApp/Questly/App/QuestlyApp.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+import SwiftData
+import QuestlyKit
+
+@main
+struct QuestlyApp: App {
+
+    let container: ModelContainer
+
+    @State private var store: QuestlyStore
+    @State private var settings: SettingsStore
+    @State private var themeManager: ThemeManager
+    @State private var notifications = NotificationService()
+    @State private var calendarService = CalendarService()
+
+    init() {
+        let container = AppContainer.shared
+        self.container = container
+
+        let settings = SettingsStore()
+        _settings = State(initialValue: settings)
+        _themeManager = State(initialValue: ThemeManager(id: settings.themeID))
+        _store = State(initialValue: QuestlyStore(
+            modelContext: container.mainContext,
+            calendar: settings.calendar
+        ))
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environment(store)
+                .environment(settings)
+                .environment(themeManager)
+                .environment(notifications)
+                .environment(calendarService)
+                .environment(\.questlyTheme, themeManager.current)
+                .tint(themeManager.current.accent)
+        }
+        .modelContainer(container)
+    }
+}

--- a/QuestlyApp/Questly/App/RootView.swift
+++ b/QuestlyApp/Questly/App/RootView.swift
@@ -1,0 +1,186 @@
+import SwiftUI
+import SwiftData
+import Combine
+import QuestlyKit
+
+/// Coque de l'application : fond, navigation par onglets, saisie rapide et
+/// file des célébrations.
+struct RootView: View {
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(SettingsStore.self) private var settings
+    @Environment(ThemeManager.self) private var themeManager
+    @Environment(NotificationService.self) private var notifications
+    @Environment(CalendarService.self) private var calendarService
+
+    @State private var selectedTab: AppTab = .today
+    @State private var isQuickAddPresented = false
+    @State private var celebrationQueue: [Celebration] = []
+    @State private var currentCelebration: Celebration?
+    @State private var comboSnapshot: (count: Int, remaining: Int)?
+    @State private var hasBootstrapped = false
+
+    /// Rafraîchit le sablier du combo une fois par seconde.
+    private let comboTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+    @Query private var tasks: [TaskItem]
+
+    var body: some View {
+        ZStack {
+            AuroraBackground(theme: themeManager.current, animated: !settings.reduceMotion)
+
+            content
+                .safeAreaInset(edge: .bottom) {
+                    QuestlyTabBar(selection: $selectedTab, badges: tabBadges)
+                        .padding(.bottom, 4)
+                }
+
+            // Le bouton flottant vit dans la pile racine : posé dans l'encart
+            // de la barre d'onglets, il déborderait et perdrait ses touches.
+            VStack {
+                Spacer()
+                HStack {
+                    Spacer()
+                    QuickAddButton { isQuickAddPresented = true }
+                        .padding(.trailing, Metrics.spacingL)
+                        .padding(.bottom, Metrics.tabBarHeight + 34)
+                }
+            }
+            .zIndex(1)
+
+            if let combo = comboSnapshot, combo.count > 1 {
+                VStack {
+                    ComboIndicator(count: combo.count, remainingSeconds: combo.remaining)
+                        .padding(.top, 4)
+                    Spacer()
+                }
+                .transition(.move(edge: .top).combined(with: .opacity))
+                .zIndex(2)
+            }
+
+            if let celebration = currentCelebration {
+                CelebrationOverlay(
+                    celebration: celebration,
+                    confettiEnabled: settings.confettiEnabled && !settings.reduceMotion
+                ) {
+                    advanceCelebrations()
+                }
+                .zIndex(3)
+            }
+        }
+        .environment(\.questlyTheme, themeManager.current)
+        .sheet(isPresented: $isQuickAddPresented) {
+            QuickAddView()
+                .presentationDetents([.height(340), .large])
+                .presentationDragIndicator(.visible)
+                .presentationBackground(.regularMaterial)
+        }
+        .fullScreenCover(isPresented: onboardingBinding) {
+            OnboardingView()
+        }
+        .task { await bootstrap() }
+        .onChange(of: store.pendingCelebrations) { _, _ in collectCelebrations() }
+        .onChange(of: settings.themeID) { _, newValue in themeManager.select(id: newValue) }
+        .onReceive(comboTimer) { _ in refreshCombo() }
+    }
+
+    // MARK: Contenu
+
+    @ViewBuilder
+    private var content: some View {
+        switch selectedTab {
+        case .today:
+            TodayView(onQuickAdd: { isQuickAddPresented = true })
+        case .quests:
+            QuestBoardView()
+        case .calendar:
+            CalendarScreen()
+        case .focus:
+            FocusView()
+        case .hero:
+            HeroView()
+        }
+    }
+
+    private var tabBadges: [AppTab: Int] {
+        let overdue = tasks.filter { $0.isOverdue(now: Date(), calendar: settings.calendar) }.count
+        return overdue > 0 ? [.quests: overdue] : [:]
+    }
+
+    private var onboardingBinding: Binding<Bool> {
+        Binding(
+            get: { !settings.hasSeenOnboarding },
+            set: { newValue in settings.hasSeenOnboarding = !newValue }
+        )
+    }
+
+    // MARK: Démarrage
+
+    private func bootstrap() async {
+        guard !hasBootstrapped else { return }
+        hasBootstrapped = true
+
+        store.calendar = settings.calendar
+        store.bootstrap()
+
+        await notifications.refreshAuthorization()
+        notifications.registerCategories()
+        notifications.scheduleDailyReview(hour: settings.dailyReviewHour)
+        notifications.scheduleStreakReminder(streak: store.streak.current)
+
+        calendarService.refreshAuthorization()
+        if settings.calendarSyncEnabled {
+            let start = settings.calendar.startOfMonth(Date())
+            let end = settings.calendar.date(byAdding: .month, value: 2, to: start) ?? start
+            calendarService.load(from: start, to: end)
+        }
+    }
+
+    // MARK: Célébrations
+
+    private func refreshCombo() {
+        let now = Date()
+        if store.combo.isActive(at: now) {
+            comboSnapshot = (store.combo.count, store.combo.remainingSeconds(at: now))
+        } else if comboSnapshot != nil {
+            withAnimation(Motion.snappy) { comboSnapshot = nil }
+        }
+    }
+
+    private func collectCelebrations() {
+        while let bundle = store.consumeCelebration() {
+            celebrationQueue.append(contentsOf: RootView.celebrations(from: bundle))
+        }
+        if currentCelebration == nil { advanceCelebrations() }
+    }
+
+    private func advanceCelebrations() {
+        if celebrationQueue.isEmpty {
+            currentCelebration = nil
+        } else {
+            currentCelebration = celebrationQueue.removeFirst()
+        }
+    }
+
+    /// Traduit une récompense en une suite de fanfares, de la plus marquante à
+    /// la plus anodine.
+    static func celebrations(from bundle: RewardBundle) -> [Celebration] {
+        var output: [Celebration] = []
+        if bundle.leveledUp {
+            output.append(.levelUp(level: bundle.newLevel, rank: bundle.newRank))
+        }
+        for achievement in bundle.unlockedAchievements {
+            output.append(.achievement(achievement))
+        }
+        if let milestone = bundle.streakMilestone {
+            output.append(.streakMilestone(days: milestone))
+        }
+        if let attribute = bundle.attributeLevelUp {
+            output.append(.attributeLevelUp(area: attribute.area, level: attribute.level))
+        }
+        for quest in bundle.completedQuests {
+            output.append(.questCompleted(title: quest))
+        }
+        return output
+    }
+}

--- a/QuestlyApp/Questly/Data/PlayerModels.swift
+++ b/QuestlyApp/Questly/Data/PlayerModels.swift
@@ -1,0 +1,414 @@
+import Foundation
+import SwiftData
+import QuestlyKit
+
+// MARK: - Profil du héros
+
+/// Enregistrement unique qui porte toute la progression du joueur.
+/// Les dictionnaires sont stockés en JSON : SwiftData reste alors compatible
+/// avec CloudKit sans type transformable exotique.
+@Model
+final class PlayerProfile {
+
+    var identifier: UUID = UUID()
+    var displayName: String = "Aventurier·ère"
+    var createdAt: Date = Date()
+
+    var totalXP: Int = 0
+    var coins: Int = 0
+    var gems: Int = 0
+
+    // Compteurs cumulés (dérivables du journal, mis en cache pour la vitesse).
+    var tasksCompleted: Int = 0
+    var tasksCreated: Int = 0
+    var bossesDefeated: Int = 0
+    var focusMinutes: Int = 0
+    var focusSessions: Int = 0
+    var perfectDays: Int = 0
+    var inboxZeroDays: Int = 0
+    var questsCompleted: Int = 0
+    var maxCombo: Int = 0
+    var longestStreak: Int = 0
+    var coinsEarned: Int = 0
+    var coinsSpent: Int = 0
+    var gemsEarned: Int = 0
+    var notesWritten: Int = 0
+    var calendarBlocksScheduled: Int = 0
+
+    // Consommables
+    var streakFreezes: Int = 1
+    var restDayTokens: Int = 0
+    var boostMultiplier: Double = 1.0
+    var boostExpiresAt: Date?
+
+    // Apparence
+    var themeIdentifier: String = "nebula"
+    var avatarLoadoutData: Data?
+    var unlockedItems: [String] = []
+    var unlockedAchievementsData: Data?
+    var attributeXPData: Data?
+    /// Compteurs secondaires (lève-tôt, week-end, habitudes…) en JSON.
+    var secondaryCountersData: Data?
+
+    // Suivi
+    var lastActiveDate: Date?
+    var lastQuestRollDate: Date?
+    var hasCompletedOnboarding: Bool = false
+
+    init() {
+        self.identifier = UUID()
+        self.createdAt = Date()
+        self.unlockedItems = AvatarCatalog.defaultLoadout.values.map { $0 }
+    }
+}
+
+extension PlayerProfile {
+
+    // MARK: Blobs JSON
+
+    var avatarLoadout: [String: String] {
+        get { PlayerProfile.decode(avatarLoadoutData) ?? defaultLoadout }
+        set { avatarLoadoutData = PlayerProfile.encode(newValue) }
+    }
+
+    private var defaultLoadout: [String: String] {
+        var output: [String: String] = [:]
+        for (slot, id) in AvatarCatalog.defaultLoadout {
+            output[slot.rawValue] = id
+        }
+        return output
+    }
+
+    var unlockedAchievements: [String: Date] {
+        get { PlayerProfile.decode(unlockedAchievementsData) ?? [:] }
+        set { unlockedAchievementsData = PlayerProfile.encode(newValue) }
+    }
+
+    var attributeXP: [String: Int] {
+        get { PlayerProfile.decode(attributeXPData) ?? [:] }
+        set { attributeXPData = PlayerProfile.encode(newValue) }
+    }
+
+    static func encode<T: Encodable>(_ value: T) -> Data? {
+        try? JSONEncoder().encode(value)
+    }
+
+    static func decode<T: Decodable>(_ data: Data?) -> T? {
+        guard let data else { return nil }
+        return try? JSONDecoder().decode(T.self, from: data)
+    }
+
+    // MARK: Progression
+
+    var levelProgress: LevelProgress {
+        LevelCurve.progress(forTotalXP: totalXP)
+    }
+
+    var level: Int { levelProgress.level }
+    var rank: Rank { levelProgress.rank }
+
+    var wallet: Wallet {
+        get { Wallet(coins: coins, gems: gems) }
+        set {
+            coins = newValue.coins
+            gems = newValue.gems
+        }
+    }
+
+    func attributeXP(for area: LifeArea) -> Int {
+        attributeXP[area.rawValue] ?? 0
+    }
+
+    func attributeLevel(for area: LifeArea) -> Int {
+        AttributeCurve.level(forTotalXP: attributeXP(for: area))
+    }
+
+    func addAttributeXP(_ amount: Int, to area: LifeArea) {
+        var current = attributeXP
+        current[area.rawValue] = (current[area.rawValue] ?? 0) + amount
+        attributeXP = current
+    }
+
+    /// Le multiplicateur de potion, s'il n'a pas expiré.
+    func activeBoost(now: Date = Date()) -> Double {
+        guard let boostExpiresAt, boostExpiresAt > now else { return 1.0 }
+        return boostMultiplier
+    }
+
+    func avatarPart(for slot: AvatarSlot) -> AvatarPart? {
+        guard let id = avatarLoadout[slot.rawValue] else { return nil }
+        return AvatarCatalog.part(id: id)
+    }
+
+    func owns(itemID: String) -> Bool {
+        unlockedItems.contains(itemID)
+    }
+
+    func snapshot(
+        currentStreak: Int,
+        completionsByArea: [LifeArea: Int],
+        calendar: Calendar = .questly()
+    ) -> PlayerSnapshot {
+        var levels: [LifeArea: Int] = [:]
+        for area in LifeArea.allCases {
+            levels[area] = attributeLevel(for: area)
+        }
+        return PlayerSnapshot(
+            level: level,
+            totalXP: totalXP,
+            tasksCompleted: tasksCompleted,
+            tasksCreated: tasksCreated,
+            bossesDefeated: bossesDefeated,
+            currentStreak: currentStreak,
+            longestStreak: longestStreak,
+            focusMinutes: focusMinutes,
+            focusSessions: focusSessions,
+            perfectDays: perfectDays,
+            earlyBirdCompletions: earlyBirdCompletions,
+            nightOwlCompletions: nightOwlCompletions,
+            weekendCompletions: weekendCompletions,
+            habitsCompleted: habitsCompleted,
+            longestHabitChain: longestHabitChain,
+            projectsCompleted: projectsCompleted,
+            coinsEarned: coinsEarned,
+            coinsSpent: coinsSpent,
+            gemsEarned: gemsEarned,
+            questsCompleted: questsCompleted,
+            maxCombo: maxCombo,
+            inboxZeroDays: inboxZeroDays,
+            onTimeCompletions: onTimeCompletions,
+            completionsByArea: completionsByArea,
+            attributeLevels: levels,
+            calendarBlocksScheduled: calendarBlocksScheduled,
+            notesWritten: notesWritten,
+            daysSinceFirstLaunch: calendar.daysBetween(createdAt, Date())
+        )
+    }
+
+    // Compteurs secondaires, également mis en cache.
+    var earlyBirdCompletions: Int {
+        get { secondaryCounters["earlyBird"] ?? 0 }
+        set { setCounter("earlyBird", newValue) }
+    }
+    var nightOwlCompletions: Int {
+        get { secondaryCounters["nightOwl"] ?? 0 }
+        set { setCounter("nightOwl", newValue) }
+    }
+    var weekendCompletions: Int {
+        get { secondaryCounters["weekend"] ?? 0 }
+        set { setCounter("weekend", newValue) }
+    }
+    var habitsCompleted: Int {
+        get { secondaryCounters["habits"] ?? 0 }
+        set { setCounter("habits", newValue) }
+    }
+    var longestHabitChain: Int {
+        get { secondaryCounters["habitChain"] ?? 0 }
+        set { setCounter("habitChain", newValue) }
+    }
+    var projectsCompleted: Int {
+        get { secondaryCounters["projects"] ?? 0 }
+        set { setCounter("projects", newValue) }
+    }
+    var onTimeCompletions: Int {
+        get { secondaryCounters["onTime"] ?? 0 }
+        set { setCounter("onTime", newValue) }
+    }
+
+    private var secondaryCounters: [String: Int] {
+        PlayerProfile.decode(secondaryCountersData) ?? [:]
+    }
+
+    private func setCounter(_ key: String, _ value: Int) {
+        var current = secondaryCounters
+        current[key] = value
+        secondaryCountersData = PlayerProfile.encode(current)
+    }
+
+    /// Incrémente un compteur secondaire en une seule écriture.
+    func bumpCounter(_ key: String, by amount: Int = 1) {
+        var current = secondaryCounters
+        current[key] = (current[key] ?? 0) + amount
+        secondaryCountersData = PlayerProfile.encode(current)
+    }
+}
+
+// MARK: - Journal d'accomplissement
+
+/// Une ligne immuable par quête accomplie. C'est la source de vérité des
+/// statistiques, des séries et de la carte de chaleur ; elle survit à la
+/// suppression de la quête d'origine.
+@Model
+final class CompletionEvent {
+    var identifier: UUID = UUID()
+    var date: Date = Date()
+    var taskTitle: String = ""
+    var taskIdentifier: UUID?
+    var xp: Int = 0
+    var coins: Int = 0
+    var focusMinutes: Int = 0
+    var priorityRaw: Int = Priority.p4.rawValue
+    var difficultyRaw: Int = Difficulty.medium.rawValue
+    var lifeAreaRaw: String?
+    var wasOnTime: Bool = true
+    var isHabit: Bool = false
+    var isBoss: Bool = false
+
+    init(
+        date: Date = Date(),
+        taskTitle: String = "",
+        taskIdentifier: UUID? = nil,
+        xp: Int = 0,
+        coins: Int = 0,
+        focusMinutes: Int = 0,
+        priority: Priority = .p4,
+        difficulty: Difficulty = .medium,
+        lifeArea: LifeArea? = nil,
+        wasOnTime: Bool = true,
+        isHabit: Bool = false,
+        isBoss: Bool = false
+    ) {
+        self.identifier = UUID()
+        self.date = date
+        self.taskTitle = taskTitle
+        self.taskIdentifier = taskIdentifier
+        self.xp = xp
+        self.coins = coins
+        self.focusMinutes = focusMinutes
+        self.priorityRaw = priority.rawValue
+        self.difficultyRaw = difficulty.rawValue
+        self.lifeAreaRaw = lifeArea?.rawValue
+        self.wasOnTime = wasOnTime
+        self.isHabit = isHabit
+        self.isBoss = isBoss
+    }
+
+    var priority: Priority { Priority(rawValue: priorityRaw) ?? .p4 }
+    var difficulty: Difficulty { Difficulty(rawValue: difficultyRaw) ?? .medium }
+    var lifeArea: LifeArea? { lifeAreaRaw.flatMap { LifeArea(rawValue: $0) } }
+
+    var record: CompletionRecord {
+        CompletionRecord(
+            id: identifier.uuidString,
+            date: date,
+            xp: xp,
+            focusMinutes: focusMinutes,
+            priority: priority,
+            difficulty: difficulty,
+            lifeArea: lifeArea,
+            wasOnTime: wasOnTime,
+            isHabit: isHabit,
+            isBoss: isBoss
+        )
+    }
+}
+
+// MARK: - Quête quotidienne
+
+@Model
+final class QuestRecord {
+    var identifier: String = ""
+    var day: Date = Date()
+    var kindRaw: String = ""
+    var periodRaw: String = QuestPeriod.daily.rawValue
+    var title: String = ""
+    var detail: String = ""
+    var target: Int = 1
+    var progress: Int = 0
+    var xpReward: Int = 0
+    var coinReward: Int = 0
+    var gemReward: Int = 0
+    var rarityRaw: Int = Rarity.common.rawValue
+    var symbolName: String = "scroll.fill"
+    var lifeAreaRaw: String?
+    var isClaimed: Bool = false
+    var completedAt: Date?
+
+    init(quest: GeneratedQuest, day: Date) {
+        self.identifier = quest.id
+        self.day = day
+        self.kindRaw = quest.kind.rawValue
+        self.periodRaw = quest.period.rawValue
+        self.title = quest.title
+        self.detail = quest.detail
+        self.target = quest.target
+        self.xpReward = quest.xpReward
+        self.coinReward = quest.coinReward
+        self.gemReward = quest.gemReward
+        self.rarityRaw = quest.rarity.rawValue
+        self.symbolName = quest.symbolName
+        self.lifeAreaRaw = quest.lifeArea?.rawValue
+    }
+
+    var kind: QuestKind { QuestKind(rawValue: kindRaw) ?? .completeTasks }
+    var period: QuestPeriod { QuestPeriod(rawValue: periodRaw) ?? .daily }
+    var rarity: Rarity { Rarity(rawValue: rarityRaw) ?? .common }
+    var lifeArea: LifeArea? { lifeAreaRaw.flatMap { LifeArea(rawValue: $0) } }
+
+    var isComplete: Bool { progress >= target }
+    var fraction: Double {
+        guard target > 0 else { return 1 }
+        return min(1, Double(progress) / Double(target))
+    }
+}
+
+// MARK: - Session de concentration
+
+@Model
+final class FocusSession {
+    var identifier: UUID = UUID()
+    var start: Date = Date()
+    var end: Date?
+    var plannedMinutes: Int = 25
+    var actualMinutes: Int = 0
+    var wasCompleted: Bool = false
+    var distractions: Int = 0
+    var taskIdentifier: UUID?
+    var taskTitle: String = ""
+    var isBreak: Bool = false
+
+    init(
+        start: Date = Date(),
+        plannedMinutes: Int = 25,
+        taskIdentifier: UUID? = nil,
+        taskTitle: String = "",
+        isBreak: Bool = false
+    ) {
+        self.identifier = UUID()
+        self.start = start
+        self.plannedMinutes = plannedMinutes
+        self.taskIdentifier = taskIdentifier
+        self.taskTitle = taskTitle
+        self.isBreak = isBreak
+    }
+}
+
+// MARK: - Note de journal
+
+@Model
+final class JournalEntry {
+    var identifier: UUID = UUID()
+    var day: Date = Date()
+    var text: String = ""
+    /// 1 (difficile) à 5 (excellent).
+    var mood: Int = 3
+    var createdAt: Date = Date()
+
+    init(day: Date = Date(), text: String = "", mood: Int = 3) {
+        self.identifier = UUID()
+        self.day = day
+        self.text = text
+        self.mood = mood
+        self.createdAt = Date()
+    }
+
+    var moodEmoji: String {
+        switch mood {
+        case 1: return "😞"
+        case 2: return "😕"
+        case 3: return "😐"
+        case 4: return "🙂"
+        default: return "🤩"
+        }
+    }
+}

--- a/QuestlyApp/Questly/Data/QuestlyStore.swift
+++ b/QuestlyApp/Questly/Data/QuestlyStore.swift
@@ -1,0 +1,856 @@
+import Foundation
+import SwiftData
+import SwiftUI
+import QuestlyKit
+
+// MARK: - Récompense
+
+/// Montée de niveau d'un attribut (domaine de vie).
+struct AttributeLevelUp: Equatable {
+    let area: LifeArea
+    let level: Int
+}
+
+/// Tout ce qui doit être célébré après une validation, en un seul paquet.
+struct RewardBundle: Equatable {
+    var award: XPAward = .none
+    var comboCount: Int = 1
+    var leveledUp: Bool = false
+    var newLevel: Int = 1
+    var newRank: Rank?
+    var unlockedAchievements: [AchievementDefinition] = []
+    var completedQuests: [String] = []
+    var streakMilestone: Int?
+    var attributeLevelUp: AttributeLevelUp?
+
+    var isEmpty: Bool {
+        award.totalXP == 0 && unlockedAchievements.isEmpty && completedQuests.isEmpty
+    }
+}
+
+// MARK: - Store
+
+/// Point d'entrée unique pour tout ce qui modifie l'état du jeu.
+///
+/// Les vues lisent les données via `@Query` (SwiftData les tient à jour toutes
+/// seules) et passent ici pour écrire, afin que les règles du jeu — XP, séries,
+/// quêtes, hauts faits, récurrences — soient appliquées au même endroit.
+@MainActor
+@Observable
+final class QuestlyStore {
+
+    var modelContext: ModelContext
+    var calendar: Calendar
+
+    /// Combo en cours, volontairement non persisté : il expire avec la session.
+    private(set) var combo = ComboTracker()
+    /// Dernier état de série calculé.
+    private(set) var streak: StreakState = .empty
+    /// File des célébrations à jouer.
+    var pendingCelebrations: [RewardBundle] = []
+
+    init(modelContext: ModelContext, calendar: Calendar = .questly()) {
+        self.modelContext = modelContext
+        self.calendar = calendar
+    }
+
+    // MARK: - Accès
+
+    func fetch<T: PersistentModel>(_ descriptor: FetchDescriptor<T>) -> [T] {
+        (try? modelContext.fetch(descriptor)) ?? []
+    }
+
+    func allTasks() -> [TaskItem] {
+        fetch(FetchDescriptor<TaskItem>())
+    }
+
+    func openTasks() -> [TaskItem] {
+        allTasks().filter(\.isOpen)
+    }
+
+    func completionEvents() -> [CompletionEvent] {
+        fetch(FetchDescriptor<CompletionEvent>(sortBy: [SortDescriptor(\.date, order: .reverse)]))
+    }
+
+    /// Le profil du joueur, créé au premier lancement.
+    @discardableResult
+    func profile() -> PlayerProfile {
+        if let existing = fetch(FetchDescriptor<PlayerProfile>()).first {
+            return existing
+        }
+        let created = PlayerProfile()
+        modelContext.insert(created)
+        save()
+        return created
+    }
+
+    func save() {
+        do {
+            try modelContext.save()
+        } catch {
+            // Une écriture ratée ne doit jamais faire tomber l'app : on garde
+            // l'état en mémoire, la prochaine sauvegarde réessaiera.
+            print("Questly: échec de sauvegarde — \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Démarrage
+
+    func bootstrap() {
+        let player = profile()
+        refreshStreak()
+        refreshQuests(for: Date(), player: player)
+        expireBoostIfNeeded(player: player)
+        player.lastActiveDate = Date()
+        save()
+    }
+
+    func expireBoostIfNeeded(player: PlayerProfile) {
+        if let expiry = player.boostExpiresAt, expiry <= Date() {
+            player.boostMultiplier = 1.0
+            player.boostExpiresAt = nil
+        }
+    }
+
+    // MARK: - Création
+
+    @discardableResult
+    func createTask(from parsed: ParsedInput, defaultProject: Project? = nil) -> TaskItem {
+        let task = TaskItem(
+            title: parsed.title.isEmpty ? "Nouvelle quête" : parsed.title,
+            dueDate: parsed.dueDate,
+            hasTime: parsed.hasTime,
+            estimatedMinutes: parsed.durationMinutes ?? 0,
+            priority: parsed.priority ?? .p4,
+            difficulty: parsed.difficulty ?? .medium,
+            status: parsed.dueDate == nil ? .inbox : .active,
+            lifeArea: parsed.lifeArea,
+            isBoss: parsed.isBoss
+        )
+        task.reminderMinutesBefore = parsed.reminderMinutesBefore
+
+        if let rule = parsed.recurrence {
+            task.recurrenceAnchor = parsed.dueDate ?? Date()
+            task.recurrence = rule
+        }
+
+        if let projectName = parsed.project {
+            task.project = findOrCreateProject(named: projectName)
+        } else {
+            task.project = defaultProject
+        }
+
+        var tags: [Tag] = []
+        for name in parsed.tags {
+            tags.append(findOrCreateTag(named: name))
+        }
+        task.tags = tags
+
+        modelContext.insert(task)
+        profile().tasksCreated += 1
+        save()
+        return task
+    }
+
+    @discardableResult
+    func createTask(title: String, dueDate: Date? = nil, hasTime: Bool = false) -> TaskItem {
+        let task = TaskItem(title: title, dueDate: dueDate, hasTime: hasTime,
+                            status: dueDate == nil ? .inbox : .active)
+        modelContext.insert(task)
+        profile().tasksCreated += 1
+        save()
+        return task
+    }
+
+    func findOrCreateProject(named name: String) -> Project {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let existing = fetch(FetchDescriptor<Project>()).first {
+            $0.name.localizedCaseInsensitiveCompare(trimmed) == .orderedSame
+        }
+        if let existing { return existing }
+        let project = Project(name: trimmed, colorHex: Palette.randomProjectHex(seed: trimmed))
+        modelContext.insert(project)
+        return project
+    }
+
+    func findOrCreateTag(named name: String) -> Tag {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let existing = fetch(FetchDescriptor<Tag>()).first {
+            $0.name.localizedCaseInsensitiveCompare(trimmed) == .orderedSame
+        }
+        if let existing { return existing }
+        let tag = Tag(name: trimmed, colorHex: Palette.randomTagHex(seed: trimmed))
+        modelContext.insert(tag)
+        return tag
+    }
+
+    // MARK: - Validation d'une quête
+
+    /// Le cœur du jeu : valider une quête, distribuer les récompenses et
+    /// renvoyer de quoi animer la célébration.
+    @discardableResult
+    func complete(_ task: TaskItem, at date: Date = Date()) -> RewardBundle {
+        guard task.isOpen else { return RewardBundle() }
+
+        let player = profile()
+        expireBoostIfNeeded(player: player)
+
+        let levelBefore = player.level
+        let rankBefore = player.rank
+        let areaLevelBefore = task.lifeArea.map { player.attributeLevel(for: $0) }
+
+        let comboCount = combo.register(at: date)
+        let isFirstToday = completionCount(on: date) == 0
+
+        let context = XPContext(
+            streakDays: streak.current,
+            comboCount: comboCount,
+            boostMultiplier: player.activeBoost(now: date),
+            isFirstCompletionOfDay: isFirstToday,
+            isDailyQuestTarget: isTargetedByActiveQuest(task),
+            completionDate: date
+        )
+
+        let award = XPEngine.award(for: task.xpDescriptor(), context: context, calendar: calendar)
+        let wasOnTime = !task.isOverdue(now: date, calendar: calendar)
+
+        // 1. La quête elle-même.
+        task.status = .completed
+        task.completedAt = date
+        task.earnedXP = award.totalXP
+        task.touch()
+        for subtask in task.orderedSubtasks where !subtask.isDone {
+            subtask.isDone = true
+            subtask.completedAt = date
+        }
+
+        // 2. Le journal.
+        let event = CompletionEvent(
+            date: date,
+            taskTitle: task.title,
+            taskIdentifier: task.identifier,
+            xp: award.totalXP,
+            coins: award.coins,
+            focusMinutes: task.focusedMinutes,
+            priority: task.priority,
+            difficulty: task.difficulty,
+            lifeArea: task.lifeArea,
+            wasOnTime: wasOnTime,
+            isHabit: task.isRecurring,
+            isBoss: task.isBoss
+        )
+        modelContext.insert(event)
+
+        // 3. Le profil.
+        player.totalXP += award.totalXP
+        player.coins += award.coins
+        player.gems += award.gems
+        player.coinsEarned += award.coins
+        player.gemsEarned += award.gems
+        player.tasksCompleted += 1
+        player.maxCombo = max(player.maxCombo, comboCount)
+        if task.isBoss { player.bossesDefeated += 1 }
+        if task.isRecurring { player.habitsCompleted += 1 }
+        if wasOnTime { player.onTimeCompletions += 1 }
+        if let area = award.lifeArea {
+            player.addAttributeXP(award.attributeXP, to: area)
+        }
+
+        let hour = calendar.component(.hour, from: date)
+        if hour < 7 { player.earlyBirdCompletions += 1 }
+        if hour >= 23 { player.nightOwlCompletions += 1 }
+        if calendar.isWeekend(date) { player.weekendCompletions += 1 }
+
+        // 4. La récurrence engendre la prochaine occurrence.
+        spawnNextOccurrence(of: task, completedAt: date)
+
+        // 5. Projet terminé ?
+        if let project = task.project, project.isComplete {
+            player.projectsCompleted += 1
+        }
+
+        save()
+
+        // 6. Recalculs et récompenses annexes.
+        refreshStreak()
+        let questsDone = refreshQuestProgress()
+        let achievements = grantNewAchievements(player: player)
+
+        var bundle = RewardBundle(
+            award: award,
+            comboCount: comboCount,
+            leveledUp: player.level > levelBefore,
+            newLevel: player.level,
+            newRank: player.rank > rankBefore ? player.rank : nil,
+            unlockedAchievements: achievements,
+            completedQuests: questsDone,
+            streakMilestone: streak.milestoneReached
+        )
+
+        if let area = task.lifeArea, let before = areaLevelBefore {
+            let after = player.attributeLevel(for: area)
+            if after > before {
+                bundle.attributeLevelUp = AttributeLevelUp(area: area, level: after)
+            }
+        }
+
+        player.longestStreak = max(player.longestStreak, streak.current)
+        save()
+
+        pendingCelebrations.append(bundle)
+        return bundle
+    }
+
+    /// Annule une validation — y compris les récompenses, pour éviter la triche
+    /// involontaire (valider / annuler en boucle).
+    func uncomplete(_ task: TaskItem) {
+        guard task.isCompleted else { return }
+        let player = profile()
+
+        if let event = fetch(FetchDescriptor<CompletionEvent>()).first(where: { $0.taskIdentifier == task.identifier && $0.date == task.completedAt }) {
+            player.totalXP = max(0, player.totalXP - event.xp)
+            player.coins = max(0, player.coins - event.coins)
+            player.coinsEarned = max(0, player.coinsEarned - event.coins)
+            modelContext.delete(event)
+        } else {
+            player.totalXP = max(0, player.totalXP - task.earnedXP)
+        }
+
+        player.tasksCompleted = max(0, player.tasksCompleted - 1)
+        if task.isBoss { player.bossesDefeated = max(0, player.bossesDefeated - 1) }
+
+        task.status = task.dueDate == nil ? .inbox : .active
+        task.completedAt = nil
+        task.earnedXP = 0
+        task.touch()
+
+        save()
+        refreshStreak()
+        _ = refreshQuestProgress()
+    }
+
+    func delete(_ task: TaskItem) {
+        modelContext.delete(task)
+        save()
+    }
+
+    func archive(_ task: TaskItem) {
+        task.status = .archived
+        task.touch()
+        save()
+    }
+
+    // MARK: - Récurrence
+
+    /// Crée la prochaine occurrence d'une quête récurrente.
+    private func spawnNextOccurrence(of task: TaskItem, completedAt: Date) {
+        guard let rule = task.recurrence else { return }
+        let anchor = task.recurrenceAnchor ?? task.dueDate ?? task.createdAt
+        let reference = rule.mode == .afterCompletion ? completedAt : (task.dueDate ?? completedAt)
+
+        guard let next = RecurrenceEngine.nextDate(
+            rule: rule,
+            after: reference,
+            anchor: anchor,
+            calendar: calendar
+        ) else { return }
+
+        let copy = TaskItem(
+            title: task.title,
+            notes: task.notes,
+            dueDate: next,
+            hasTime: task.hasTime,
+            estimatedMinutes: task.estimatedMinutes,
+            priority: task.priority,
+            difficulty: task.difficulty,
+            energy: task.energy,
+            status: .active,
+            lifeArea: task.lifeArea,
+            isBoss: task.isBoss,
+            project: task.project
+        )
+        copy.recurrenceAnchor = anchor
+        copy.recurrenceData = task.recurrenceData
+        copy.recurrenceCount = task.recurrenceCount + 1
+        copy.reminderMinutesBefore = task.reminderMinutesBefore
+        copy.tags = task.tags
+        copy.sortIndex = task.sortIndex
+
+        // Les sous-quêtes repartent à zéro à chaque occurrence.
+        var newSubtasks: [Subtask] = []
+        for subtask in task.orderedSubtasks {
+            let fresh = Subtask(title: subtask.title, sortIndex: subtask.sortIndex)
+            newSubtasks.append(fresh)
+            modelContext.insert(fresh)
+        }
+        copy.subtasks = newSubtasks
+
+        modelContext.insert(copy)
+
+        // L'occurrence accomplie ne porte plus la règle : elle devient une
+        // ligne d'historique.
+        task.recurrenceData = nil
+    }
+
+    // MARK: - Planification
+
+    @discardableResult
+    func schedule(_ task: TaskItem, at start: Date, minutes: Int? = nil) -> TimeBlock {
+        let duration = minutes ?? (task.estimatedMinutes > 0 ? task.estimatedMinutes : 30)
+        let block = TimeBlock(
+            title: task.title,
+            start: start,
+            end: start.addingTimeInterval(TimeInterval(duration * 60)),
+            colorHex: task.lifeArea?.hex ?? task.priority.hex,
+            task: task
+        )
+        modelContext.insert(block)
+        if task.dueDate == nil {
+            task.dueDate = start
+            task.hasTime = true
+            task.status = .active
+        }
+        profile().calendarBlocksScheduled += 1
+        save()
+        return block
+    }
+
+    func move(_ block: TimeBlock, to start: Date) {
+        let duration = block.end.timeIntervalSince(block.start)
+        block.start = start
+        block.end = start.addingTimeInterval(duration)
+        save()
+    }
+
+    func resize(_ block: TimeBlock, toMinutes minutes: Int) {
+        block.end = block.start.addingTimeInterval(TimeInterval(max(5, minutes) * 60))
+        save()
+    }
+
+    func delete(_ block: TimeBlock) {
+        modelContext.delete(block)
+        save()
+    }
+
+    func snooze(_ task: TaskItem, to date: Date, keepTime: Bool = false) {
+        if keepTime, let current = task.dueDate {
+            let comps = calendar.dateComponents([.hour, .minute], from: current)
+            task.dueDate = calendar.setting(hour: comps.hour ?? 9, minute: comps.minute ?? 0, of: date)
+        } else {
+            task.dueDate = date
+        }
+        task.status = .active
+        task.touch()
+        save()
+    }
+
+    // MARK: - Concentration
+
+    @discardableResult
+    func recordFocus(minutes: Int, on task: TaskItem?, completed: Bool, distractions: Int = 0) -> FocusSession {
+        let session = FocusSession(
+            start: Date().addingTimeInterval(TimeInterval(-minutes * 60)),
+            plannedMinutes: minutes,
+            taskIdentifier: task?.identifier,
+            taskTitle: task?.title ?? ""
+        )
+        session.end = Date()
+        session.actualMinutes = minutes
+        session.wasCompleted = completed
+        session.distractions = distractions
+        modelContext.insert(session)
+
+        if let task {
+            task.focusedMinutes += minutes
+            task.touch()
+        }
+
+        let player = profile()
+        player.focusMinutes += minutes
+        if completed { player.focusSessions += 1 }
+        save()
+        _ = refreshQuestProgress()
+        return session
+    }
+
+    // MARK: - Séries
+
+    func refreshStreak() {
+        let player = profile()
+        let days = Set(completionEvents().map { calendar.startOfDay(for: $0.date) })
+        let config = StreakEngine.Configuration(
+            restWeekdays: [],
+            availableFreezes: player.streakFreezes,
+            maxGapPerFreeze: 1
+        )
+        streak = StreakEngine.evaluate(
+            activeDays: days,
+            today: Date(),
+            configuration: config,
+            calendar: calendar
+        )
+        if streak.freezesConsumed > 0 {
+            player.streakFreezes = max(0, player.streakFreezes - streak.freezesConsumed)
+        }
+        player.longestStreak = max(player.longestStreak, streak.longest)
+    }
+
+    func completionCount(on day: Date) -> Int {
+        completionEvents().filter { calendar.isSameDay($0.date, day) }.count
+    }
+
+    // MARK: - Quêtes quotidiennes
+
+    func todayQuests() -> [QuestRecord] {
+        let today = calendar.startOfDay(for: Date())
+        let weekStart = calendar.startOfWeek(Date())
+        return fetch(FetchDescriptor<QuestRecord>()).filter { record in
+            record.period == .daily
+                ? calendar.isSameDay(record.day, today)
+                : calendar.isSameDay(record.day, weekStart)
+        }
+    }
+
+    func refreshQuests(for date: Date, player: PlayerProfile) {
+        let today = calendar.startOfDay(for: date)
+        let existingDaily = fetch(FetchDescriptor<QuestRecord>()).filter {
+            $0.period == .daily && calendar.isSameDay($0.day, today)
+        }
+
+        if existingDaily.isEmpty {
+            let stats = currentStats(days: 30)
+            let neglected = InsightEngine.neglectedAreas(stats: stats, limit: 1)
+            let generated = QuestGenerator.daily(
+                for: today,
+                playerLevel: player.level,
+                preferredAreas: neglected,
+                calendar: calendar
+            )
+            for quest in generated {
+                modelContext.insert(QuestRecord(quest: quest, day: today))
+            }
+        }
+
+        let weekStart = calendar.startOfWeek(date)
+        let existingWeekly = fetch(FetchDescriptor<QuestRecord>()).filter {
+            $0.period == .weekly && calendar.isSameDay($0.day, weekStart)
+        }
+        if existingWeekly.isEmpty {
+            let weekly = QuestGenerator.weekly(for: date, playerLevel: player.level, calendar: calendar)
+            modelContext.insert(QuestRecord(quest: weekly, day: weekStart))
+        }
+
+        player.lastQuestRollDate = today
+        save()
+        _ = refreshQuestProgress()
+    }
+
+    /// Recalcule l'avancement de chaque quête et renvoie celles qui viennent
+    /// d'être bouclées.
+    @discardableResult
+    func refreshQuestProgress() -> [String] {
+        let quests = todayQuests()
+        guard !quests.isEmpty else { return [] }
+
+        var newlyCompleted: [String] = []
+        for quest in quests {
+            let window = quest.period == .daily
+                ? (start: calendar.startOfDay(for: Date()), end: calendar.endOfDay(Date()))
+                : (start: calendar.startOfWeek(Date()), end: calendar.endOfWeek(Date()))
+            let value = progressValue(for: quest, from: window.start, to: window.end)
+            let wasComplete = quest.isComplete
+            quest.progress = value
+            if !wasComplete && quest.isComplete {
+                quest.completedAt = Date()
+                newlyCompleted.append(quest.title)
+            }
+        }
+        save()
+        return newlyCompleted
+    }
+
+    private func progressValue(for quest: QuestRecord, from start: Date, to end: Date) -> Int {
+        let events = completionEvents().filter { $0.date >= start && $0.date <= end }
+
+        switch quest.kind {
+        case .completeTasks:
+            return events.count
+        case .completeHighPriority:
+            return events.filter { $0.priority == .p1 || $0.priority == .p2 }.count
+        case .focusMinutes:
+            let sessions = fetch(FetchDescriptor<FocusSession>()).filter {
+                $0.start >= start && $0.start <= end && !$0.isBreak
+            }
+            return sessions.reduce(0) { $0 + $1.actualMinutes }
+        case .completeInArea:
+            guard let area = quest.lifeArea else { return 0 }
+            return events.filter { $0.lifeArea == area }.count
+        case .completeBeforeNoon:
+            return events.filter { calendar.component(.hour, from: $0.date) < 12 }.count
+        case .clearOverdue:
+            return events.filter { !$0.wasOnTime }.count
+        case .defeatBoss:
+            return events.filter(\.isBoss).count
+        case .completeHabit:
+            return events.filter(\.isHabit).count
+        case .scheduleBlocks:
+            return fetch(FetchDescriptor<TimeBlock>()).filter {
+                !$0.isExternal && $0.start >= start && $0.start <= end
+            }.count
+        case .planTomorrow:
+            let tomorrow = Date().adding(days: 1, calendar: calendar)
+            return allTasks().filter { task in
+                guard let due = task.dueDate else { return false }
+                return calendar.isSameDay(due, tomorrow)
+            }.count
+        case .completeDifficult:
+            return events.filter { $0.difficulty.rawValue >= Difficulty.hard.rawValue }.count
+        case .writeNote:
+            return fetch(FetchDescriptor<JournalEntry>()).filter {
+                $0.createdAt >= start && $0.createdAt <= end
+            }.count
+        case .comboChain:
+            return combo.count
+        case .noSnooze:
+            return 0
+        }
+    }
+
+    /// Encaisse la récompense d'une quête bouclée.
+    @discardableResult
+    func claim(_ quest: QuestRecord) -> Bool {
+        guard quest.isComplete, !quest.isClaimed else { return false }
+        let player = profile()
+        quest.isClaimed = true
+        player.totalXP += quest.xpReward
+        player.coins += quest.coinReward
+        player.gems += quest.gemReward
+        player.coinsEarned += quest.coinReward
+        player.gemsEarned += quest.gemReward
+        player.questsCompleted += 1
+        save()
+        return true
+    }
+
+    private func isTargetedByActiveQuest(_ task: TaskItem) -> Bool {
+        todayQuests().contains { quest in
+            guard !quest.isComplete else { return false }
+            switch quest.kind {
+            case .completeHighPriority:
+                return task.priority == .p1 || task.priority == .p2
+            case .defeatBoss:
+                return task.isBoss
+            case .completeInArea:
+                return quest.lifeArea != nil && task.lifeArea == quest.lifeArea
+            case .completeDifficult:
+                return task.difficulty.rawValue >= Difficulty.hard.rawValue
+            case .completeHabit:
+                return task.isRecurring
+            default:
+                return false
+            }
+        }
+    }
+
+    // MARK: - Hauts faits
+
+    func playerSnapshot() -> PlayerSnapshot {
+        let player = profile()
+        var byArea: [LifeArea: Int] = [:]
+        for event in completionEvents() {
+            if let area = event.lifeArea {
+                byArea[area, default: 0] += 1
+            }
+        }
+        return player.snapshot(currentStreak: streak.current, completionsByArea: byArea, calendar: calendar)
+    }
+
+    @discardableResult
+    func grantNewAchievements(player: PlayerProfile) -> [AchievementDefinition] {
+        let snapshot = playerSnapshot()
+        let known = Set(player.unlockedAchievements.keys)
+        let unlocked = AchievementEngine.newlyUnlocked(snapshot: snapshot, alreadyUnlocked: known)
+        guard !unlocked.isEmpty else { return [] }
+
+        var dates = player.unlockedAchievements
+        for definition in unlocked {
+            dates[definition.id] = Date()
+            player.totalXP += definition.xpReward
+            player.coins += definition.coinReward
+            player.gems += definition.gemReward
+            player.coinsEarned += definition.coinReward
+            player.gemsEarned += definition.gemReward
+        }
+        player.unlockedAchievements = dates
+        save()
+        return unlocked
+    }
+
+    func achievementProgress() -> [AchievementProgress] {
+        AchievementEngine.evaluate(
+            snapshot: playerSnapshot(),
+            unlockDates: profile().unlockedAchievements
+        )
+    }
+
+    // MARK: - Boutique
+
+    @discardableResult
+    func purchase(_ item: ShopItem) -> Bool {
+        let player = profile()
+        guard player.level >= item.requiredLevel else { return false }
+        if !item.isConsumable && player.owns(itemID: item.id) { return false }
+
+        var wallet = player.wallet
+        guard wallet.spend(item.price) else { return false }
+        player.wallet = wallet
+        player.coinsSpent += item.price.coins
+
+        apply(effect: item.effect, to: player)
+        if !item.isConsumable {
+            player.unlockedItems.append(item.id)
+        }
+        save()
+        _ = grantNewAchievements(player: player)
+        return true
+    }
+
+    func apply(effect: ShopEffect, to player: PlayerProfile) {
+        switch effect {
+        case .xpBoost(let multiplier, let hours):
+            player.boostMultiplier = multiplier
+            player.boostExpiresAt = Date().addingTimeInterval(TimeInterval(hours * 3600))
+        case .streakFreeze(let count):
+            player.streakFreezes += count
+        case .restDayToken(let count):
+            player.restDayTokens += count
+        case .unlockTheme(let id):
+            if !player.unlockedItems.contains("theme.\(id)") {
+                player.unlockedItems.append("theme.\(id)")
+            }
+        case .unlockAvatarPart(let id):
+            if !player.unlockedItems.contains(id) {
+                player.unlockedItems.append(id)
+            }
+        case .openChest(let tier):
+            let seed = UInt64(abs(Date().timeIntervalSince1970.hashValue % 1_000_000))
+            for drop in LootEngine.openChest(tier: tier, seed: seed) {
+                apply(effect: drop.effect, to: player)
+            }
+        case .coinPouch(let amount):
+            player.coins += amount
+            player.coinsEarned += amount
+        }
+    }
+
+    func equip(part: AvatarPart, on player: PlayerProfile) {
+        var loadout = player.avatarLoadout
+        loadout[part.slot.rawValue] = part.id
+        player.avatarLoadout = loadout
+        save()
+    }
+
+    // MARK: - Statistiques
+
+    func currentStats(days: Int = 30) -> ProductivityStats {
+        let end = Date()
+        let start = end.adding(days: -max(1, days), calendar: calendar)
+        return StatsEngine.compute(
+            records: completionEvents().map(\.record),
+            from: start,
+            to: end,
+            calendar: calendar
+        )
+    }
+
+    func heatmapCells(months: Int = 12) -> [HeatmapCell] {
+        let end = calendar.startOfDay(for: Date())
+        let start = calendar.date(byAdding: .month, value: -months, to: end) ?? end
+        var counts: [Date: Int] = [:]
+        for event in completionEvents() {
+            let day = calendar.startOfDay(for: event.date)
+            counts[day, default: 0] += 1
+        }
+        return StreakEngine.heatmap(completionsByDay: counts, from: start, to: end, calendar: calendar)
+    }
+
+    // MARK: - Planification automatique
+
+    func autoPlanToday(workingHours: WorkingHours) -> PlanResult {
+        let today = Date()
+        let candidates = openTasks()
+            .filter { task in
+                guard let due = task.dueDate else { return false }
+                return calendar.startOfDay(for: due) <= calendar.startOfDay(for: today)
+            }
+            .filter { $0.scheduledBlocks.isEmpty }
+            .map { task in
+                PlannableTask(
+                    id: task.identifier.uuidString,
+                    title: task.title,
+                    estimatedMinutes: task.estimatedMinutes > 0 ? task.estimatedMinutes : 30,
+                    priority: task.priority,
+                    difficulty: task.difficulty,
+                    energy: task.energy,
+                    dueDate: task.dueDate,
+                    isBoss: task.isBoss
+                )
+            }
+
+        let busy = blocks(on: today).map {
+            BusyInterval(id: $0.identifier.uuidString, start: $0.start, end: $0.end, title: $0.title)
+        }
+
+        return ScheduleEngine.autoPlan(
+            tasks: candidates,
+            on: today,
+            busy: busy,
+            workingHours: workingHours,
+            notBefore: today,
+            calendar: calendar
+        )
+    }
+
+    func applyPlan(_ plan: PlanResult) {
+        let tasksByID = Dictionary(
+            allTasks().map { ($0.identifier.uuidString, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        for block in plan.blocks {
+            guard let task = tasksByID[block.taskID] else { continue }
+            schedule(task, at: block.start, minutes: Int(block.end.timeIntervalSince(block.start) / 60))
+        }
+    }
+
+    func blocks(on day: Date) -> [TimeBlock] {
+        fetch(FetchDescriptor<TimeBlock>()).filter { calendar.isSameDay($0.start, day) }
+            .sorted { $0.start < $1.start }
+    }
+
+    // MARK: - Journal
+
+    @discardableResult
+    func writeJournal(text: String, mood: Int, on day: Date = Date()) -> JournalEntry {
+        let entry = JournalEntry(day: calendar.startOfDay(for: day), text: text, mood: mood)
+        modelContext.insert(entry)
+        profile().notesWritten += 1
+        save()
+        _ = refreshQuestProgress()
+        return entry
+    }
+
+    // MARK: - Maintenance
+
+    /// Bascule les quêtes en retard vers aujourd'hui, à la demande.
+    func rescheduleOverdueToToday() {
+        let today = Date()
+        for task in openTasks() where task.isOverdue(now: today, calendar: calendar) {
+            snooze(task, to: today, keepTime: task.hasTime)
+        }
+    }
+
+    func consumeCelebration() -> RewardBundle? {
+        guard !pendingCelebrations.isEmpty else { return nil }
+        return pendingCelebrations.removeFirst()
+    }
+}

--- a/QuestlyApp/Questly/Data/TaskModels.swift
+++ b/QuestlyApp/Questly/Data/TaskModels.swift
@@ -1,0 +1,358 @@
+import Foundation
+import SwiftData
+import QuestlyKit
+
+// MARK: - Quête
+
+/// Une quête : l'unité de base de l'app. Le vocabulaire du jeu remplace
+/// « tâche » côté interface, mais le modèle reste une todo classique enrichie.
+///
+/// Toutes les propriétés ont une valeur par défaut et aucune contrainte
+/// d'unicité n'est déclarée : c'est la condition pour que la synchronisation
+/// iCloud (CloudKit) puisse être activée sans migration.
+@Model
+final class TaskItem {
+
+    var identifier: UUID = UUID()
+    var title: String = ""
+    var notes: String = ""
+
+    var createdAt: Date = Date()
+    var updatedAt: Date = Date()
+    var dueDate: Date?
+    var startDate: Date?
+    var completedAt: Date?
+
+    /// `false` = échéance « toute la journée ».
+    var hasTime: Bool = false
+    var estimatedMinutes: Int = 0
+    var focusedMinutes: Int = 0
+
+    var priorityRaw: Int = Priority.p4.rawValue
+    var difficultyRaw: Int = Difficulty.medium.rawValue
+    var energyRaw: Int = EnergyLevel.medium.rawValue
+    var statusRaw: Int = TaskStatus.inbox.rawValue
+    var lifeAreaRaw: String?
+
+    var isBoss: Bool = false
+    var isFlagged: Bool = false
+    /// Position manuelle dans les listes réordonnables.
+    var sortIndex: Double = 0
+
+    /// Règle de répétition encodée en JSON : robuste et indépendant du schéma.
+    var recurrenceData: Data?
+    /// Point de départ de la série, figé à la création.
+    var recurrenceAnchor: Date?
+    /// Nombre de fois où la quête récurrente a déjà été bouclée.
+    var recurrenceCount: Int = 0
+
+    var reminderMinutesBefore: Int?
+    /// XP réellement gagné au moment de la validation.
+    var earnedXP: Int = 0
+
+    @Relationship(deleteRule: .cascade, inverse: \Subtask.task)
+    var subtasks: [Subtask]? = []
+
+    @Relationship(deleteRule: .cascade, inverse: \TimeBlock.task)
+    var blocks: [TimeBlock]? = []
+
+    var project: Project?
+    var tags: [Tag]? = []
+
+    init(
+        title: String = "",
+        notes: String = "",
+        dueDate: Date? = nil,
+        hasTime: Bool = false,
+        estimatedMinutes: Int = 0,
+        priority: Priority = .p4,
+        difficulty: Difficulty = .medium,
+        energy: EnergyLevel = .medium,
+        status: TaskStatus = .inbox,
+        lifeArea: LifeArea? = nil,
+        isBoss: Bool = false,
+        project: Project? = nil
+    ) {
+        self.identifier = UUID()
+        self.title = title
+        self.notes = notes
+        self.createdAt = Date()
+        self.updatedAt = Date()
+        self.dueDate = dueDate
+        self.hasTime = hasTime
+        self.estimatedMinutes = estimatedMinutes
+        self.priorityRaw = priority.rawValue
+        self.difficultyRaw = difficulty.rawValue
+        self.energyRaw = energy.rawValue
+        self.statusRaw = status.rawValue
+        self.lifeAreaRaw = lifeArea?.rawValue
+        self.isBoss = isBoss
+        self.project = project
+        self.sortIndex = Date().timeIntervalSince1970
+    }
+}
+
+// MARK: - Accesseurs typés
+
+extension TaskItem {
+
+    var priority: Priority {
+        get { Priority(rawValue: priorityRaw) ?? .p4 }
+        set { priorityRaw = newValue.rawValue }
+    }
+
+    var difficulty: Difficulty {
+        get { Difficulty(rawValue: difficultyRaw) ?? .medium }
+        set { difficultyRaw = newValue.rawValue }
+    }
+
+    var energy: EnergyLevel {
+        get { EnergyLevel(rawValue: energyRaw) ?? .medium }
+        set { energyRaw = newValue.rawValue }
+    }
+
+    var status: TaskStatus {
+        get { TaskStatus(rawValue: statusRaw) ?? .inbox }
+        set { statusRaw = newValue.rawValue }
+    }
+
+    var lifeArea: LifeArea? {
+        get { lifeAreaRaw.flatMap { LifeArea(rawValue: $0) } }
+        set { lifeAreaRaw = newValue?.rawValue }
+    }
+
+    var recurrence: RecurrenceRule? {
+        get {
+            guard let recurrenceData else { return nil }
+            return try? JSONDecoder().decode(RecurrenceRule.self, from: recurrenceData)
+        }
+        set {
+            recurrenceData = newValue.flatMap { try? JSONEncoder().encode($0) }
+            if newValue != nil && recurrenceAnchor == nil {
+                recurrenceAnchor = dueDate ?? Date()
+            }
+            if newValue == nil {
+                recurrenceAnchor = nil
+            }
+        }
+    }
+
+    var isRecurring: Bool { recurrenceData != nil }
+
+    var orderedSubtasks: [Subtask] {
+        (subtasks ?? []).sorted { $0.sortIndex < $1.sortIndex }
+    }
+
+    var sortedTags: [Tag] {
+        (tags ?? []).sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    var scheduledBlocks: [TimeBlock] {
+        (blocks ?? []).sorted { $0.start < $1.start }
+    }
+
+    var isCompleted: Bool { status == .completed }
+    var isOpen: Bool { status.isOpen }
+
+    var completedSubtaskCount: Int { orderedSubtasks.filter(\.isDone).count }
+
+    /// Avancement basé sur les sous-quêtes, sinon 0 ou 1.
+    var progress: Double {
+        let all = orderedSubtasks
+        guard !all.isEmpty else { return isCompleted ? 1 : 0 }
+        return Double(all.filter(\.isDone).count) / Double(all.count)
+    }
+
+    func isOverdue(now: Date = Date(), calendar: Calendar = .questly()) -> Bool {
+        guard isOpen, let dueDate else { return false }
+        if hasTime { return dueDate < now }
+        return calendar.startOfDay(for: dueDate) < calendar.startOfDay(for: now)
+    }
+
+    func isDue(on day: Date, calendar: Calendar = .questly()) -> Bool {
+        guard let dueDate else { return false }
+        return calendar.isSameDay(dueDate, day)
+    }
+
+    func isDueToday(now: Date = Date(), calendar: Calendar = .questly()) -> Bool {
+        isDue(on: now, calendar: calendar)
+    }
+
+    /// Descripteur consommé par le moteur d'XP.
+    func xpDescriptor() -> XPTaskDescriptor {
+        XPTaskDescriptor(
+            difficulty: difficulty,
+            priority: priority,
+            estimatedMinutes: estimatedMinutes > 0 ? estimatedMinutes : nil,
+            completedSubtaskCount: completedSubtaskCount,
+            totalSubtaskCount: orderedSubtasks.count,
+            dueDate: dueDate,
+            hasTimeComponent: hasTime,
+            isBoss: isBoss,
+            lifeArea: lifeArea,
+            focusedMinutes: focusedMinutes,
+            isHabit: isRecurring
+        )
+    }
+
+    /// XP annoncé sur la fiche, avant validation.
+    var previewXP: Int {
+        XPEngine.previewXP(for: xpDescriptor())
+    }
+
+    /// Points de vie du boss, en minutes de concentration restantes.
+    var bossRemainingHP: Int {
+        max(0, difficulty.bossHitPoints - focusedMinutes)
+    }
+
+    var bossHealthFraction: Double {
+        let total = Double(difficulty.bossHitPoints)
+        guard total > 0 else { return 0 }
+        return max(0, min(1, Double(bossRemainingHP) / total))
+    }
+
+    func touch() {
+        updatedAt = Date()
+    }
+}
+
+// MARK: - Sous-quête
+
+@Model
+final class Subtask {
+    var identifier: UUID = UUID()
+    var title: String = ""
+    var isDone: Bool = false
+    var sortIndex: Double = 0
+    var completedAt: Date?
+    var task: TaskItem?
+
+    init(title: String = "", sortIndex: Double = 0) {
+        self.identifier = UUID()
+        self.title = title
+        self.sortIndex = sortIndex
+    }
+}
+
+// MARK: - Projet
+
+/// Un projet regroupe des quêtes et se comporte comme une « campagne » :
+/// il a une barre de progression, une couleur et une date cible.
+@Model
+final class Project {
+    var identifier: UUID = UUID()
+    var name: String = ""
+    var emoji: String = "📁"
+    var colorHex: String = "5E5CE6"
+    var notes: String = ""
+    var isArchived: Bool = false
+    var sortIndex: Double = 0
+    var createdAt: Date = Date()
+    var targetDate: Date?
+    var lifeAreaRaw: String?
+
+    @Relationship(deleteRule: .nullify, inverse: \TaskItem.project)
+    var tasks: [TaskItem]? = []
+
+    init(
+        name: String = "",
+        emoji: String = "📁",
+        colorHex: String = "5E5CE6",
+        targetDate: Date? = nil,
+        lifeArea: LifeArea? = nil
+    ) {
+        self.identifier = UUID()
+        self.name = name
+        self.emoji = emoji
+        self.colorHex = colorHex
+        self.targetDate = targetDate
+        self.lifeAreaRaw = lifeArea?.rawValue
+        self.createdAt = Date()
+        self.sortIndex = Date().timeIntervalSince1970
+    }
+
+    var lifeArea: LifeArea? {
+        get { lifeAreaRaw.flatMap { LifeArea(rawValue: $0) } }
+        set { lifeAreaRaw = newValue?.rawValue }
+    }
+
+    var allTasks: [TaskItem] { tasks ?? [] }
+    var openTasks: [TaskItem] { allTasks.filter(\.isOpen) }
+    var completedTasks: [TaskItem] { allTasks.filter(\.isCompleted) }
+
+    var progress: Double {
+        let total = allTasks.count
+        guard total > 0 else { return 0 }
+        return Double(completedTasks.count) / Double(total)
+    }
+
+    var isComplete: Bool {
+        !allTasks.isEmpty && openTasks.isEmpty
+    }
+}
+
+// MARK: - Étiquette
+
+@Model
+final class Tag {
+    var identifier: UUID = UUID()
+    var name: String = ""
+    var colorHex: String = "BF5AF2"
+    var createdAt: Date = Date()
+
+    @Relationship(inverse: \TaskItem.tags)
+    var tasks: [TaskItem]? = []
+
+    init(name: String = "", colorHex: String = "BF5AF2") {
+        self.identifier = UUID()
+        self.name = name
+        self.colorHex = colorHex
+        self.createdAt = Date()
+    }
+
+    var openTaskCount: Int { (tasks ?? []).filter(\.isOpen).count }
+}
+
+// MARK: - Bloc de temps
+
+/// Un créneau posé dans le calendrier. Il peut porter une quête (time-blocking)
+/// ou refléter un évènement du calendrier système.
+@Model
+final class TimeBlock {
+    var identifier: UUID = UUID()
+    var title: String = ""
+    var start: Date = Date()
+    var end: Date = Date().addingTimeInterval(3600)
+    var colorHex: String = "5E5CE6"
+    var notes: String = ""
+    /// Miroir en lecture seule d'un évènement EventKit.
+    var isExternal: Bool = false
+    var externalIdentifier: String?
+    var isAllDay: Bool = false
+    var task: TaskItem?
+
+    init(
+        title: String = "",
+        start: Date = Date(),
+        end: Date = Date().addingTimeInterval(3600),
+        colorHex: String = "5E5CE6",
+        task: TaskItem? = nil,
+        isAllDay: Bool = false
+    ) {
+        self.identifier = UUID()
+        self.title = title
+        self.start = start
+        self.end = end
+        self.colorHex = colorHex
+        self.task = task
+        self.isAllDay = isAllDay
+    }
+
+    var durationMinutes: Int {
+        max(0, Int(end.timeIntervalSince(start) / 60))
+    }
+
+    func overlaps(_ other: TimeBlock) -> Bool {
+        start < other.end && other.start < end
+    }
+}

--- a/QuestlyApp/Questly/DesignSystem/Components/Badges.swift
+++ b/QuestlyApp/Questly/DesignSystem/Components/Badges.swift
@@ -1,0 +1,299 @@
+import SwiftUI
+import QuestlyKit
+
+// MARK: - Priorité
+
+struct PriorityBadge: View {
+    let priority: Priority
+    var compact: Bool = false
+
+    var body: some View {
+        let color = Color(hex: priority.hex)
+        HStack(spacing: 3) {
+            Image(systemName: priority.symbolName)
+                .font(.system(size: compact ? 9 : 11, weight: .bold))
+            if !compact {
+                Text(priority.shortLabel)
+                    .font(.questMicro)
+            }
+        }
+        .foregroundStyle(color)
+        .padding(.horizontal, compact ? 5 : 7)
+        .padding(.vertical, compact ? 3 : 4)
+        .background {
+            Capsule().fill(color.opacity(0.16))
+        }
+    }
+}
+
+// MARK: - Difficulté
+
+struct DifficultyBadge: View {
+    let difficulty: Difficulty
+    var showsLabel: Bool = true
+
+    var body: some View {
+        let color = Color(hex: difficulty.hex)
+        HStack(spacing: 4) {
+            Image(systemName: difficulty.symbolName)
+                .font(.system(size: 10, weight: .semibold))
+            if showsLabel {
+                Text(difficulty.label)
+                    .font(.questMicro)
+            }
+        }
+        .foregroundStyle(color)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 4)
+        .background { Capsule().fill(color.opacity(0.16)) }
+    }
+}
+
+// MARK: - Domaine de vie
+
+struct LifeAreaBadge: View {
+    let area: LifeArea
+    var compact: Bool = false
+
+    var body: some View {
+        let color = Color(hex: area.hex)
+        HStack(spacing: 4) {
+            Image(systemName: area.symbolName)
+                .font(.system(size: compact ? 9 : 11, weight: .semibold))
+            if !compact {
+                Text(area.label).font(.questMicro)
+            }
+        }
+        .foregroundStyle(color)
+        .padding(.horizontal, compact ? 5 : 7)
+        .padding(.vertical, compact ? 3 : 4)
+        .background { Capsule().fill(color.opacity(0.16)) }
+    }
+}
+
+// MARK: - Étiquette
+
+struct TagChip: View {
+    let name: String
+    let colorHex: String
+    var isSelected: Bool = false
+
+    var body: some View {
+        let color = Color(hex: colorHex)
+        Text("#\(name)")
+            .font(.questMicro)
+            .foregroundStyle(isSelected ? .white : color)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background {
+                Capsule().fill(isSelected ? color : color.opacity(0.16))
+            }
+    }
+}
+
+// MARK: - Rareté
+
+struct RarityChip: View {
+    let rarity: Rarity
+
+    var body: some View {
+        let color = Color(hex: rarity.hex)
+        Text(rarity.label.uppercased())
+            .font(.system(size: 9, weight: .heavy, design: .rounded))
+            .kerning(0.6)
+            .foregroundStyle(color)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background {
+                Capsule()
+                    .fill(color.opacity(0.18))
+                    .overlay { Capsule().strokeBorder(color.opacity(0.5), lineWidth: 0.8) }
+            }
+    }
+}
+
+// MARK: - Monnaies
+
+struct CurrencyPill: View {
+    enum Kind {
+        case coins
+        case gems
+
+        var symbolName: String {
+            switch self {
+            case .coins: return "dollarsign.circle.fill"
+            case .gems: return "diamond.fill"
+            }
+        }
+
+        var color: Color {
+            switch self {
+            case .coins: return Color(hex: "FFD60A")
+            case .gems: return Color(hex: "64D2FF")
+            }
+        }
+    }
+
+    let kind: Kind
+    let amount: Int
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: kind.symbolName)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(kind.color)
+            Text("\(amount)")
+                .font(.questCaption)
+                .monospacedDigit()
+                .contentTransition(.numericText())
+        }
+        .padding(.horizontal, 9)
+        .padding(.vertical, 5)
+        .background { Capsule().fill(.ultraThinMaterial) }
+        .overlay { Capsule().strokeBorder(kind.color.opacity(0.25), lineWidth: 1) }
+    }
+}
+
+// MARK: - Pastille d'XP
+
+struct XPPill: View {
+    let amount: Int
+    var isPreview: Bool = false
+
+    @Environment(\.questlyTheme) private var theme
+
+    var body: some View {
+        HStack(spacing: 3) {
+            Image(systemName: "bolt.fill")
+                .font(.system(size: 9, weight: .bold))
+            Text(isPreview ? "+\(amount)" : "\(amount)")
+                .font(.questMicro)
+                .monospacedDigit()
+        }
+        .foregroundStyle(isPreview ? theme.accent : .white)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .background {
+            Capsule()
+                .fill(isPreview
+                      ? AnyShapeStyle(theme.accent.opacity(0.16))
+                      : AnyShapeStyle(theme.gradient))
+        }
+    }
+}
+
+// MARK: - Indicateur de combo
+
+/// Apparaît en haut de l'écran quand plusieurs quêtes s'enchaînent.
+struct ComboIndicator: View {
+    let count: Int
+    let remainingSeconds: Int
+
+    @Environment(\.questlyTheme) private var theme
+    @State private var appeared = false
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "bolt.fill")
+                .font(.system(size: 15, weight: .heavy))
+                .foregroundStyle(Color(hex: "FFD60A"))
+                .symbolEffect(.bounce, value: count)
+
+            Text("COMBO ×\(count)")
+                .font(.system(size: 14, weight: .heavy, design: .rounded))
+                .kerning(0.8)
+                .foregroundStyle(.white)
+
+            Text("+\(Int((XPEngine.comboMultiplier(count: count) - 1) * 100)) %")
+                .font(.questMicro)
+                .foregroundStyle(.white.opacity(0.8))
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 9)
+        .background {
+            Capsule()
+                .fill(
+                    LinearGradient(
+                        colors: [Color(hex: "FF9F0A"), Color(hex: "FF375F")],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                )
+        }
+        .overlay(alignment: .bottom) {
+            // Sablier du combo.
+            GeometryReader { geo in
+                Capsule()
+                    .fill(.white.opacity(0.9))
+                    .frame(
+                        width: geo.size.width * min(1, Double(remainingSeconds) / XPEngine.comboWindow),
+                        height: 2
+                    )
+            }
+            .frame(height: 2)
+            .padding(.horizontal, 10)
+            .padding(.bottom, 3)
+        }
+        .glow(Color(hex: "FF9F0A"), radius: 14, opacity: 0.6)
+        .scaleEffect(appeared ? 1 : 0.7)
+        .opacity(appeared ? 1 : 0)
+        .onAppear {
+            withAnimation(Motion.bouncy) { appeared = true }
+        }
+    }
+}
+
+// MARK: - Case à cocher de quête
+
+/// La case à cocher est le geste le plus répété de l'app : elle mérite sa
+/// propre animation (remplissage + pointe qui se dessine).
+struct QuestCheckbox: View {
+    let isCompleted: Bool
+    let tint: Color
+    var size: CGFloat = 26
+    var isBoss: Bool = false
+    let action: () -> Void
+
+    @State private var isAnimating = false
+
+    var body: some View {
+        Button(action: {
+            isAnimating = true
+            action()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { isAnimating = false }
+        }) {
+            ZStack {
+                if isBoss {
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .strokeBorder(tint.opacity(isCompleted ? 0 : 0.7), lineWidth: 2)
+                        .frame(width: size, height: size)
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .fill(tint)
+                        .frame(width: size, height: size)
+                        .scaleEffect(isCompleted ? 1 : 0)
+                } else {
+                    Circle()
+                        .strokeBorder(tint.opacity(isCompleted ? 0 : 0.55), lineWidth: 2)
+                        .frame(width: size, height: size)
+                    Circle()
+                        .fill(tint)
+                        .frame(width: size, height: size)
+                        .scaleEffect(isCompleted ? 1 : 0)
+                }
+
+                Image(systemName: isBoss ? "crown.fill" : "checkmark")
+                    .font(.system(size: size * 0.5, weight: .heavy))
+                    .foregroundStyle(.white)
+                    .scaleEffect(isCompleted ? 1 : 0.2)
+                    .opacity(isCompleted ? 1 : 0)
+            }
+            .scaleEffect(isAnimating ? 1.25 : 1)
+            .animation(Motion.bouncy, value: isCompleted)
+            .animation(Motion.snappy, value: isAnimating)
+            .contentShape(Rectangle())
+            .frame(width: size + 12, height: size + 12)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(isCompleted ? "Marquer comme non accomplie" : "Accomplir la quête")
+    }
+}

--- a/QuestlyApp/Questly/DesignSystem/Components/CelebrationOverlay.swift
+++ b/QuestlyApp/Questly/DesignSystem/Components/CelebrationOverlay.swift
@@ -1,0 +1,262 @@
+import SwiftUI
+import QuestlyKit
+
+// MARK: - Contenu célébré
+
+/// Un évènement à célébrer. Les célébrations sont mises en file : on ne
+/// superpose jamais deux fanfares.
+enum Celebration: Identifiable, Equatable {
+    case levelUp(level: Int, rank: Rank?)
+    case achievement(AchievementDefinition)
+    case streakMilestone(days: Int)
+    case questCompleted(title: String)
+    case attributeLevelUp(area: LifeArea, level: Int)
+    case loot([LootDrop])
+
+    var id: String {
+        switch self {
+        case .levelUp(let level, _): return "level.\(level)"
+        case .achievement(let definition): return "achievement.\(definition.id)"
+        case .streakMilestone(let days): return "streak.\(days)"
+        case .questCompleted(let title): return "quest.\(title)"
+        case .attributeLevelUp(let area, let level): return "attr.\(area.rawValue).\(level)"
+        case .loot(let drops): return "loot." + drops.map(\.id).joined(separator: "-")
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .levelUp(let level, _): return "Niveau \(level) !"
+        case .achievement(let definition): return definition.title
+        case .streakMilestone(let days): return "\(days) jours d'affilée"
+        case .questCompleted: return "Quête du jour bouclée"
+        case .attributeLevelUp(let area, let level): return "\(area.label) niveau \(level)"
+        case .loot: return "Butin !"
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .levelUp(_, let rank):
+            if let rank { return "Nouveau rang : \(rank.title)" }
+            return "Ta légende s'écrit."
+        case .achievement(let definition):
+            return definition.detail
+        case .streakMilestone(let days):
+            return "Multiplicateur ×\(String(format: "%.2f", XPEngine.streakMultiplier(days: days))) sur chaque quête."
+        case .questCompleted(let title):
+            return title
+        case .attributeLevelUp(let area, _):
+            return area.subtitle
+        case .loot(let drops):
+            return drops.map(\.name).joined(separator: " · ")
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .levelUp(_, let rank): return rank?.symbolName ?? "arrow.up.circle.fill"
+        case .achievement(let definition): return definition.symbolName
+        case .streakMilestone: return "flame.fill"
+        case .questCompleted: return "scroll.fill"
+        case .attributeLevelUp(let area, _): return area.symbolName
+        case .loot: return "shippingbox.fill"
+        }
+    }
+
+    var accentHex: String {
+        switch self {
+        case .levelUp(_, let rank): return rank?.hex ?? "FFD60A"
+        case .achievement(let definition): return definition.rarity.hex
+        case .streakMilestone: return "FF7A00"
+        case .questCompleted: return "5E5CE6"
+        case .attributeLevelUp(let area, _): return area.hex
+        case .loot(let drops): return (drops.map(\.rarity).max() ?? .common).hex
+        }
+    }
+
+    var rarity: Rarity? {
+        switch self {
+        case .achievement(let definition): return definition.rarity
+        case .loot(let drops): return drops.map(\.rarity).max()
+        default: return nil
+        }
+    }
+
+    /// Les grands moments méritent des confettis ; les petits, une simple carte.
+    var deservesConfetti: Bool {
+        switch self {
+        case .levelUp, .streakMilestone: return true
+        case .achievement(let definition): return definition.rarity >= .rare
+        case .loot(let drops): return (drops.map(\.rarity).max() ?? .common) >= .epic
+        default: return false
+        }
+    }
+}
+
+// MARK: - Superposition
+
+/// La fanfare : carte centrale, rayons, confettis, disparition automatique.
+struct CelebrationOverlay: View {
+    let celebration: Celebration
+    var confettiEnabled: Bool = true
+    let onDismiss: () -> Void
+
+    @Environment(\.questlyTheme) private var theme
+    @State private var appeared = false
+
+    private var accent: Color { Color(hex: celebration.accentHex) }
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(appeared ? 0.45 : 0)
+                .ignoresSafeArea()
+                .onTapGesture { dismiss() }
+
+            if celebration.deservesConfetti {
+                RadiantBurst(color: accent)
+                    .frame(width: 400, height: 400)
+                    .opacity(appeared ? 1 : 0)
+            }
+
+            card
+                .scaleEffect(appeared ? 1 : 0.7)
+                .opacity(appeared ? 1 : 0)
+
+            if confettiEnabled && celebration.deservesConfetti {
+                ConfettiView(pieceCount: 110, duration: 2.8)
+                    .ignoresSafeArea()
+            }
+        }
+        .onAppear {
+            withAnimation(Motion.celebration) { appeared = true }
+            Haptics.play(hapticEvent)
+            // Disparition automatique : on ne bloque jamais l'utilisateur.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3.4) { dismiss() }
+        }
+    }
+
+    private var hapticEvent: Haptics.Event {
+        switch celebration {
+        case .levelUp: return .levelUp
+        case .achievement: return .success
+        case .streakMilestone: return .heavy
+        default: return .questComplete
+        }
+    }
+
+    private var card: some View {
+        VStack(spacing: Metrics.spacingM) {
+            ZStack {
+                Circle()
+                    .fill(
+                        RadialGradient(
+                            colors: [accent.opacity(0.55), accent.opacity(0.05)],
+                            center: .center,
+                            startRadius: 4,
+                            endRadius: 70
+                        )
+                    )
+                    .frame(width: 130, height: 130)
+
+                Image(systemName: celebration.symbolName)
+                    .font(.system(size: 56, weight: .bold))
+                    .foregroundStyle(
+                        LinearGradient(
+                            colors: [accent, accent.opacity(0.7)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+                    .glow(accent, radius: 18, opacity: 0.8)
+                    .symbolEffect(.bounce, value: appeared)
+            }
+
+            if let rarity = celebration.rarity {
+                RarityChip(rarity: rarity)
+            }
+
+            Text(celebration.title)
+                .font(.questTitle)
+                .multilineTextAlignment(.center)
+                .shimmer(active: celebration.deservesConfetti)
+
+            Text(celebration.message)
+                .font(.questCallout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, Metrics.spacingM)
+
+            Button("Continuer") { dismiss() }
+                .buttonStyle(PrimaryButtonStyle(theme: theme))
+                .padding(.top, Metrics.spacingXS)
+        }
+        .padding(Metrics.spacingL)
+        .frame(maxWidth: 320)
+        .background {
+            RoundedRectangle(cornerRadius: Metrics.cornerRadiusLarge, style: .continuous)
+                .fill(.regularMaterial)
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: Metrics.cornerRadiusLarge, style: .continuous)
+                .strokeBorder(accent.opacity(0.4), lineWidth: 1.5)
+        }
+        .shadow(color: accent.opacity(0.35), radius: 30, x: 0, y: 12)
+        .padding(Metrics.spacingL)
+    }
+
+    private func dismiss() {
+        guard appeared else { return }
+        withAnimation(Motion.snappy) { appeared = false }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25, execute: onDismiss)
+    }
+}
+
+// MARK: - Bandeau discret
+
+/// Pour les petites nouvelles (XP gagné, quête avancée) : un bandeau qui
+/// glisse depuis le haut sans interrompre.
+struct RewardToast: View {
+    let symbolName: String
+    let title: String
+    let detail: String
+    let accentHex: String
+
+    @State private var appeared = false
+
+    var body: some View {
+        HStack(spacing: Metrics.spacingS) {
+            Image(systemName: symbolName)
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(Color(hex: accentHex))
+                .frame(width: 34, height: 34)
+                .background {
+                    Circle().fill(Color(hex: accentHex).opacity(0.16))
+                }
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title).font(.questCallout)
+                Text(detail)
+                    .font(.questMicro)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, Metrics.spacingM)
+        .padding(.vertical, Metrics.spacingS)
+        .background {
+            Capsule().fill(.regularMaterial)
+        }
+        .overlay {
+            Capsule().strokeBorder(Color(hex: accentHex).opacity(0.25), lineWidth: 1)
+        }
+        .shadow(color: .black.opacity(0.18), radius: 12, y: 6)
+        .padding(.horizontal, Metrics.spacingL)
+        .offset(y: appeared ? 0 : -100)
+        .opacity(appeared ? 1 : 0)
+        .onAppear {
+            withAnimation(Motion.bouncy) { appeared = true }
+        }
+    }
+}

--- a/QuestlyApp/Questly/DesignSystem/Components/Effects.swift
+++ b/QuestlyApp/Questly/DesignSystem/Components/Effects.swift
@@ -1,0 +1,247 @@
+import SwiftUI
+import QuestlyKit
+
+// MARK: - Confettis
+
+struct ConfettiPiece: Identifiable {
+    let id: Int
+    let hue: Color
+    let startX: Double
+    let drift: Double
+    let delay: Double
+    let spin: Double
+    let size: Double
+    let isCircle: Bool
+}
+
+/// Confettis dessinés dans un `Canvas` unique : quelques centaines de formes
+/// sans créer une seule vue SwiftUI, donc sans à-coup sur l'animation.
+struct ConfettiView: View {
+    var pieceCount: Int = 90
+    var duration: Double = 2.6
+    var colors: [Color] = [
+        Color(hex: "FF375F"), Color(hex: "FF9F0A"), Color(hex: "FFD60A"),
+        Color(hex: "30D158"), Color(hex: "64D2FF"), Color(hex: "BF5AF2")
+    ]
+    var onFinished: (() -> Void)?
+
+    @State private var startDate = Date()
+    @State private var pieces: [ConfettiPiece] = []
+
+    var body: some View {
+        TimelineView(.animation) { timeline in
+            Canvas { context, size in
+                let elapsed = timeline.date.timeIntervalSince(startDate)
+                for piece in pieces {
+                    let local = elapsed - piece.delay
+                    guard local > 0 else { continue }
+                    let progress = local / duration
+                    guard progress < 1 else { continue }
+
+                    // Chute avec accélération douce et dérive latérale.
+                    let y = -40 + (size.height + 80) * pow(progress, 1.35)
+                    let x = piece.startX * size.width
+                        + sin(progress * 6 + piece.spin) * piece.drift
+                    let opacity = progress > 0.75 ? (1 - progress) * 4 : 1
+                    let rotation = Angle.degrees(progress * 720 * (piece.spin > 3 ? -1 : 1))
+
+                    var layer = context
+                    layer.opacity = opacity
+                    layer.translateBy(x: x, y: y)
+                    layer.rotate(by: rotation)
+
+                    let rect = CGRect(
+                        x: -piece.size / 2,
+                        y: -piece.size / 2,
+                        width: piece.size,
+                        height: piece.size * (piece.isCircle ? 1 : 0.55)
+                    )
+                    let path = piece.isCircle
+                        ? Path(ellipseIn: rect)
+                        : Path(roundedRect: rect, cornerRadius: 1.5)
+                    layer.fill(path, with: .color(piece.hue))
+                }
+            }
+        }
+        .allowsHitTesting(false)
+        .onAppear {
+            pieces = Self.makePieces(count: pieceCount, colors: colors)
+            startDate = Date()
+            if let onFinished {
+                DispatchQueue.main.asyncAfter(deadline: .now() + duration + 0.6, execute: onFinished)
+            }
+        }
+    }
+
+    static func makePieces(count: Int, colors: [Color]) -> [ConfettiPiece] {
+        var rng = SeededRandom(seed: UInt64(count) &* 7919 &+ 13)
+        return (0..<count).map { index in
+            ConfettiPiece(
+                id: index,
+                hue: colors[Int(rng.next(upperBound: UInt64(colors.count)))],
+                startX: rng.nextDouble(),
+                drift: 20 + rng.nextDouble() * 70,
+                delay: rng.nextDouble() * 0.5,
+                spin: rng.nextDouble() * 6.28,
+                size: 6 + rng.nextDouble() * 8,
+                isCircle: rng.nextDouble() > 0.6
+            )
+        }
+    }
+}
+
+// MARK: - Éclat de validation
+
+/// Petite explosion radiale jouée à l'endroit exact où l'on coche une quête.
+struct CompletionBurst: View {
+    var color: Color
+    var particleCount: Int = 14
+    var radius: Double = 34
+    var duration: Double = 0.6
+
+    @State private var progress: Double = 0
+
+    var body: some View {
+        Canvas { context, size in
+            let center = CGPoint(x: size.width / 2, y: size.height / 2)
+            for index in 0..<particleCount {
+                let angle = (Double(index) / Double(particleCount)) * 2 * .pi
+                let distance = radius * progress
+                let point = CGPoint(
+                    x: center.x + cos(angle) * distance,
+                    y: center.y + sin(angle) * distance
+                )
+                let scale = max(0, 1 - progress)
+                let dotSize = 5.0 * scale
+                var layer = context
+                layer.opacity = scale
+                layer.fill(
+                    Path(ellipseIn: CGRect(
+                        x: point.x - dotSize / 2,
+                        y: point.y - dotSize / 2,
+                        width: dotSize,
+                        height: dotSize
+                    )),
+                    with: .color(color)
+                )
+            }
+
+            // Onde de choc.
+            let ringRadius = radius * progress * 1.1
+            var ringLayer = context
+            ringLayer.opacity = max(0, 0.5 - progress * 0.5)
+            ringLayer.stroke(
+                Path(ellipseIn: CGRect(
+                    x: center.x - ringRadius,
+                    y: center.y - ringRadius,
+                    width: ringRadius * 2,
+                    height: ringRadius * 2
+                )),
+                with: .color(color),
+                lineWidth: 2
+            )
+        }
+        .allowsHitTesting(false)
+        .onAppear {
+            withAnimation(.easeOut(duration: duration)) { progress = 1 }
+        }
+    }
+}
+
+// MARK: - Texte flottant
+
+/// « +42 XP » qui s'envole depuis la ligne validée.
+struct FloatingXPText: View {
+    let amount: Int
+    var color: Color = Color(hex: "FFD60A")
+
+    @State private var offset: CGFloat = 0
+    @State private var opacity: Double = 1
+
+    var body: some View {
+        Text("+\(amount) XP")
+            .font(.system(size: 15, weight: .heavy, design: .rounded))
+            .foregroundStyle(color)
+            .glow(color, radius: 8, opacity: 0.7)
+            .offset(y: offset)
+            .opacity(opacity)
+            .onAppear {
+                withAnimation(.easeOut(duration: 1.0)) {
+                    offset = -44
+                    opacity = 0
+                }
+            }
+            .allowsHitTesting(false)
+    }
+}
+
+// MARK: - Halo pulsant
+
+/// Attire l'œil sur un élément sans l'agiter — utilisé pour la quête du jour.
+struct PulsingHalo: View {
+    var color: Color
+    var size: CGFloat = 60
+
+    @State private var animate = false
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(color.opacity(0.5), lineWidth: 2)
+                .scaleEffect(animate ? 1.35 : 1)
+                .opacity(animate ? 0 : 0.8)
+            Circle()
+                .stroke(color.opacity(0.35), lineWidth: 1.5)
+                .scaleEffect(animate ? 1.6 : 1)
+                .opacity(animate ? 0 : 0.5)
+        }
+        .frame(width: size, height: size)
+        .onAppear {
+            withAnimation(.easeOut(duration: 1.9).repeatForever(autoreverses: false)) {
+                animate = true
+            }
+        }
+        .allowsHitTesting(false)
+    }
+}
+
+// MARK: - Effet de rayons
+
+/// Rayons de lumière derrière une montée de niveau.
+struct RadiantBurst: View {
+    var color: Color
+    var rayCount: Int = 16
+
+    @State private var rotation: Double = 0
+    @State private var scale: Double = 0.6
+
+    var body: some View {
+        Canvas { context, size in
+            let center = CGPoint(x: size.width / 2, y: size.height / 2)
+            let maxRadius = min(size.width, size.height) * 0.75 * scale
+            for index in 0..<rayCount {
+                let angle = (Double(index) / Double(rayCount)) * 2 * .pi + rotation
+                var path = Path()
+                path.move(to: center)
+                path.addLine(to: CGPoint(
+                    x: center.x + cos(angle - 0.04) * maxRadius,
+                    y: center.y + sin(angle - 0.04) * maxRadius
+                ))
+                path.addLine(to: CGPoint(
+                    x: center.x + cos(angle + 0.04) * maxRadius,
+                    y: center.y + sin(angle + 0.04) * maxRadius
+                ))
+                path.closeSubpath()
+                context.fill(path, with: .color(color.opacity(0.28)))
+            }
+        }
+        .blur(radius: 6)
+        .allowsHitTesting(false)
+        .onAppear {
+            withAnimation(.linear(duration: 18).repeatForever(autoreverses: false)) {
+                rotation = .pi * 2
+            }
+            withAnimation(.easeOut(duration: 0.8)) { scale = 1 }
+        }
+    }
+}

--- a/QuestlyApp/Questly/DesignSystem/Components/ProgressElements.swift
+++ b/QuestlyApp/Questly/DesignSystem/Components/ProgressElements.swift
@@ -1,0 +1,289 @@
+import SwiftUI
+import QuestlyKit
+
+// MARK: - Barre d'XP
+
+/// Barre d'expérience avec reflet et remplissage animé.
+struct XPBar: View {
+    let progress: LevelProgress
+    var height: CGFloat = 12
+    var showsLabels: Bool = true
+
+    @Environment(\.questlyTheme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(Color.primary.opacity(0.08))
+
+                    Capsule()
+                        .fill(theme.gradient)
+                        .frame(width: max(height, geo.size.width * progress.fraction))
+                        .overlay(alignment: .trailing) {
+                            Circle()
+                                .fill(.white.opacity(0.85))
+                                .frame(width: height * 0.5, height: height * 0.5)
+                                .padding(.trailing, height * 0.25)
+                                .blur(radius: 0.5)
+                        }
+                        .glow(theme.accent, radius: 8, opacity: 0.55)
+                }
+            }
+            .frame(height: height)
+            .animation(Motion.gentle, value: progress.fraction)
+
+            if showsLabels {
+                HStack {
+                    Text("Niv. \(progress.level)")
+                        .font(.questCaption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text("\(progress.xpIntoLevel) / \(progress.xpRequiredForLevel) XP")
+                        .font(.questCaption)
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Anneau de niveau
+
+/// L'avatar du héros dans un anneau de progression : c'est la pièce
+/// d'identité de l'app, présente sur presque tous les écrans.
+struct LevelRing: View {
+    let progress: LevelProgress
+    var size: CGFloat = 74
+    var lineWidth: CGFloat = 6
+    var emoji: String = "🧭"
+    var showsLevelBadge: Bool = true
+
+    @Environment(\.questlyTheme) private var theme
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.primary.opacity(0.08), lineWidth: lineWidth)
+
+            Circle()
+                .trim(from: 0, to: max(0.001, progress.fraction))
+                .stroke(
+                    theme.ringGradient,
+                    style: StrokeStyle(lineWidth: lineWidth, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+                .glow(theme.accent, radius: 6, opacity: 0.5)
+                .animation(Motion.gentle, value: progress.fraction)
+
+            Circle()
+                .fill(.ultraThinMaterial)
+                .padding(lineWidth + 3)
+
+            Text(emoji)
+                .font(.system(size: size * 0.42))
+        }
+        .frame(width: size, height: size)
+        .overlay(alignment: .bottom) {
+            if showsLevelBadge {
+                Text("\(progress.level)")
+                    .font(.questMicro)
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 3)
+                    .background {
+                        Capsule().fill(theme.gradient)
+                    }
+                    .overlay {
+                        Capsule().strokeBorder(Color(.systemBackground), lineWidth: 1.5)
+                    }
+                    .offset(y: 6)
+            }
+        }
+    }
+}
+
+// MARK: - Anneau générique
+
+struct ProgressRing: View {
+    let fraction: Double
+    var size: CGFloat = 44
+    var lineWidth: CGFloat = 5
+    var color: Color = .accentColor
+    var trackOpacity: Double = 0.12
+    var content: AnyView?
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(color.opacity(trackOpacity), lineWidth: lineWidth)
+            Circle()
+                .trim(from: 0, to: max(0.001, min(1, fraction)))
+                .stroke(color, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+                .animation(Motion.gentle, value: fraction)
+            if let content {
+                content
+            }
+        }
+        .frame(width: size, height: size)
+    }
+}
+
+// MARK: - Flamme de série
+
+/// La flamme grossit et change de teinte avec la série. En danger, elle pulse.
+struct StreakFlame: View {
+    let days: Int
+    var isAtRisk: Bool = false
+    var size: CGFloat = 22
+
+    @State private var pulse = false
+
+    private var tint: Color {
+        switch days {
+        case 0: return .gray
+        case 1...6: return Color(hex: "FFB020")
+        case 7...29: return Color(hex: "FF7A00")
+        case 30...99: return Color(hex: "FF3B30")
+        default: return Color(hex: "BF5AF2")
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: days > 0 ? "flame.fill" : "flame")
+                .font(.system(size: size, weight: .semibold))
+                .foregroundStyle(
+                    LinearGradient(
+                        colors: [tint, tint.opacity(0.6)],
+                        startPoint: .bottom,
+                        endPoint: .top
+                    )
+                )
+                .glow(tint, radius: days > 0 ? 8 : 0, opacity: 0.7)
+                .scaleEffect(pulse ? 1.12 : 1)
+                .animation(
+                    isAtRisk
+                        ? .easeInOut(duration: 0.9).repeatForever(autoreverses: true)
+                        : Motion.snappy,
+                    value: pulse
+                )
+
+            Text("\(days)")
+                .font(.questNumber(size * 0.8))
+                .foregroundStyle(tint)
+                .monospacedDigit()
+                .contentTransition(.numericText())
+        }
+        .onAppear { pulse = isAtRisk }
+        .onChange(of: isAtRisk) { _, newValue in pulse = newValue }
+        .accessibilityLabel("Série de \(days) jours")
+    }
+}
+
+// MARK: - Courbe compacte
+
+/// Mini-courbe sans axes, pour glisser une tendance dans une carte.
+struct Sparkline: View {
+    let values: [Double]
+    var color: Color = .accentColor
+    var fills: Bool = true
+
+    var body: some View {
+        GeometryReader { geo in
+            let points = normalizedPoints(in: geo.size)
+            ZStack {
+                if fills, points.count > 1 {
+                    Path { path in
+                        path.move(to: CGPoint(x: points[0].x, y: geo.size.height))
+                        for point in points { path.addLine(to: point) }
+                        path.addLine(to: CGPoint(x: points[points.count - 1].x, y: geo.size.height))
+                        path.closeSubpath()
+                    }
+                    .fill(
+                        LinearGradient(
+                            colors: [color.opacity(0.35), color.opacity(0.02)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+                }
+
+                if points.count > 1 {
+                    Path { path in
+                        path.move(to: points[0])
+                        for point in points.dropFirst() { path.addLine(to: point) }
+                    }
+                    .stroke(color, style: StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round))
+                }
+            }
+        }
+    }
+
+    private func normalizedPoints(in size: CGSize) -> [CGPoint] {
+        guard values.count > 1 else { return [] }
+        let maxValue = values.max() ?? 1
+        let minValue = values.min() ?? 0
+        let range = max(0.0001, maxValue - minValue)
+        let stepX = size.width / CGFloat(values.count - 1)
+
+        return values.enumerated().map { index, value in
+            let ratio = (value - minValue) / range
+            return CGPoint(
+                x: CGFloat(index) * stepX,
+                y: size.height - CGFloat(ratio) * size.height
+            )
+        }
+    }
+}
+
+// MARK: - Barre de vie du boss
+
+/// Barre de PV segmentée, façon jeu de rôle.
+struct BossHealthBar: View {
+    let fraction: Double
+    let remainingMinutes: Int
+    var height: CGFloat = 16
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: height / 2, style: .continuous)
+                        .fill(Color.black.opacity(0.25))
+
+                    RoundedRectangle(cornerRadius: height / 2, style: .continuous)
+                        .fill(
+                            LinearGradient(
+                                colors: fraction > 0.35
+                                    ? [Color(hex: "FF453A"), Color(hex: "FF9F0A")]
+                                    : [Color(hex: "FF453A"), Color(hex: "FF2D55")],
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                        )
+                        .frame(width: max(0, geo.size.width * fraction))
+                        .animation(Motion.gentle, value: fraction)
+
+                    // Encoches tous les 10 %.
+                    HStack(spacing: 0) {
+                        ForEach(0..<10, id: \.self) { index in
+                            Rectangle()
+                                .fill(Color.black.opacity(index == 9 ? 0 : 0.25))
+                                .frame(width: 1)
+                                .frame(maxWidth: .infinity, alignment: .trailing)
+                        }
+                    }
+                }
+            }
+            .frame(height: height)
+
+            Text(remainingMinutes > 0 ? "\(remainingMinutes) PV restants" : "Boss vaincu")
+                .font(.questMicro)
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/QuestlyApp/Questly/DesignSystem/Components/QuestlyTabBar.swift
+++ b/QuestlyApp/Questly/DesignSystem/Components/QuestlyTabBar.swift
@@ -1,0 +1,144 @@
+import SwiftUI
+
+// MARK: - Onglets
+
+enum AppTab: String, CaseIterable, Identifiable, Hashable {
+    case today
+    case quests
+    case calendar
+    case focus
+    case hero
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .today: return "Repaire"
+        case .quests: return "Quêtes"
+        case .calendar: return "Calendrier"
+        case .focus: return "Donjon"
+        case .hero: return "Héros"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .today: return "house.fill"
+        case .quests: return "checklist"
+        case .calendar: return "calendar"
+        case .focus: return "timer"
+        case .hero: return "person.crop.circle.fill"
+        }
+    }
+}
+
+// MARK: - Barre d'onglets
+
+/// Barre maison : la pilule active glisse d'un onglet à l'autre et l'icône
+/// rebondit. Un `TabView` standard n'offre ni l'un ni l'autre.
+struct QuestlyTabBar: View {
+    @Binding var selection: AppTab
+    var badges: [AppTab: Int] = [:]
+
+    @Environment(\.questlyTheme) private var theme
+    @Namespace private var namespace
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(AppTab.allCases) { tab in
+                tabButton(tab)
+            }
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 8)
+        .background {
+            Capsule()
+                .fill(.regularMaterial)
+                .shadow(color: .black.opacity(0.18), radius: 18, y: 8)
+        }
+        .overlay {
+            Capsule().strokeBorder(Color.primary.opacity(0.06), lineWidth: 1)
+        }
+        .padding(.horizontal, Metrics.spacingM)
+    }
+
+    private func tabButton(_ tab: AppTab) -> some View {
+        let isSelected = selection == tab
+
+        return Button {
+            guard selection != tab else { return }
+            withAnimation(Motion.snappy) { selection = tab }
+            Haptics.selection()
+        } label: {
+            VStack(spacing: 3) {
+                ZStack {
+                    if isSelected {
+                        Circle()
+                            .fill(theme.gradient)
+                            .frame(width: 38, height: 38)
+                            .matchedGeometryEffect(id: "tab.pill", in: namespace)
+                            .glow(theme.accent, radius: 10, opacity: 0.5)
+                    }
+
+                    Image(systemName: tab.symbolName)
+                        .font(.system(size: 17, weight: .semibold))
+                        .foregroundStyle(isSelected ? Color.white : Color.secondary)
+                        .symbolEffect(.bounce, value: isSelected)
+                }
+                .frame(height: 38)
+                .overlay(alignment: .topTrailing) {
+                    if let count = badges[tab], count > 0, !isSelected {
+                        Text(count > 99 ? "99+" : "\(count)")
+                            .font(.system(size: 9, weight: .bold, design: .rounded))
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background { Capsule().fill(Color(hex: "FF453A")) }
+                            .offset(x: 8, y: -2)
+                    }
+                }
+
+                Text(tab.title)
+                    .font(.system(size: 9, weight: isSelected ? .bold : .medium, design: .rounded))
+                    .foregroundStyle(isSelected ? theme.accent : .secondary)
+            }
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(tab.title)
+    }
+}
+
+// MARK: - Bouton d'ajout
+
+/// Bouton flottant de saisie rapide. Toujours au même endroit, toujours à un
+/// pouce de distance.
+struct QuickAddButton: View {
+    let action: () -> Void
+
+    @Environment(\.questlyTheme) private var theme
+    @State private var isPressed = false
+
+    var body: some View {
+        Button {
+            Haptics.play(.medium)
+            action()
+        } label: {
+            Image(systemName: "plus")
+                .font(.system(size: 24, weight: .bold))
+                .foregroundStyle(.white)
+                .frame(width: 58, height: 58)
+                .background {
+                    Circle()
+                        .fill(theme.gradient)
+                        .shadow(color: theme.accent.opacity(0.5), radius: 16, y: 8)
+                }
+                .overlay {
+                    Circle().strokeBorder(.white.opacity(0.25), lineWidth: 1)
+                }
+        }
+        .buttonStyle(PressableStyle(scale: 0.9))
+        .accessibilityLabel("Nouvelle quête")
+    }
+}

--- a/QuestlyApp/Questly/DesignSystem/Components/Surfaces.swift
+++ b/QuestlyApp/Questly/DesignSystem/Components/Surfaces.swift
@@ -1,0 +1,255 @@
+import SwiftUI
+
+// MARK: - Carte de verre
+
+/// La surface de base de l'app : un matériau translucide, un liseré lumineux
+/// et une ombre douce. Utilisée partout pour l'unité visuelle.
+struct GlassCard<Content: View>: View {
+    var cornerRadius: CGFloat = Metrics.cornerRadius
+    var padding: CGFloat = Metrics.spacingM
+    var tint: Color = .clear
+    var strokeOpacity: Double = 0.18
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        content
+            .padding(padding)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background {
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(.ultraThinMaterial)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                            .fill(tint.opacity(0.14))
+                    }
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .strokeBorder(
+                        LinearGradient(
+                            colors: [
+                                Color.white.opacity(strokeOpacity),
+                                Color.white.opacity(strokeOpacity * 0.25)
+                            ],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        ),
+                        lineWidth: 1
+                    )
+            }
+            .shadow(color: .black.opacity(0.16), radius: 14, x: 0, y: 8)
+    }
+}
+
+// MARK: - Styles de bouton
+
+/// Un bouton qui s'enfonce : le retour tactile visuel le plus important de l'app.
+struct PressableStyle: ButtonStyle {
+    var scale: CGFloat = 0.94
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? scale : 1)
+            .opacity(configuration.isPressed ? 0.85 : 1)
+            .animation(Motion.snappy, value: configuration.isPressed)
+    }
+}
+
+/// Bouton principal, plein, en dégradé de thème.
+struct PrimaryButtonStyle: ButtonStyle {
+    var theme: QuestlyTheme
+    var isEnabled: Bool = true
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.questHeadline)
+            .foregroundStyle(.white)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 15)
+            .background {
+                RoundedRectangle(cornerRadius: Metrics.cornerRadius, style: .continuous)
+                    .fill(theme.gradient)
+                    .opacity(isEnabled ? 1 : 0.4)
+            }
+            .shadow(color: theme.accent.opacity(isEnabled ? 0.4 : 0), radius: 16, x: 0, y: 8)
+            .scaleEffect(configuration.isPressed ? 0.97 : 1)
+            .animation(Motion.snappy, value: configuration.isPressed)
+    }
+}
+
+/// Bouton secondaire, discret.
+struct SoftButtonStyle: ButtonStyle {
+    var tint: Color
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.questCallout)
+            .foregroundStyle(tint)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 9)
+            .background {
+                Capsule().fill(tint.opacity(0.14))
+            }
+            .scaleEffect(configuration.isPressed ? 0.95 : 1)
+            .animation(Motion.snappy, value: configuration.isPressed)
+    }
+}
+
+// MARK: - Effets
+
+/// Reflet qui balaie une surface — réservé aux moments forts (montée de niveau,
+/// objet légendaire) pour qu'il garde sa valeur.
+struct ShimmerModifier: ViewModifier {
+    var active: Bool = true
+    @State private var phase: CGFloat = -1
+
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                if active {
+                    GeometryReader { geo in
+                        LinearGradient(
+                            colors: [.clear, .white.opacity(0.55), .clear],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                        .frame(width: geo.size.width * 0.6)
+                        .offset(x: phase * geo.size.width * 1.6)
+                        .blendMode(.plusLighter)
+                    }
+                    .allowsHitTesting(false)
+                    .mask(content)
+                }
+            }
+            .onAppear {
+                guard active else { return }
+                withAnimation(.linear(duration: 1.8).repeatForever(autoreverses: false)) {
+                    phase = 1
+                }
+            }
+    }
+}
+
+extension View {
+    func shimmer(active: Bool = true) -> some View {
+        modifier(ShimmerModifier(active: active))
+    }
+
+    /// Halo coloré derrière un élément.
+    func glow(_ color: Color, radius: CGFloat = 12, opacity: Double = 0.6) -> some View {
+        shadow(color: color.opacity(opacity), radius: radius, x: 0, y: 0)
+    }
+
+    /// Applique une transformation seulement si la condition est vraie.
+    @ViewBuilder
+    func applyIf<Transformed: View>(_ condition: Bool, transform: (Self) -> Transformed) -> some View {
+        if condition { transform(self) } else { self }
+    }
+}
+
+// MARK: - État vide
+
+struct EmptyStateView: View {
+    let symbolName: String
+    let title: String
+    let message: String
+    var actionTitle: String?
+    var action: (() -> Void)?
+
+    @Environment(\.questlyTheme) private var theme
+
+    var body: some View {
+        VStack(spacing: Metrics.spacingM) {
+            ZStack {
+                Circle()
+                    .fill(theme.softGradient)
+                    .frame(width: 96, height: 96)
+                Image(systemName: symbolName)
+                    .font(.system(size: 40, weight: .medium))
+                    .foregroundStyle(theme.gradient)
+            }
+
+            Text(title)
+                .font(.questHeadline)
+                .multilineTextAlignment(.center)
+
+            Text(message)
+                .font(.questCallout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, Metrics.spacingXL)
+
+            if let actionTitle, let action {
+                Button(actionTitle, action: action)
+                    .buttonStyle(SoftButtonStyle(tint: theme.accent))
+                    .padding(.top, Metrics.spacingXS)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, Metrics.spacingXL)
+    }
+}
+
+// MARK: - Sélecteur segmenté
+
+/// Segmenté maison : la pilule glisse au lieu de sauter, ce qui rend la
+/// navigation entre vues du calendrier beaucoup plus fluide.
+struct QuestlySegmentedPicker<Item: Hashable>: View {
+    let items: [Item]
+    let label: (Item) -> String
+    @Binding var selection: Item
+
+    @Environment(\.questlyTheme) private var theme
+    @Namespace private var namespace
+
+    var body: some View {
+        HStack(spacing: 2) {
+            ForEach(items, id: \.self) { item in
+                Button {
+                    withAnimation(Motion.snappy) { selection = item }
+                    Haptics.selection()
+                } label: {
+                    Text(label(item))
+                        .font(.questCaption)
+                        .foregroundStyle(selection == item ? .white : .secondary)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                        .background {
+                            if selection == item {
+                                Capsule()
+                                    .fill(theme.gradient)
+                                    .matchedGeometryEffect(id: "segment", in: namespace)
+                            }
+                        }
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(3)
+        .background {
+            Capsule().fill(.ultraThinMaterial)
+        }
+    }
+}
+
+// MARK: - Compteur animé
+
+/// Nombre qui s'incrémente visuellement : indispensable pour que gagner de l'XP
+/// se ressente.
+struct CountingNumber: View, Animatable {
+    var value: Double
+    var format: String = "%.0f"
+    var font: Font = .questNumber(20)
+
+    var animatableData: Double {
+        get { value }
+        set { value = newValue }
+    }
+
+    var body: some View {
+        Text(String(format: format, value))
+            .font(font)
+            .monospacedDigit()
+            .contentTransition(.numericText())
+    }
+}

--- a/QuestlyApp/Questly/DesignSystem/Palette.swift
+++ b/QuestlyApp/Questly/DesignSystem/Palette.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+// MARK: - Couleurs hexadécimales
+
+extension Color {
+    /// Construit une couleur à partir d'un hexadécimal « RRGGBB » ou « RRGGBBAA ».
+    init(hex: String) {
+        let cleaned = hex
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "#", with: "")
+        var value: UInt64 = 0
+        Scanner(string: cleaned).scanHexInt64(&value)
+
+        let red: Double
+        let green: Double
+        let blue: Double
+        var alpha: Double = 1
+
+        switch cleaned.count {
+        case 8:
+            red = Double((value & 0xFF00_0000) >> 24) / 255
+            green = Double((value & 0x00FF_0000) >> 16) / 255
+            blue = Double((value & 0x0000_FF00) >> 8) / 255
+            alpha = Double(value & 0x0000_00FF) / 255
+        case 6:
+            red = Double((value & 0xFF0000) >> 16) / 255
+            green = Double((value & 0x00FF00) >> 8) / 255
+            blue = Double(value & 0x0000FF) / 255
+        default:
+            red = 0.5
+            green = 0.5
+            blue = 0.5
+        }
+        self.init(.sRGB, red: red, green: green, blue: blue, opacity: alpha)
+    }
+}
+
+// MARK: - Palette
+
+/// Couleurs partagées et petits utilitaires de teinte.
+enum Palette {
+
+    static let projectHexes = [
+        "5E5CE6", "FF375F", "FF9F0A", "30D158", "64D2FF",
+        "BF5AF2", "FF6B6B", "34D399", "F59E0B", "38BDF8"
+    ]
+
+    static let tagHexes = [
+        "BF5AF2", "5E9BFF", "FF7AC6", "FFB020", "34D399",
+        "A78BFA", "F472B6", "22D3EE", "FB923C", "4ADE80"
+    ]
+
+    /// Couleur stable dérivée du nom : deux projets identiques gardent la même
+    /// teinte d'une installation à l'autre.
+    static func randomProjectHex(seed: String) -> String {
+        projectHexes[stableIndex(for: seed, count: projectHexes.count)]
+    }
+
+    static func randomTagHex(seed: String) -> String {
+        tagHexes[stableIndex(for: seed, count: tagHexes.count)]
+    }
+
+    static func stableIndex(for seed: String, count: Int) -> Int {
+        guard count > 0 else { return 0 }
+        var hash: UInt64 = 5381
+        for byte in seed.lowercased().utf8 {
+            hash = (hash &* 33) &+ UInt64(byte)
+        }
+        return Int(hash % UInt64(count))
+    }
+
+    static func color(forHex hex: String) -> Color { Color(hex: hex) }
+}
+
+// MARK: - Métriques
+
+/// Rythme visuel de l'app : une seule source pour les espacements et les rayons.
+enum Metrics {
+    static let cornerRadiusSmall: CGFloat = 12
+    static let cornerRadius: CGFloat = 20
+    static let cornerRadiusLarge: CGFloat = 28
+
+    static let spacingXS: CGFloat = 4
+    static let spacingS: CGFloat = 8
+    static let spacingM: CGFloat = 14
+    static let spacingL: CGFloat = 20
+    static let spacingXL: CGFloat = 32
+
+    static let rowHeight: CGFloat = 60
+    static let tabBarHeight: CGFloat = 64
+    /// Hauteur d'une heure sur la timeline du calendrier.
+    static let hourHeight: CGFloat = 64
+}
+
+// MARK: - Typographie
+
+extension Font {
+    static let questTitle = Font.system(size: 30, weight: .bold, design: .rounded)
+    static let questHeadline = Font.system(size: 20, weight: .semibold, design: .rounded)
+    static let questBody = Font.system(size: 16, weight: .regular, design: .rounded)
+    static let questCallout = Font.system(size: 14, weight: .medium, design: .rounded)
+    static let questCaption = Font.system(size: 12, weight: .medium, design: .rounded)
+    static let questMicro = Font.system(size: 10, weight: .semibold, design: .rounded)
+
+    static func questNumber(_ size: CGFloat) -> Font {
+        .system(size: size, weight: .bold, design: .rounded)
+    }
+}
+
+// MARK: - Animations
+
+enum Motion {
+    static let snappy = Animation.spring(response: 0.34, dampingFraction: 0.72)
+    static let bouncy = Animation.spring(response: 0.42, dampingFraction: 0.6)
+    static let gentle = Animation.spring(response: 0.55, dampingFraction: 0.85)
+    static let quick = Animation.easeOut(duration: 0.18)
+    static let celebration = Animation.spring(response: 0.6, dampingFraction: 0.55)
+}

--- a/QuestlyApp/Questly/DesignSystem/Theme.swift
+++ b/QuestlyApp/Questly/DesignSystem/Theme.swift
@@ -1,0 +1,189 @@
+import SwiftUI
+import QuestlyKit
+
+// MARK: - Thème
+
+/// Une ambiance visuelle complète. Les surfaces restent des matériaux système
+/// (donc lisibles en clair comme en sombre) ; le thème pilote les accents, les
+/// dégradés et l'atmosphère de fond.
+struct QuestlyTheme: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let symbolName: String
+    let accentHex: String
+    let secondaryHex: String
+    let tertiaryHex: String
+    let auraTopHex: String
+    let auraBottomHex: String
+    /// Prix indicatif affiché dans la boutique (0 = offert).
+    let unlockItemID: String?
+
+    var accent: Color { Color(hex: accentHex) }
+    var secondary: Color { Color(hex: secondaryHex) }
+    var tertiary: Color { Color(hex: tertiaryHex) }
+    var auraTop: Color { Color(hex: auraTopHex) }
+    var auraBottom: Color { Color(hex: auraBottomHex) }
+
+    var gradient: LinearGradient {
+        LinearGradient(
+            colors: [accent, secondary],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    var softGradient: LinearGradient {
+        LinearGradient(
+            colors: [accent.opacity(0.22), secondary.opacity(0.12)],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    var ringGradient: AngularGradient {
+        AngularGradient(
+            colors: [accent, secondary, tertiary, accent],
+            center: .center
+        )
+    }
+}
+
+enum ThemeCatalog {
+
+    static let all: [QuestlyTheme] = [
+        QuestlyTheme(
+            id: "nebula", name: "Nébuleuse", symbolName: "sparkles",
+            accentHex: "7C5CFF", secondaryHex: "C77DFF", tertiaryHex: "4CC9F0",
+            auraTopHex: "7C5CFF", auraBottomHex: "2D1B69", unlockItemID: nil
+        ),
+        QuestlyTheme(
+            id: "aurora", name: "Aurore", symbolName: "sunrise.fill",
+            accentHex: "FF6B9D", secondaryHex: "FFA45B", tertiaryHex: "FFD93D",
+            auraTopHex: "FF6B9D", auraBottomHex: "6B2D5C", unlockItemID: "theme.aurora"
+        ),
+        QuestlyTheme(
+            id: "forest", name: "Sylve", symbolName: "leaf.fill",
+            accentHex: "2DD4A7", secondaryHex: "60D394", tertiaryHex: "AAF683",
+            auraTopHex: "2DD4A7", auraBottomHex: "134E4A", unlockItemID: "theme.forest"
+        ),
+        QuestlyTheme(
+            id: "ocean", name: "Abysse", symbolName: "water.waves",
+            accentHex: "3B82F6", secondaryHex: "22D3EE", tertiaryHex: "818CF8",
+            auraTopHex: "3B82F6", auraBottomHex: "0C2D5A", unlockItemID: "theme.ocean"
+        ),
+        QuestlyTheme(
+            id: "ember", name: "Braise", symbolName: "flame.fill",
+            accentHex: "FB7185", secondaryHex: "F59E0B", tertiaryHex: "FCD34D",
+            auraTopHex: "FB7185", auraBottomHex: "4C1D1D", unlockItemID: "theme.ember"
+        ),
+        QuestlyTheme(
+            id: "candy", name: "Guimauve", symbolName: "birthday.cake.fill",
+            accentHex: "F472B6", secondaryHex: "A78BFA", tertiaryHex: "7DD3FC",
+            auraTopHex: "F472B6", auraBottomHex: "4A2545", unlockItemID: "theme.candy"
+        ),
+        QuestlyTheme(
+            id: "ink", name: "Encre", symbolName: "circle.lefthalf.filled",
+            accentHex: "9CA3AF", secondaryHex: "6B7280", tertiaryHex: "D1D5DB",
+            auraTopHex: "6B7280", auraBottomHex: "1F2937", unlockItemID: "theme.ink"
+        ),
+        QuestlyTheme(
+            id: "gold", name: "Âge d'or", symbolName: "crown.fill",
+            accentHex: "F0B429", secondaryHex: "FCD34D", tertiaryHex: "FDE68A",
+            auraTopHex: "F0B429", auraBottomHex: "3A2A08", unlockItemID: "theme.gold"
+        )
+    ]
+
+    static let `default` = all[0]
+
+    static func theme(id: String) -> QuestlyTheme {
+        all.first { $0.id == id } ?? `default`
+    }
+}
+
+// MARK: - Gestionnaire
+
+/// Détient le thème courant et le partage à toute l'app.
+@Observable
+final class ThemeManager {
+    var current: QuestlyTheme
+
+    init(id: String = ThemeCatalog.default.id) {
+        self.current = ThemeCatalog.theme(id: id)
+    }
+
+    func select(id: String) {
+        withAnimation(Motion.gentle) {
+            current = ThemeCatalog.theme(id: id)
+        }
+    }
+
+    /// Un thème est disponible s'il est offert ou déjà acheté.
+    func isUnlocked(_ theme: QuestlyTheme, ownedItems: [String]) -> Bool {
+        guard let requirement = theme.unlockItemID else { return true }
+        return ownedItems.contains(requirement)
+    }
+}
+
+// MARK: - Fond animé
+
+/// Fond « aurore » : deux halos qui respirent lentement derrière l'interface.
+/// C'est ce qui donne la sensation de profondeur sans coûter cher à dessiner.
+struct AuroraBackground: View {
+    let theme: QuestlyTheme
+    var animated: Bool = true
+
+    @State private var phase: CGFloat = 0
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack {
+                Color(.systemBackground)
+
+                Circle()
+                    .fill(theme.auraTop.opacity(0.30))
+                    .frame(width: geo.size.width * 1.1)
+                    .blur(radius: 90)
+                    .offset(
+                        x: -geo.size.width * 0.28 + phase * 22,
+                        y: -geo.size.height * 0.30 + phase * 14
+                    )
+
+                Circle()
+                    .fill(theme.auraBottom.opacity(0.34))
+                    .frame(width: geo.size.width * 1.0)
+                    .blur(radius: 100)
+                    .offset(
+                        x: geo.size.width * 0.32 - phase * 18,
+                        y: geo.size.height * 0.34 - phase * 20
+                    )
+
+                Circle()
+                    .fill(theme.tertiary.opacity(0.16))
+                    .frame(width: geo.size.width * 0.7)
+                    .blur(radius: 80)
+                    .offset(x: phase * 30, y: geo.size.height * 0.05 + phase * 12)
+            }
+            .ignoresSafeArea()
+        }
+        .ignoresSafeArea()
+        .onAppear {
+            guard animated else { return }
+            withAnimation(.easeInOut(duration: 9).repeatForever(autoreverses: true)) {
+                phase = 1
+            }
+        }
+    }
+}
+
+// MARK: - Clés d'environnement
+
+private struct ThemeKey: EnvironmentKey {
+    static let defaultValue = ThemeCatalog.default
+}
+
+extension EnvironmentValues {
+    var questlyTheme: QuestlyTheme {
+        get { self[ThemeKey.self] }
+        set { self[ThemeKey.self] = newValue }
+    }
+}

--- a/QuestlyApp/Questly/Features/Calendar/CalendarPanels.swift
+++ b/QuestlyApp/Questly/Features/Calendar/CalendarPanels.swift
@@ -1,0 +1,562 @@
+import SwiftUI
+import SwiftData
+import QuestlyKit
+
+// MARK: - Journée détaillée sous la grille du mois
+
+/// Ce qui rend la vue Mois réellement exploitable : la journée sélectionnée
+/// s'ouvre juste en dessous, avec ses créneaux et ses quêtes.
+struct DayAgendaPanel: View {
+
+    let date: Date
+    var onSelectTask: (TaskItem) -> Void
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(SettingsStore.self) private var settings
+    @Environment(CalendarService.self) private var calendarService
+    @Environment(\.questlyTheme) private var theme
+
+    @Query private var tasks: [TaskItem]
+    @Query private var blocks: [TimeBlock]
+
+    @State private var showsComposer = false
+
+    private var calendar: Calendar { settings.calendar }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Metrics.spacingS) {
+                header
+
+                if entries.isEmpty && dayTasks.isEmpty {
+                    EmptyStateView(
+                        symbolName: "calendar.badge.plus",
+                        title: "Journée libre",
+                        message: "Rien de prévu le \(QuestlyFormat.fullDay(date, calendar: calendar)).",
+                        actionTitle: "Réserver un créneau",
+                        action: { showsComposer = true }
+                    )
+                } else {
+                    ForEach(entries) { entry in
+                        entryRow(entry)
+                    }
+
+                    if !untimedTasks.isEmpty {
+                        Text("Sans heure")
+                            .font(.questMicro)
+                            .foregroundStyle(.secondary)
+                            .padding(.top, Metrics.spacingXS)
+
+                        ForEach(untimedTasks) { task in
+                            TaskRow(task: task, isCompact: true) { onSelectTask(task) }
+                        }
+                    }
+                }
+            }
+            .padding(Metrics.spacingM)
+            .padding(.bottom, 100)
+        }
+        .sheet(isPresented: $showsComposer) {
+            SlotComposerSheet(start: calendar.setting(hour: settings.defaultDueHour, minute: 0, of: date))
+                .presentationDetents([.medium, .large])
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Text(QuestlyFormat.fullDay(date, calendar: calendar))
+                .font(.questCallout)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Button {
+                showsComposer = true
+            } label: {
+                Image(systemName: "plus.circle.fill")
+                    .font(.system(size: 18))
+                    .foregroundStyle(theme.accent)
+            }
+        }
+    }
+
+    private func entryRow(_ entry: TimedEntry) -> some View {
+        HStack(alignment: .top, spacing: Metrics.spacingS) {
+            VStack(alignment: .trailing, spacing: 1) {
+                Text(QuestlyFormat.time(entry.start, calendar: calendar))
+                    .font(.questCaption)
+                    .monospacedDigit()
+                Text(DurationFormatter.short(minutes: entry.durationMinutes))
+                    .font(.questMicro)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(width: 54, alignment: .trailing)
+
+            RoundedRectangle(cornerRadius: 2)
+                .fill(entry.color)
+                .frame(width: 3)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(entry.title)
+                    .font(.questBody)
+                    .strikethrough(entry.isCompleted)
+                if entry.source == .external {
+                    Label("Calendrier iOS", systemImage: "calendar")
+                        .font(.questMicro)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+
+            if entry.source != .external {
+                Button {
+                    open(entry)
+                } label: {
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func open(_ entry: TimedEntry) {
+        guard let id = entry.taskIdentifier,
+              let task = tasks.first(where: { $0.identifier == id }) else { return }
+        onSelectTask(task)
+    }
+
+    private var dayTasks: [TaskItem] {
+        tasks.filter { $0.isDue(on: date, calendar: calendar) }
+    }
+
+    private var untimedTasks: [TaskItem] {
+        dayTasks.filter { !$0.hasTime }
+            .sorted(by: TaskSorting.smart(calendar: calendar))
+    }
+
+    private var entries: [TimedEntry] {
+        var output: [TimedEntry] = []
+        for block in blocks where calendar.isSameDay(block.start, date) {
+            output.append(TimedEntry.from(block: block))
+        }
+        let scheduled = Set(output.compactMap(\.taskIdentifier))
+        for task in dayTasks where task.hasTime && !scheduled.contains(task.identifier) {
+            output.append(TimedEntry.from(task: task))
+        }
+        for event in calendarService.events(on: date, calendar: calendar) where !event.isAllDay {
+            output.append(TimedEntry.from(external: event))
+        }
+        return output.sorted { $0.start < $1.start }
+    }
+}
+
+// MARK: - Vue année
+
+/// Douze mini-mois teintés par l'activité : la vue d'ensemble d'une année.
+struct YearGridView: View {
+
+    @Binding var selectedDate: Date
+    var onSelectMonth: (Date) -> Void
+
+    @Environment(SettingsStore.self) private var settings
+    @Environment(\.questlyTheme) private var theme
+
+    @Query private var tasks: [TaskItem]
+
+    private var calendar: Calendar { settings.calendar }
+
+    var body: some View {
+        ScrollView {
+            LazyVGrid(
+                columns: Array(repeating: GridItem(.flexible(), spacing: Metrics.spacingS), count: 3),
+                spacing: Metrics.spacingM
+            ) {
+                ForEach(months, id: \.self) { month in
+                    MiniMonthView(
+                        month: month,
+                        activeDays: activeDays(in: month),
+                        isCurrentMonth: calendar.isDate(month, equalTo: Date(), toGranularity: .month)
+                    )
+                    .onTapGesture {
+                        onSelectMonth(month)
+                        Haptics.selection()
+                    }
+                }
+            }
+            .padding(Metrics.spacingM)
+            .padding(.bottom, 100)
+        }
+    }
+
+    private var months: [Date] {
+        let year = calendar.component(.year, from: selectedDate)
+        return (1...12).compactMap { month in
+            var comps = DateComponents()
+            comps.year = year
+            comps.month = month
+            comps.day = 1
+            return calendar.date(from: comps)
+        }
+    }
+
+    private func activeDays(in month: Date) -> [Date: Int] {
+        var output: [Date: Int] = [:]
+        let start = calendar.startOfMonth(month)
+        let end = calendar.endOfMonth(month)
+        for task in tasks {
+            guard let due = task.dueDate, due >= start, due <= end else { continue }
+            let day = calendar.startOfDay(for: due)
+            output[day, default: 0] += 1
+        }
+        return output
+    }
+}
+
+struct MiniMonthView: View {
+
+    let month: Date
+    let activeDays: [Date: Int]
+    let isCurrentMonth: Bool
+
+    @Environment(SettingsStore.self) private var settings
+    @Environment(\.questlyTheme) private var theme
+
+    private var calendar: Calendar { settings.calendar }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(QuestlyFormat.month(month, calendar: calendar))
+                .font(.questCaption)
+                .foregroundStyle(isCurrentMonth ? theme.accent : .primary)
+
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 1), count: 7), spacing: 2) {
+                ForEach(calendar.monthGrid(for: month), id: \.self) { day in
+                    let inMonth = calendar.isDate(day, equalTo: month, toGranularity: .month)
+                    let count = activeDays[calendar.startOfDay(for: day)] ?? 0
+                    Circle()
+                        .fill(fill(count: count, inMonth: inMonth))
+                        .frame(width: 6, height: 6)
+                        .overlay {
+                            if calendar.isSameDay(day, Date()) {
+                                Circle().strokeBorder(theme.accent, lineWidth: 1)
+                            }
+                        }
+                }
+            }
+        }
+        .padding(Metrics.spacingS)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background {
+            RoundedRectangle(cornerRadius: Metrics.cornerRadiusSmall, style: .continuous)
+                .fill(.ultraThinMaterial)
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: Metrics.cornerRadiusSmall, style: .continuous)
+                .strokeBorder(isCurrentMonth ? theme.accent.opacity(0.4) : .clear, lineWidth: 1)
+        }
+    }
+
+    private func fill(count: Int, inMonth: Bool) -> Color {
+        guard inMonth else { return Color.primary.opacity(0.04) }
+        switch count {
+        case 0: return Color.primary.opacity(0.08)
+        case 1: return theme.accent.opacity(0.35)
+        case 2...3: return theme.accent.opacity(0.6)
+        default: return theme.accent
+        }
+    }
+}
+
+// MARK: - Agenda
+
+/// Liste continue des jours à venir : la vue la plus rapide pour « et après ? ».
+struct AgendaListView: View {
+
+    let startDate: Date
+    var onSelectTask: (TaskItem) -> Void
+
+    @Environment(SettingsStore.self) private var settings
+    @Environment(CalendarService.self) private var calendarService
+    @Environment(\.questlyTheme) private var theme
+
+    @Query private var tasks: [TaskItem]
+    @Query private var blocks: [TimeBlock]
+
+    @State private var horizon = 45
+
+    private var calendar: Calendar { settings.calendar }
+
+    var body: some View {
+        List {
+            ForEach(days, id: \.self) { day in
+                let dayTasks = openTasks(on: day)
+                let dayBlocks = blocks.filter { calendar.isSameDay($0.start, day) }
+                let events = calendarService.events(on: day, calendar: calendar)
+
+                if !dayTasks.isEmpty || !dayBlocks.isEmpty || !events.isEmpty {
+                    Section {
+                        ForEach(dayBlocks.sorted { $0.start < $1.start }) { block in
+                            blockRow(block)
+                        }
+                        ForEach(events) { event in
+                            externalRow(event)
+                        }
+                        ForEach(dayTasks) { task in
+                            TaskRow(task: task, isCompact: true) { onSelectTask(task) }
+                                .taskSwipeActions(for: task) { onSelectTask(task) }
+                        }
+                    } header: {
+                        HStack {
+                            Text(QuestlyFormat.fullDay(day, calendar: calendar))
+                            if calendar.isSameDay(day, Date()) {
+                                Text("AUJOURD'HUI")
+                                    .font(.system(size: 9, weight: .heavy, design: .rounded))
+                                    .foregroundStyle(theme.accent)
+                            }
+                        }
+                    }
+                }
+            }
+
+            Section {
+                Button("Charger 45 jours de plus") {
+                    withAnimation { horizon += 45 }
+                }
+                .font(.questCaption)
+                Color.clear.frame(height: 80).listRowBackground(Color.clear)
+            }
+        }
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+    }
+
+    private var days: [Date] {
+        let start = calendar.startOfDay(for: startDate)
+        return (0..<horizon).map { start.adding(days: $0, calendar: calendar) }
+    }
+
+    private func openTasks(on day: Date) -> [TaskItem] {
+        tasks.filter { $0.isDue(on: day, calendar: calendar) && $0.isOpen }
+            .sorted(by: TaskSorting.smart(calendar: calendar))
+    }
+
+    private func blockRow(_ block: TimeBlock) -> some View {
+        HStack(spacing: Metrics.spacingS) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(Color(hex: block.colorHex))
+                .frame(width: 3, height: 26)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(block.title).font(.questCallout)
+                Text("\(QuestlyFormat.time(block.start, calendar: calendar)) – \(QuestlyFormat.time(block.end, calendar: calendar))")
+                    .font(.questMicro)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Image(systemName: "rectangle.fill.badge.checkmark")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func externalRow(_ event: CalendarService.ExternalEvent) -> some View {
+        HStack(spacing: Metrics.spacingS) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(Color(hex: event.colorHex))
+                .frame(width: 3, height: 26)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(event.title).font(.questCallout)
+                Text(event.isAllDay
+                     ? "Toute la journée · \(event.calendarName)"
+                     : "\(QuestlyFormat.time(event.start, calendar: calendar)) · \(event.calendarName)")
+                    .font(.questMicro)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Image(systemName: "calendar")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - Tiroir des quêtes à placer
+
+/// Bande de quêtes sans créneau, que l'on fait glisser sur la timeline.
+struct UnscheduledTray: View {
+
+    let selectedDate: Date
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(SettingsStore.self) private var settings
+    @Environment(\.questlyTheme) private var theme
+
+    @Query private var tasks: [TaskItem]
+
+    private var calendar: Calendar { settings.calendar }
+
+    private var candidates: [TaskItem] {
+        tasks
+            .filter { $0.isOpen && $0.scheduledBlocks.isEmpty }
+            .filter { task in
+                guard let due = task.dueDate else { return true }
+                return calendar.startOfDay(for: due) <= calendar.startOfDay(for: selectedDate)
+            }
+            .sorted(by: TaskSorting.smart(calendar: calendar))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Label("À placer", systemImage: "tray.full.fill")
+                    .font(.questMicro)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text("Glisse une quête sur la timeline")
+                    .font(.questMicro)
+                    .foregroundStyle(.secondary)
+            }
+
+            if candidates.isEmpty {
+                Text("Tout est planifié. Impressionnant.")
+                    .font(.questCaption)
+                    .foregroundStyle(.secondary)
+                    .padding(.vertical, 6)
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        ForEach(candidates.prefix(12)) { task in
+                            trayChip(task)
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+            }
+        }
+        .padding(.horizontal, Metrics.spacingM)
+        .padding(.vertical, Metrics.spacingS)
+        .background(.regularMaterial)
+    }
+
+    private func trayChip(_ task: TaskItem) -> some View {
+        let color = Color(hex: task.lifeArea?.hex ?? task.priority.hex)
+
+        return HStack(spacing: 5) {
+            Circle().fill(color).frame(width: 7, height: 7)
+            Text(task.title)
+                .font(.questMicro)
+                .lineLimit(1)
+            if task.estimatedMinutes > 0 {
+                Text(DurationFormatter.short(minutes: task.estimatedMinutes))
+                    .font(.system(size: 9, weight: .medium, design: .rounded))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.horizontal, 9)
+        .padding(.vertical, 7)
+        .background {
+            Capsule().fill(color.opacity(0.12))
+        }
+        .overlay {
+            Capsule().strokeBorder(color.opacity(0.3), lineWidth: 1)
+        }
+        .frame(maxWidth: 190)
+        .draggable(task.identifier.uuidString) {
+            // Aperçu affiché sous le doigt pendant le glissement.
+            Text(task.title)
+                .font(.questMicro)
+                .padding(8)
+                .background { Capsule().fill(color.opacity(0.9)) }
+                .foregroundStyle(.white)
+        }
+    }
+}
+
+// MARK: - Plan automatique
+
+/// Résultat de la planification automatique, à valider avant application.
+struct AutoPlanSheet: View {
+
+    let result: PlanResult
+    let onApply: () -> Void
+
+    @Environment(SettingsStore.self) private var settings
+    @Environment(\.questlyTheme) private var theme
+    @Environment(\.dismiss) private var dismiss
+
+    private var calendar: Calendar { settings.calendar }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    HStack {
+                        Label("Temps planifié", systemImage: "clock.fill")
+                        Spacer()
+                        Text(DurationFormatter.short(minutes: result.usedMinutes))
+                            .foregroundStyle(.secondary)
+                    }
+                    HStack {
+                        Label("Temps libre restant", systemImage: "wind")
+                        Spacer()
+                        Text(DurationFormatter.short(minutes: result.freeMinutes))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Section("Programme proposé") {
+                    if result.blocks.isEmpty {
+                        Text("Aucun créneau libre trouvé aujourd'hui.")
+                            .font(.questCaption)
+                            .foregroundStyle(.secondary)
+                    }
+                    ForEach(result.blocks) { block in
+                        HStack(alignment: .top, spacing: Metrics.spacingS) {
+                            Text(QuestlyFormat.time(block.start, calendar: calendar))
+                                .font(.questCaption)
+                                .monospacedDigit()
+                                .frame(width: 46, alignment: .trailing)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(block.title).font(.questBody)
+                                Text(block.rationale)
+                                    .font(.questMicro)
+                                    .foregroundStyle(theme.accent)
+                            }
+                        }
+                    }
+                }
+
+                if !result.unplaced.isEmpty {
+                    Section("Ne rentre pas aujourd'hui") {
+                        ForEach(result.unplaced) { task in
+                            HStack {
+                                Text(task.title).font(.questCallout)
+                                Spacer()
+                                Text(DurationFormatter.short(minutes: task.estimatedMinutes))
+                                    .font(.questMicro)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Planifier ma journée")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Annuler") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Appliquer") {
+                        onApply()
+                        Haptics.success()
+                        dismiss()
+                    }
+                    .fontWeight(.semibold)
+                    .disabled(result.blocks.isEmpty)
+                }
+            }
+        }
+    }
+}

--- a/QuestlyApp/Questly/Features/Calendar/CalendarScreen.swift
+++ b/QuestlyApp/Questly/Features/Calendar/CalendarScreen.swift
@@ -1,0 +1,577 @@
+import SwiftUI
+import SwiftData
+import QuestlyKit
+
+/// Le calendrier complet : jour, semaine, mois, année, agenda — avec les
+/// évènements du calendrier système, le time-blocking par glisser-déposer et
+/// la planification automatique de la journée.
+struct CalendarScreen: View {
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(SettingsStore.self) private var settings
+    @Environment(CalendarService.self) private var calendarService
+    @Environment(\.questlyTheme) private var theme
+
+    @Query private var tasks: [TaskItem]
+    @Query private var blocks: [TimeBlock]
+
+    @State private var mode: CalendarMode = .month
+    @State private var selectedDate = Date()
+    @State private var monthPage = 0
+    @State private var weekPage = 0
+    @State private var showsTray = false
+    @State private var showsDatePicker = false
+    @State private var selectedTask: TaskItem?
+    @State private var planProposal: PlanProposal?
+
+    /// Enveloppe identifiable pour présenter un plan dans une feuille.
+    struct PlanProposal: Identifiable {
+        let id = UUID()
+        let result: PlanResult
+    }
+
+    private var calendar: Calendar { settings.calendar }
+    private let monthRange = -60...60
+    private let weekRange = -104...104
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                header
+                modePicker
+                Divider().opacity(0.4)
+                modeContent
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar { toolbarContent }
+            .safeAreaInset(edge: .bottom) {
+                if showsTray && mode != .year {
+                    UnscheduledTray(selectedDate: selectedDate)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+            }
+            .sheet(isPresented: $showsDatePicker) {
+                datePickerSheet
+                    .presentationDetents([.height(420)])
+            }
+            .sheet(item: $selectedTask) { task in
+                TaskDetailView(task: task)
+            }
+            .sheet(item: $planProposal) { proposal in
+                AutoPlanSheet(result: proposal.result) {
+                    store.applyPlan(proposal.result)
+                    planProposal = nil
+                }
+                .presentationDetents([.medium, .large])
+            }
+            .onChange(of: monthPage) { _, newValue in
+                guard mode == .month else { return }
+                syncSelection(monthOffset: newValue)
+            }
+            .onChange(of: weekPage) { _, newValue in
+                guard mode == .week else { return }
+                syncSelection(weekOffset: newValue)
+            }
+            .onChange(of: mode) { _, _ in loadExternalEvents() }
+            .onChange(of: selectedDate) { _, _ in loadExternalEvents() }
+            .task { loadExternalEvents() }
+        }
+    }
+
+    // MARK: En-tête
+
+    private var header: some View {
+        HStack(spacing: Metrics.spacingS) {
+            Button {
+                step(-1)
+            } label: {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 15, weight: .semibold))
+            }
+            .buttonStyle(SoftButtonStyle(tint: theme.accent))
+
+            Button {
+                showsDatePicker = true
+            } label: {
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(headerTitle)
+                        .font(.questHeadline)
+                        .foregroundStyle(.primary)
+                    Text(headerSubtitle)
+                        .font(.questMicro)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .buttonStyle(.plain)
+
+            Spacer()
+
+            if !calendar.isSameDay(selectedDate, Date()) {
+                Button("Aujourd'hui") { goToToday() }
+                    .font(.questMicro)
+                    .buttonStyle(SoftButtonStyle(tint: theme.accent))
+            }
+
+            Button {
+                step(1)
+            } label: {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 15, weight: .semibold))
+            }
+            .buttonStyle(SoftButtonStyle(tint: theme.accent))
+        }
+        .padding(.horizontal, Metrics.spacingM)
+        .padding(.vertical, Metrics.spacingS)
+    }
+
+    private var headerTitle: String {
+        switch mode {
+        case .day: return QuestlyFormat.fullDay(selectedDate, calendar: calendar)
+        case .week:
+            let days = calendar.weekDays(for: selectedDate)
+            let first = days.first ?? selectedDate
+            let last = days.last ?? selectedDate
+            return "\(QuestlyFormat.dayNumber(first, calendar: calendar)) – \(QuestlyFormat.dayNumber(last, calendar: calendar)) \(QuestlyFormat.month(last, calendar: calendar))"
+        case .month, .agenda: return QuestlyFormat.monthYear(selectedDate, calendar: calendar)
+        case .year: return String(calendar.component(.year, from: selectedDate))
+        }
+    }
+
+    private var headerSubtitle: String {
+        let dayTasks = tasksDue(on: selectedDate)
+        let minutes = blocks.filter { calendar.isSameDay($0.start, selectedDate) }
+            .reduce(0) { $0 + $1.durationMinutes }
+        if dayTasks.isEmpty && minutes == 0 { return "Journée libre" }
+        var parts: [String] = []
+        if !dayTasks.isEmpty { parts.append("\(dayTasks.count) quête\(dayTasks.count > 1 ? "s" : "")") }
+        if minutes > 0 { parts.append(DurationFormatter.short(minutes: minutes) + " planifiées") }
+        return parts.joined(separator: " · ")
+    }
+
+    private var modePicker: some View {
+        QuestlySegmentedPicker(
+            items: CalendarMode.allCases,
+            label: { $0.label },
+            selection: $mode
+        )
+        .padding(.horizontal, Metrics.spacingM)
+        .padding(.bottom, Metrics.spacingS)
+    }
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        ToolbarItem(placement: .topBarTrailing) {
+            Menu {
+                Button {
+                    withAnimation(Motion.snappy) { showsTray.toggle() }
+                } label: {
+                    Label(
+                        showsTray ? "Masquer les quêtes à placer" : "Afficher les quêtes à placer",
+                        systemImage: "tray.full"
+                    )
+                }
+
+                Button {
+                    planProposal = PlanProposal(
+                        result: store.autoPlanToday(workingHours: settings.workingHours)
+                    )
+                } label: {
+                    Label("Planifier ma journée", systemImage: "wand.and.stars")
+                }
+
+                Divider()
+
+                Button {
+                    Task { await enableCalendarSync() }
+                } label: {
+                    Label(
+                        calendarService.access == .granted ? "Recharger le calendrier système" : "Connecter le calendrier iOS",
+                        systemImage: "calendar.badge.plus"
+                    )
+                }
+            } label: {
+                Image(systemName: "ellipsis.circle")
+            }
+        }
+    }
+
+    // MARK: Contenus
+
+    @ViewBuilder
+    private var modeContent: some View {
+        switch mode {
+        case .day:
+            dayContent
+        case .week:
+            weekPager
+        case .month:
+            monthContent
+        case .year:
+            YearGridView(selectedDate: $selectedDate) { date in
+                selectedDate = date
+                withAnimation(Motion.snappy) { mode = .month }
+                monthPage = monthOffset(for: date)
+            }
+        case .agenda:
+            AgendaListView(startDate: selectedDate) { task in
+                selectedTask = task
+            }
+        }
+    }
+
+    private var dayContent: some View {
+        QuestlyTimeline(days: [selectedDate], selectedDate: $selectedDate)
+            .gesture(
+                DragGesture(minimumDistance: 40)
+                    .onEnded { value in
+                        guard abs(value.translation.width) > abs(value.translation.height) else { return }
+                        step(value.translation.width < 0 ? 1 : -1)
+                    }
+            )
+    }
+
+    private var weekPager: some View {
+        TabView(selection: $weekPage) {
+            ForEach(weekRange, id: \.self) { offset in
+                let reference = calendar.date(byAdding: .weekOfYear, value: offset, to: Date()) ?? Date()
+                VStack(spacing: 0) {
+                    weekdayHeader(for: calendar.weekDays(for: reference))
+                    QuestlyTimeline(
+                        days: calendar.weekDays(for: reference),
+                        selectedDate: $selectedDate
+                    )
+                }
+                .tag(offset)
+            }
+        }
+        .tabViewStyle(.page(indexDisplayMode: .never))
+    }
+
+    private func weekdayHeader(for days: [Date]) -> some View {
+        HStack(spacing: 1) {
+            Color.clear.frame(width: 52)
+            ForEach(days, id: \.self) { day in
+                let isToday = calendar.isSameDay(day, Date())
+                VStack(spacing: 1) {
+                    Text(QuestlyFormat.weekdayInitial(day, calendar: calendar))
+                        .font(.questMicro)
+                        .foregroundStyle(.secondary)
+                    Text(QuestlyFormat.dayNumber(day, calendar: calendar))
+                        .font(.questCaption)
+                        .foregroundStyle(isToday ? .white : .primary)
+                        .frame(width: 24, height: 24)
+                        .background {
+                            if isToday {
+                                Circle().fill(theme.gradient)
+                            }
+                        }
+                }
+                .frame(maxWidth: .infinity)
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    selectedDate = day
+                    withAnimation(Motion.snappy) { mode = .day }
+                }
+            }
+        }
+        .padding(.vertical, 4)
+        .padding(.trailing, 8)
+        .background(.ultraThinMaterial)
+    }
+
+    private var monthContent: some View {
+        VStack(spacing: 0) {
+            TabView(selection: $monthPage) {
+                ForEach(monthRange, id: \.self) { offset in
+                    let reference = calendar.date(byAdding: .month, value: offset, to: Date()) ?? Date()
+                    MonthGridView(
+                        month: reference,
+                        selectedDate: $selectedDate,
+                        summaries: summaries(forMonth: reference)
+                    )
+                    .tag(offset)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .never))
+            .frame(height: 320)
+
+            Divider().opacity(0.4)
+
+            DayAgendaPanel(date: selectedDate) { task in
+                selectedTask = task
+            }
+        }
+    }
+
+    // MARK: Sélecteur de date
+
+    private var datePickerSheet: some View {
+        NavigationStack {
+            VStack {
+                DatePicker(
+                    "Aller à",
+                    selection: $selectedDate,
+                    displayedComponents: [.date]
+                )
+                .datePickerStyle(.graphical)
+                .padding()
+
+                Spacer()
+            }
+            .navigationTitle("Aller à une date")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("OK") {
+                        monthPage = monthOffset(for: selectedDate)
+                        weekPage = weekOffset(for: selectedDate)
+                        showsDatePicker = false
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: Navigation
+
+    private func step(_ direction: Int) {
+        withAnimation(Motion.snappy) {
+            switch mode {
+            case .day:
+                selectedDate = selectedDate.adding(days: direction, calendar: calendar)
+            case .week:
+                weekPage += direction
+                selectedDate = calendar.date(byAdding: .weekOfYear, value: direction, to: selectedDate) ?? selectedDate
+            case .month, .agenda:
+                monthPage += direction
+                selectedDate = calendar.date(byAdding: .month, value: direction, to: selectedDate) ?? selectedDate
+            case .year:
+                selectedDate = calendar.date(byAdding: .year, value: direction, to: selectedDate) ?? selectedDate
+            }
+        }
+        Haptics.selection()
+    }
+
+    private func goToToday() {
+        withAnimation(Motion.gentle) {
+            selectedDate = Date()
+            monthPage = 0
+            weekPage = 0
+        }
+        Haptics.light()
+    }
+
+    private func monthOffset(for date: Date) -> Int {
+        let from = calendar.startOfMonth(Date())
+        let to = calendar.startOfMonth(date)
+        return calendar.dateComponents([.month], from: from, to: to).month ?? 0
+    }
+
+    private func weekOffset(for date: Date) -> Int {
+        let from = calendar.startOfWeek(Date())
+        let to = calendar.startOfWeek(date)
+        return (calendar.daysBetween(from, to)) / 7
+    }
+
+    private func syncSelection(monthOffset: Int) {
+        guard let target = calendar.date(byAdding: .month, value: monthOffset, to: Date()) else { return }
+        if !calendar.isDate(selectedDate, equalTo: target, toGranularity: .month) {
+            let day = min(calendar.component(.day, from: selectedDate), calendar.numberOfDaysInMonth(target))
+            var comps = calendar.dateComponents([.year, .month], from: target)
+            comps.day = day
+            selectedDate = calendar.date(from: comps) ?? target
+        }
+    }
+
+    private func syncSelection(weekOffset: Int) {
+        guard let target = calendar.date(byAdding: .weekOfYear, value: weekOffset, to: Date()) else { return }
+        if calendar.startOfWeek(selectedDate) != calendar.startOfWeek(target) {
+            selectedDate = target
+        }
+    }
+
+    // MARK: Données
+
+    private func tasksDue(on day: Date) -> [TaskItem] {
+        tasks.filter { $0.isDue(on: day, calendar: calendar) }
+    }
+
+    private func summaries(forMonth month: Date) -> [Date: DaySummary] {
+        var output: [Date: DaySummary] = [:]
+        let grid = calendar.monthGrid(for: month)
+        guard let first = grid.first, let last = grid.last else { return output }
+
+        for task in tasks {
+            guard let due = task.dueDate else { continue }
+            let day = calendar.startOfDay(for: due)
+            guard day >= first && day <= last else { continue }
+            var summary = output[day] ?? DaySummary()
+            summary.taskCount += 1
+            if task.isCompleted { summary.completedCount += 1 }
+            if task.isBoss { summary.hasBoss = true }
+            if task.isOverdue(now: Date(), calendar: calendar) { summary.hasOverdue = true }
+            let hex = task.lifeArea?.hex ?? task.priority.hex
+            if !summary.areaHexes.contains(hex) && summary.areaHexes.count < 3 {
+                summary.areaHexes.append(hex)
+            }
+            output[day] = summary
+        }
+
+        for block in blocks {
+            let day = calendar.startOfDay(for: block.start)
+            guard day >= first && day <= last else { continue }
+            var summary = output[day] ?? DaySummary()
+            summary.blockMinutes += block.durationMinutes
+            output[day] = summary
+        }
+
+        return output
+    }
+
+    private func loadExternalEvents() {
+        guard settings.calendarSyncEnabled, calendarService.access == .granted else { return }
+        let start = calendar.startOfMonth(selectedDate).adding(days: -7, calendar: calendar)
+        let end = calendar.endOfMonth(selectedDate).adding(days: 7, calendar: calendar)
+        calendarService.load(from: start, to: end)
+    }
+
+    private func enableCalendarSync() async {
+        if calendarService.access != .granted {
+            let granted = await calendarService.requestAccess()
+            settings.calendarSyncEnabled = granted
+        }
+        loadExternalEvents()
+    }
+}
+
+// MARK: - Grille du mois
+
+struct MonthGridView: View {
+
+    let month: Date
+    @Binding var selectedDate: Date
+    let summaries: [Date: DaySummary]
+
+    @Environment(SettingsStore.self) private var settings
+    @Environment(\.questlyTheme) private var theme
+
+    private var calendar: Calendar { settings.calendar }
+
+    var body: some View {
+        VStack(spacing: 4) {
+            weekdayHeader
+
+            let grid = calendar.monthGrid(for: month)
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 2), count: 7), spacing: 4) {
+                ForEach(grid, id: \.self) { day in
+                    MonthDayCell(
+                        day: day,
+                        isInMonth: calendar.isDate(day, equalTo: month, toGranularity: .month),
+                        isToday: calendar.isSameDay(day, Date()),
+                        isSelected: calendar.isSameDay(day, selectedDate),
+                        summary: summaries[calendar.startOfDay(for: day)] ?? DaySummary(),
+                        capacityMinutes: settings.workEndMinute - settings.workStartMinute
+                    )
+                    .onTapGesture {
+                        withAnimation(Motion.snappy) { selectedDate = day }
+                        Haptics.selection()
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, Metrics.spacingS)
+    }
+
+    private var weekdayHeader: some View {
+        HStack(spacing: 2) {
+            ForEach(calendar.weekDays(for: Date()), id: \.self) { day in
+                Text(QuestlyFormat.weekdayInitial(day, calendar: calendar))
+                    .font(.questMicro)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+        .padding(.top, 4)
+    }
+}
+
+// MARK: - Case du mois
+
+struct MonthDayCell: View {
+
+    let day: Date
+    let isInMonth: Bool
+    let isToday: Bool
+    let isSelected: Bool
+    let summary: DaySummary
+    let capacityMinutes: Int
+
+    @Environment(SettingsStore.self) private var settings
+    @Environment(\.questlyTheme) private var theme
+
+    private var calendar: Calendar { settings.calendar }
+
+    var body: some View {
+        VStack(spacing: 3) {
+            Text(QuestlyFormat.dayNumber(day, calendar: calendar))
+                .font(.system(size: 14, weight: isToday ? .bold : .medium, design: .rounded))
+                .foregroundStyle(numberColor)
+                .frame(width: 28, height: 28)
+                .background {
+                    if isSelected {
+                        Circle().fill(theme.gradient)
+                    } else if isToday {
+                        Circle().strokeBorder(theme.accent, lineWidth: 1.5)
+                    }
+                }
+
+            dots
+        }
+        .frame(height: 46)
+        .frame(maxWidth: .infinity)
+        .background {
+            if summary.blockMinutes > 0 {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(theme.accent.opacity(0.06 + summary.load(capacityMinutes: capacityMinutes) * 0.14))
+            }
+        }
+        .overlay(alignment: .topTrailing) {
+            if summary.hasBoss {
+                Image(systemName: "crown.fill")
+                    .font(.system(size: 7))
+                    .foregroundStyle(Color(hex: "BF5AF2"))
+                    .padding(2)
+            }
+        }
+        .opacity(isInMonth ? 1 : 0.32)
+        .contentShape(Rectangle())
+    }
+
+    private var numberColor: Color {
+        if isSelected { return .white }
+        if isToday { return theme.accent }
+        if summary.hasOverdue { return Color(hex: "FF453A") }
+        return .primary
+    }
+
+    private var dots: some View {
+        HStack(spacing: 2) {
+            if summary.taskCount == 0 {
+                Circle().fill(Color.clear).frame(width: 5, height: 5)
+            } else {
+                ForEach(Array(summary.areaHexes.prefix(3).enumerated()), id: \.offset) { _, hex in
+                    Circle()
+                        .fill(Color(hex: hex))
+                        .frame(width: 5, height: 5)
+                        .opacity(summary.completionFraction >= 1 ? 0.35 : 1)
+                }
+                if summary.taskCount > 3 {
+                    Text("+")
+                        .font(.system(size: 8, weight: .bold))
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .frame(height: 6)
+    }
+}

--- a/QuestlyApp/Questly/Features/Calendar/CalendarSupport.swift
+++ b/QuestlyApp/Questly/Features/Calendar/CalendarSupport.swift
@@ -1,0 +1,237 @@
+import SwiftUI
+import QuestlyKit
+
+// MARK: - Entrée de calendrier
+
+/// Élément affichable sur une timeline, quelle que soit son origine :
+/// bloc Questly, quête horodatée, ou évènement du calendrier système.
+struct TimedEntry: Identifiable, Equatable {
+
+    enum Source: Equatable {
+        case block
+        case task
+        case external
+    }
+
+    let id: String
+    let title: String
+    let start: Date
+    let end: Date
+    let colorHex: String
+    let source: Source
+    let symbolName: String
+    /// Identifiant de la quête liée, s'il y en a une.
+    let taskIdentifier: UUID?
+    let blockIdentifier: UUID?
+    let isCompleted: Bool
+
+    var durationMinutes: Int { max(5, Int(end.timeIntervalSince(start) / 60)) }
+    var color: Color { Color(hex: colorHex) }
+
+    var isEditable: Bool { source != .external }
+
+    static func from(block: TimeBlock) -> TimedEntry {
+        TimedEntry(
+            id: "block-\(block.identifier.uuidString)",
+            title: block.title.isEmpty ? (block.task?.title ?? "Bloc") : block.title,
+            start: block.start,
+            end: block.end,
+            colorHex: block.colorHex,
+            source: .block,
+            symbolName: block.task?.isBoss == true ? "crown.fill" : "rectangle.fill",
+            taskIdentifier: block.task?.identifier,
+            blockIdentifier: block.identifier,
+            isCompleted: block.task?.isCompleted ?? false
+        )
+    }
+
+    static func from(task: TaskItem, defaultMinutes: Int = 30) -> TimedEntry {
+        let start = task.dueDate ?? Date()
+        let minutes = task.estimatedMinutes > 0 ? task.estimatedMinutes : defaultMinutes
+        return TimedEntry(
+            id: "task-\(task.identifier.uuidString)",
+            title: task.title,
+            start: start,
+            end: start.addingTimeInterval(TimeInterval(minutes * 60)),
+            colorHex: task.lifeArea?.hex ?? task.priority.hex,
+            source: .task,
+            symbolName: task.isBoss ? "crown.fill" : "checkmark.circle",
+            taskIdentifier: task.identifier,
+            blockIdentifier: nil,
+            isCompleted: task.isCompleted
+        )
+    }
+
+    static func from(external: CalendarService.ExternalEvent) -> TimedEntry {
+        TimedEntry(
+            id: "ext-\(external.id)",
+            title: external.title,
+            start: external.start,
+            end: external.end,
+            colorHex: external.colorHex,
+            source: .external,
+            symbolName: "calendar",
+            taskIdentifier: nil,
+            blockIdentifier: nil,
+            isCompleted: false
+        )
+    }
+}
+
+// MARK: - Disposition des chevauchements
+
+/// Place côte à côte les entrées qui se chevauchent, comme le fait
+/// Calendar d'Apple : sans ça, une journée chargée devient illisible.
+enum TimelineLayout {
+
+    struct Placement: Identifiable, Equatable {
+        let entry: TimedEntry
+        /// Colonne occupée (0 = la plus à gauche).
+        let column: Int
+        /// Nombre total de colonnes dans le groupe de chevauchement.
+        let columnCount: Int
+
+        var id: String { entry.id }
+    }
+
+    static func place(_ entries: [TimedEntry]) -> [Placement] {
+        let sorted = entries.sorted { lhs, rhs in
+            if lhs.start != rhs.start { return lhs.start < rhs.start }
+            return lhs.end > rhs.end
+        }
+
+        var placements: [Placement] = []
+        var cluster: [TimedEntry] = []
+        var clusterEnd: Date?
+
+        func flush() {
+            guard !cluster.isEmpty else { return }
+            placements.append(contentsOf: assignColumns(cluster))
+            cluster = []
+            clusterEnd = nil
+        }
+
+        for entry in sorted {
+            if let end = clusterEnd, entry.start >= end {
+                flush()
+            }
+            cluster.append(entry)
+            clusterEnd = max(clusterEnd ?? entry.end, entry.end)
+        }
+        flush()
+
+        return placements
+    }
+
+    /// Attribue une colonne à chaque entrée d'un groupe qui se chevauche.
+    private static func assignColumns(_ cluster: [TimedEntry]) -> [Placement] {
+        var columnEnds: [Date] = []
+        var assignments: [(TimedEntry, Int)] = []
+
+        for entry in cluster {
+            var placed = false
+            for index in columnEnds.indices where columnEnds[index] <= entry.start {
+                columnEnds[index] = entry.end
+                assignments.append((entry, index))
+                placed = true
+                break
+            }
+            if !placed {
+                columnEnds.append(entry.end)
+                assignments.append((entry, columnEnds.count - 1))
+            }
+        }
+
+        let total = max(1, columnEnds.count)
+        return assignments.map { Placement(entry: $0.0, column: $0.1, columnCount: total) }
+    }
+}
+
+// MARK: - Géométrie de la timeline
+
+/// Conversions entre minutes et points sur la timeline.
+struct TimelineGeometry {
+    var hourHeight: CGFloat = Metrics.hourHeight
+    var startHour: Int = 0
+    var endHour: Int = 24
+
+    var totalHeight: CGFloat {
+        CGFloat(endHour - startHour) * hourHeight
+    }
+
+    func offset(for date: Date, in day: Date, calendar: Calendar) -> CGFloat {
+        let minutes = Double(date.minutesSinceMidnight(calendar: calendar))
+        let dayDelta = Double(calendar.daysBetween(day, date)) * 24 * 60
+        let total = minutes + dayDelta - Double(startHour * 60)
+        return CGFloat(total / 60) * hourHeight
+    }
+
+    func height(forMinutes minutes: Int) -> CGFloat {
+        max(18, CGFloat(minutes) / 60 * hourHeight)
+    }
+
+    /// Instant correspondant à une position verticale, arrondi au pas donné.
+    func date(atOffset offset: CGFloat, in day: Date, calendar: Calendar, snapMinutes: Int = 15) -> Date {
+        let rawMinutes = Double(offset / hourHeight) * 60 + Double(startHour * 60)
+        let clamped = min(max(rawMinutes, 0), 24 * 60 - Double(snapMinutes))
+        let snapped = (clamped / Double(snapMinutes)).rounded() * Double(snapMinutes)
+        return calendar.startOfDay(for: day).addingTimeInterval(snapped * 60)
+    }
+}
+
+// MARK: - Mode d'affichage
+
+enum CalendarMode: String, CaseIterable, Identifiable, Hashable {
+    case day
+    case week
+    case month
+    case year
+    case agenda
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .day: return "Jour"
+        case .week: return "Semaine"
+        case .month: return "Mois"
+        case .year: return "Année"
+        case .agenda: return "Agenda"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .day: return "rectangle.grid.1x2"
+        case .week: return "calendar.day.timeline.left"
+        case .month: return "calendar"
+        case .year: return "square.grid.3x3"
+        case .agenda: return "list.bullet"
+        }
+    }
+}
+
+// MARK: - Densité d'une journée
+
+/// Résumé d'une journée, utilisé par la grille du mois et la vue année.
+struct DaySummary: Equatable {
+    var taskCount: Int = 0
+    var completedCount: Int = 0
+    var blockMinutes: Int = 0
+    var hasBoss: Bool = false
+    var hasOverdue: Bool = false
+    var areaHexes: [String] = []
+
+    var isEmpty: Bool { taskCount == 0 && blockMinutes == 0 }
+
+    var completionFraction: Double {
+        guard taskCount > 0 else { return 0 }
+        return Double(completedCount) / Double(taskCount)
+    }
+
+    /// Charge de la journée, 0…1, pour teinter la case du mois.
+    func load(capacityMinutes: Int) -> Double {
+        guard capacityMinutes > 0 else { return 0 }
+        return min(1, Double(blockMinutes) / Double(capacityMinutes))
+    }
+}

--- a/QuestlyApp/Questly/Features/Calendar/QuestlyTimeline.swift
+++ b/QuestlyApp/Questly/Features/Calendar/QuestlyTimeline.swift
@@ -1,0 +1,544 @@
+import SwiftUI
+import Combine
+import SwiftData
+import QuestlyKit
+
+/// Timeline horaire, utilisée pour la vue Jour (une colonne) et la vue Semaine
+/// (sept colonnes). On peut y déposer une quête, déplacer un bloc, en créer un
+/// d'un appui long sur une plage libre.
+struct QuestlyTimeline: View {
+
+    let days: [Date]
+    @Binding var selectedDate: Date
+    var showsAllDayRow: Bool = true
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(SettingsStore.self) private var settings
+    @Environment(CalendarService.self) private var calendarService
+    @Environment(\.questlyTheme) private var theme
+
+    @Query private var tasks: [TaskItem]
+    @Query private var blocks: [TimeBlock]
+
+    @State private var geometry = TimelineGeometry()
+    @State private var draggingEntry: String?
+    @State private var dragOffset: CGFloat = 0
+    @State private var pendingSlot: PendingSlot?
+    @State private var selectedTask: TaskItem?
+    @State private var now = Date()
+
+    private let gutterWidth: CGFloat = 52
+    private let refreshTimer = Timer.publish(every: 60, on: .main, in: .common).autoconnect()
+
+    private var calendar: Calendar { settings.calendar }
+
+    struct PendingSlot: Identifiable {
+        let id = UUID()
+        let start: Date
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if showsAllDayRow { allDayRow }
+            ScrollViewReader { proxy in
+                ScrollView(.vertical, showsIndicators: false) {
+                    timelineBody
+                        .padding(.bottom, 120)
+                }
+                .onAppear {
+                    proxy.scrollTo(scrollAnchorHour, anchor: .top)
+                }
+            }
+        }
+        .onReceive(refreshTimer) { _ in now = Date() }
+        .sheet(item: $pendingSlot) { slot in
+            SlotComposerSheet(start: slot.start)
+                .presentationDetents([.medium, .large])
+        }
+        .sheet(item: $selectedTask) { task in
+            TaskDetailView(task: task)
+        }
+    }
+
+    private var scrollAnchorHour: Int {
+        max(0, calendar.component(.hour, from: Date()) - 1)
+    }
+
+    // MARK: Ligne « toute la journée »
+
+    /// Colonne de la bande « toute la journée » (un type nommé : les key-paths
+    /// sur tuples ne sont pas disponibles en Swift).
+    private struct AllDayColumn: Identifiable {
+        let id: Date
+        let tasks: [TaskItem]
+    }
+
+    private var allDayRow: some View {
+        let columns = days.map { AllDayColumn(id: $0, tasks: allDayTasks(on: $0)) }
+        let hasAny = columns.contains { !$0.tasks.isEmpty }
+
+        return Group {
+            if hasAny {
+                HStack(alignment: .top, spacing: 1) {
+                    Text("Journée")
+                        .font(.questMicro)
+                        .foregroundStyle(.secondary)
+                        .frame(width: gutterWidth, alignment: .trailing)
+                        .padding(.trailing, 4)
+
+                    ForEach(columns) { column in
+                        VStack(spacing: 3) {
+                            ForEach(column.tasks.prefix(3)) { task in
+                                Button {
+                                    selectedTask = task
+                                } label: {
+                                    Text(task.title)
+                                        .font(.questMicro)
+                                        .lineLimit(1)
+                                        .foregroundStyle(.white)
+                                        .padding(.horizontal, 6)
+                                        .padding(.vertical, 3)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .background {
+                                            RoundedRectangle(cornerRadius: 5, style: .continuous)
+                                                .fill(Color(hex: task.lifeArea?.hex ?? task.priority.hex)
+                                                    .opacity(task.isCompleted ? 0.4 : 0.9))
+                                        }
+                                }
+                                .buttonStyle(.plain)
+                            }
+                            if column.tasks.count > 3 {
+                                Text("+\(column.tasks.count - 3)")
+                                    .font(.questMicro)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                }
+                .padding(.vertical, 5)
+                .padding(.trailing, 8)
+                .background(.ultraThinMaterial)
+            }
+        }
+    }
+
+    // MARK: Corps de la timeline
+
+    private var timelineBody: some View {
+        ZStack(alignment: .topLeading) {
+            hourGrid
+            HStack(spacing: 1) {
+                ForEach(days, id: \.self) { day in
+                    dayColumn(day)
+                }
+            }
+            .padding(.leading, gutterWidth)
+            .padding(.trailing, 8)
+
+            nowIndicator
+        }
+    }
+
+    private var hourGrid: some View {
+        VStack(spacing: 0) {
+            ForEach(0..<24, id: \.self) { hour in
+                HStack(alignment: .top, spacing: 4) {
+                    Text(String(format: "%02d:00", hour))
+                        .font(.questMicro)
+                        .foregroundStyle(.secondary)
+                        .frame(width: gutterWidth - 6, alignment: .trailing)
+                        .offset(y: -6)
+
+                    Rectangle()
+                        .fill(Color.primary.opacity(0.07))
+                        .frame(height: 1)
+                }
+                .frame(height: geometry.hourHeight, alignment: .top)
+                .id(hour)
+            }
+        }
+    }
+
+    private func dayColumn(_ day: Date) -> some View {
+        GeometryReader { proxy in
+            let width = proxy.size.width
+            let placements = TimelineLayout.place(entries(on: day))
+
+            ZStack(alignment: .topLeading) {
+                // Fond cliquable : appui long = nouveau bloc.
+                Rectangle()
+                    .fill(calendar.isSameDay(day, Date())
+                          ? theme.accent.opacity(0.04)
+                          : Color.clear)
+                    .contentShape(Rectangle())
+                    .onTapGesture { location in
+                        let start = geometry.date(atOffset: location.y, in: day, calendar: calendar, snapMinutes: 30)
+                        pendingSlot = PendingSlot(start: start)
+                        Haptics.light()
+                    }
+
+                // Bande des heures non travaillées, pour situer la journée.
+                nonWorkingOverlay(day: day)
+
+                ForEach(placements) { placement in
+                    entryView(placement, day: day, columnWidth: width)
+                }
+            }
+            .frame(height: geometry.totalHeight)
+            .dropDestination(for: String.self) { items, location in
+                handleDrop(items: items, location: location, day: day)
+            }
+        }
+        .frame(height: geometry.totalHeight)
+    }
+
+    private func nonWorkingOverlay(day: Date) -> some View {
+        let hours = settings.workingHours
+        let startOffset = CGFloat(hours.startMinute) / 60 * geometry.hourHeight
+        let endOffset = CGFloat(hours.endMinute) / 60 * geometry.hourHeight
+
+        return VStack(spacing: 0) {
+            Rectangle()
+                .fill(Color.primary.opacity(0.035))
+                .frame(height: startOffset)
+            Spacer(minLength: 0)
+            Rectangle()
+                .fill(Color.primary.opacity(0.035))
+                .frame(height: max(0, geometry.totalHeight - endOffset))
+        }
+        .allowsHitTesting(false)
+    }
+
+    private func entryView(_ placement: TimelineLayout.Placement, day: Date, columnWidth: CGFloat) -> some View {
+        let entry = placement.entry
+        let slotWidth = max(24, (columnWidth - 4) / CGFloat(placement.columnCount))
+        let isDragging = draggingEntry == entry.id
+        let baseOffset = geometry.offset(for: entry.start, in: day, calendar: calendar)
+
+        return TimelineEntryCard(entry: entry, compact: slotWidth < 90)
+            .frame(width: slotWidth - 3, height: geometry.height(forMinutes: entry.durationMinutes))
+            .offset(
+                x: CGFloat(placement.column) * slotWidth + 2,
+                y: baseOffset + (isDragging ? dragOffset : 0)
+            )
+            .opacity(isDragging ? 0.85 : 1)
+            .scaleEffect(isDragging ? 1.03 : 1)
+            .shadow(color: .black.opacity(isDragging ? 0.25 : 0), radius: 10, y: 6)
+            .zIndex(isDragging ? 10 : 0)
+            .onTapGesture { open(entry) }
+            .applyIf(entry.isEditable) { view in
+                view.gesture(moveGesture(for: entry, day: day))
+            }
+            .contextMenu { entryMenu(entry) }
+    }
+
+    private func moveGesture(for entry: TimedEntry, day: Date) -> some Gesture {
+        LongPressGesture(minimumDuration: 0.25)
+            .onEnded { _ in
+                draggingEntry = entry.id
+                Haptics.play(.medium)
+            }
+            .sequenced(before: DragGesture(minimumDistance: 0))
+            .onChanged { value in
+                guard case .second(true, let drag?) = value else { return }
+                dragOffset = drag.translation.height
+            }
+            .onEnded { value in
+                guard case .second(true, let drag?) = value else {
+                    draggingEntry = nil
+                    dragOffset = 0
+                    return
+                }
+                commitMove(entry: entry, day: day, translation: drag.translation.height)
+                draggingEntry = nil
+                dragOffset = 0
+            }
+    }
+
+    private func commitMove(entry: TimedEntry, day: Date, translation: CGFloat) {
+        let originalOffset = geometry.offset(for: entry.start, in: day, calendar: calendar)
+        let newStart = geometry.date(
+            atOffset: originalOffset + translation,
+            in: day,
+            calendar: calendar,
+            snapMinutes: 15
+        )
+
+        if let blockID = entry.blockIdentifier,
+           let block = blocks.first(where: { $0.identifier == blockID }) {
+            store.move(block, to: newStart)
+            Haptics.success()
+        } else if let taskID = entry.taskIdentifier,
+                  let task = tasks.first(where: { $0.identifier == taskID }) {
+            task.dueDate = newStart
+            task.hasTime = true
+            task.touch()
+            store.save()
+            Haptics.success()
+        }
+    }
+
+    @ViewBuilder
+    private func entryMenu(_ entry: TimedEntry) -> some View {
+        if let blockID = entry.blockIdentifier,
+           let block = blocks.first(where: { $0.identifier == blockID }) {
+            Button {
+                store.resize(block, toMinutes: 30)
+            } label: { Label("30 minutes", systemImage: "timer") }
+            Button {
+                store.resize(block, toMinutes: 60)
+            } label: { Label("1 heure", systemImage: "timer") }
+            Button {
+                store.resize(block, toMinutes: 120)
+            } label: { Label("2 heures", systemImage: "timer") }
+            Divider()
+            Button(role: .destructive) {
+                store.delete(block)
+                Haptics.warning()
+            } label: { Label("Libérer le créneau", systemImage: "trash") }
+        } else if entry.source == .task {
+            Button {
+                open(entry)
+            } label: { Label("Ouvrir la quête", systemImage: "square.and.pencil") }
+        }
+    }
+
+    private func open(_ entry: TimedEntry) {
+        guard let taskID = entry.taskIdentifier,
+              let task = tasks.first(where: { $0.identifier == taskID }) else { return }
+        selectedTask = task
+    }
+
+    // MARK: Indicateur d'instant présent
+
+    @ViewBuilder
+    private var nowIndicator: some View {
+        if let index = days.firstIndex(where: { calendar.isSameDay($0, now) }) {
+            let offset = geometry.offset(for: now, in: days[index], calendar: calendar)
+            HStack(spacing: 0) {
+                Circle()
+                    .fill(Color(hex: "FF453A"))
+                    .frame(width: 7, height: 7)
+                Rectangle()
+                    .fill(Color(hex: "FF453A"))
+                    .frame(height: 1.5)
+            }
+            .padding(.leading, gutterWidth - 3)
+            .padding(.trailing, 8)
+            .offset(y: offset)
+            .allowsHitTesting(false)
+            .zIndex(5)
+        }
+    }
+
+    // MARK: Données
+
+    private func entries(on day: Date) -> [TimedEntry] {
+        var output: [TimedEntry] = []
+
+        for block in blocks where calendar.isSameDay(block.start, day) && !block.isAllDay {
+            output.append(TimedEntry.from(block: block))
+        }
+
+        // Les quêtes horodatées sans bloc réservé apparaissent quand même.
+        let scheduledTaskIDs = Set(output.compactMap(\.taskIdentifier))
+        for task in tasks where task.hasTime && task.isOpen {
+            guard let due = task.dueDate, calendar.isSameDay(due, day) else { continue }
+            guard !scheduledTaskIDs.contains(task.identifier) else { continue }
+            output.append(TimedEntry.from(task: task))
+        }
+
+        for event in calendarService.events(on: day, calendar: calendar) where !event.isAllDay {
+            output.append(TimedEntry.from(external: event))
+        }
+
+        return output
+    }
+
+    private func allDayTasks(on day: Date) -> [TaskItem] {
+        tasks.filter { task in
+            guard !task.hasTime, let due = task.dueDate else { return false }
+            return calendar.isSameDay(due, day) && task.isOpen
+        }
+    }
+
+    private func handleDrop(items: [String], location: CGPoint, day: Date) -> Bool {
+        guard let identifier = items.first,
+              let uuid = UUID(uuidString: identifier),
+              let task = tasks.first(where: { $0.identifier == uuid }) else { return false }
+
+        let start = geometry.date(atOffset: location.y, in: day, calendar: calendar, snapMinutes: 15)
+        store.schedule(task, at: start)
+        Haptics.success()
+        return true
+    }
+}
+
+// MARK: - Carte d'une entrée
+
+struct TimelineEntryCard: View {
+    let entry: TimedEntry
+    var compact: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            HStack(spacing: 3) {
+                if entry.source == .external {
+                    Image(systemName: "calendar")
+                        .font(.system(size: 8, weight: .bold))
+                } else if entry.symbolName == "crown.fill" {
+                    Image(systemName: "crown.fill")
+                        .font(.system(size: 8, weight: .bold))
+                }
+                Text(entry.title)
+                    .font(.system(size: compact ? 9 : 11, weight: .semibold, design: .rounded))
+                    .lineLimit(compact ? 1 : 2)
+                    .strikethrough(entry.isCompleted)
+            }
+
+            if !compact && entry.durationMinutes >= 40 {
+                Text(QuestlyFormat.time(entry.start))
+                    .font(.system(size: 9, weight: .medium, design: .rounded))
+                    .opacity(0.8)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 5)
+        .padding(.vertical, 3)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .foregroundStyle(entry.source == .external ? entry.color : .white)
+        .background {
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .fill(entry.source == .external
+                      ? AnyShapeStyle(entry.color.opacity(0.16))
+                      : AnyShapeStyle(LinearGradient(
+                          colors: [entry.color, entry.color.opacity(0.78)],
+                          startPoint: .topLeading,
+                          endPoint: .bottomTrailing
+                      )))
+                .opacity(entry.isCompleted ? 0.45 : 1)
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .strokeBorder(entry.color.opacity(entry.source == .external ? 0.5 : 0), lineWidth: 1)
+        }
+        .overlay(alignment: .leading) {
+            if entry.source == .external {
+                Rectangle()
+                    .fill(entry.color)
+                    .frame(width: 3)
+                    .clipShape(RoundedRectangle(cornerRadius: 2))
+            }
+        }
+    }
+}
+
+// MARK: - Composition d'un créneau
+
+/// Feuille ouverte en tapant une plage libre : on y crée un bloc, soit à partir
+/// d'une quête existante, soit d'un intitulé libre.
+struct SlotComposerSheet: View {
+
+    let start: Date
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(SettingsStore.self) private var settings
+    @Environment(\.questlyTheme) private var theme
+    @Environment(\.dismiss) private var dismiss
+
+    @Query private var tasks: [TaskItem]
+
+    @State private var title = ""
+    @State private var minutes = 60
+    @State private var searchText = ""
+
+    private var calendar: Calendar { settings.calendar }
+
+    private var candidates: [TaskItem] {
+        let open = tasks.filter(\.isOpen)
+        guard !searchText.isEmpty else {
+            return Array(open.sorted(by: TaskSorting.smart(calendar: calendar)).prefix(12))
+        }
+        let needle = searchText.lowercased()
+        return open.filter { $0.title.lowercased().contains(needle) }
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    HStack {
+                        Label("Début", systemImage: "clock")
+                        Spacer()
+                        Text("\(QuestlyFormat.fullDay(start, calendar: calendar)) · \(QuestlyFormat.time(start, calendar: calendar))")
+                            .font(.questCaption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Picker("Durée", selection: $minutes) {
+                        ForEach([15, 30, 45, 60, 90, 120, 180], id: \.self) { value in
+                            Text(DurationFormatter.short(minutes: value)).tag(value)
+                        }
+                    }
+                }
+
+                Section("Bloquer une quête") {
+                    ForEach(candidates) { task in
+                        Button {
+                            store.schedule(task, at: start, minutes: minutes)
+                            Haptics.success()
+                            dismiss()
+                        } label: {
+                            HStack {
+                                Circle()
+                                    .fill(Color(hex: task.lifeArea?.hex ?? task.priority.hex))
+                                    .frame(width: 8, height: 8)
+                                Text(task.title).font(.questBody)
+                                Spacer()
+                                if task.estimatedMinutes > 0 {
+                                    Text(DurationFormatter.short(minutes: task.estimatedMinutes))
+                                        .font(.questMicro)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+
+                Section("Ou créer un bloc libre") {
+                    TextField("Intitulé du créneau", text: $title)
+                    Button {
+                        createFreeBlock()
+                    } label: {
+                        Label("Réserver ce créneau", systemImage: "plus.rectangle.on.rectangle")
+                    }
+                    .disabled(title.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+            }
+            .searchable(text: $searchText, prompt: "Chercher une quête")
+            .navigationTitle("Nouveau créneau")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Annuler") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func createFreeBlock() {
+        let block = TimeBlock(
+            title: title.trimmingCharacters(in: .whitespacesAndNewlines),
+            start: start,
+            end: start.addingTimeInterval(TimeInterval(minutes * 60)),
+            colorHex: theme.accentHex
+        )
+        store.modelContext.insert(block)
+        store.save()
+        Haptics.success()
+        dismiss()
+    }
+}

--- a/QuestlyApp/Questly/Features/Focus/FocusView.swift
+++ b/QuestlyApp/Questly/Features/Focus/FocusView.swift
@@ -1,0 +1,590 @@
+import SwiftUI
+import SwiftData
+import Combine
+import QuestlyKit
+
+/// Le Donjon : minuteur de concentration façon Pomodoro, transformé en combat.
+/// Chaque minute de concentration retire des points de vie au boss choisi.
+struct FocusView: View {
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(SettingsStore.self) private var settings
+    @Environment(NotificationService.self) private var notifications
+    @Environment(\.questlyTheme) private var theme
+    @Environment(\.scenePhase) private var scenePhase
+
+    @Query private var tasks: [TaskItem]
+    @Query private var sessions: [FocusSession]
+
+    @State private var phase: Phase = .idle
+    @State private var kind: SessionKind = .focus
+    @State private var startedAt: Date?
+    @State private var elapsedBeforePause = 0
+    @State private var tick = Date()
+    @State private var selectedTaskID: UUID?
+    @State private var distractions = 0
+    @State private var completedRounds = 0
+    @State private var showsTaskPicker = false
+    @State private var showsCelebration = false
+
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+    enum Phase: Equatable {
+        case idle
+        case running
+        case paused
+        case finished
+    }
+
+    enum SessionKind: Equatable {
+        case focus
+        case shortBreak
+        case longBreak
+
+        var label: String {
+            switch self {
+            case .focus: return "Concentration"
+            case .shortBreak: return "Pause"
+            case .longBreak: return "Grande pause"
+            }
+        }
+
+        var symbolName: String {
+            switch self {
+            case .focus: return "target"
+            case .shortBreak: return "cup.and.saucer.fill"
+            case .longBreak: return "figure.walk"
+            }
+        }
+    }
+
+    private var calendar: Calendar { settings.calendar }
+
+    private var selectedTask: TaskItem? {
+        guard let selectedTaskID else { return nil }
+        return tasks.first { $0.identifier == selectedTaskID }
+    }
+
+    private var plannedMinutes: Int {
+        switch kind {
+        case .focus: return settings.focusDuration
+        case .shortBreak: return settings.breakDuration
+        case .longBreak: return settings.longBreakDuration
+        }
+    }
+
+    private var elapsedSeconds: Int {
+        guard let startedAt, phase == .running else { return elapsedBeforePause }
+        return elapsedBeforePause + Int(tick.timeIntervalSince(startedAt))
+    }
+
+    private var remainingSeconds: Int {
+        max(0, plannedMinutes * 60 - elapsedSeconds)
+    }
+
+    private var progress: Double {
+        let total = Double(plannedMinutes * 60)
+        guard total > 0 else { return 0 }
+        return min(1, Double(elapsedSeconds) / total)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: Metrics.spacingL) {
+                kindPicker
+                timerDial
+                targetCard
+                controls
+                if kind == .focus { distractionCard }
+                todaySummary
+                Color.clear.frame(height: 110)
+            }
+            .padding(.horizontal, Metrics.spacingM)
+            .padding(.top, Metrics.spacingM)
+        }
+        .scrollIndicators(.hidden)
+        .onReceive(timer) { date in
+            tick = date
+            if phase == .running && remainingSeconds == 0 {
+                finish()
+            }
+        }
+        .onChange(of: scenePhase) { _, newValue in
+            // Le temps continue de couler en arrière-plan : on recalcule à partir
+            // des dates plutôt que de compter les tics.
+            if newValue == .active { tick = Date() }
+        }
+        .sheet(isPresented: $showsTaskPicker) {
+            FocusTaskPicker(selectedTaskID: $selectedTaskID)
+                .presentationDetents([.medium, .large])
+        }
+    }
+
+    // MARK: Type de session
+
+    private var kindPicker: some View {
+        HStack(spacing: Metrics.spacingS) {
+            ForEach([SessionKind.focus, .shortBreak, .longBreak], id: \.self) { value in
+                Button {
+                    guard phase == .idle else { return }
+                    withAnimation(Motion.snappy) { kind = value }
+                    Haptics.selection()
+                } label: {
+                    VStack(spacing: 3) {
+                        Image(systemName: value.symbolName)
+                            .font(.system(size: 14, weight: .semibold))
+                        Text(value.label)
+                            .font(.questMicro)
+                    }
+                    .foregroundStyle(kind == value ? .white : .secondary)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+                    .background {
+                        RoundedRectangle(cornerRadius: Metrics.cornerRadiusSmall, style: .continuous)
+                            .fill(kind == value
+                                  ? AnyShapeStyle(theme.gradient)
+                                  : AnyShapeStyle(Color.primary.opacity(0.05)))
+                    }
+                }
+                .buttonStyle(.plain)
+                .disabled(phase != .idle)
+            }
+        }
+    }
+
+    // MARK: Cadran
+
+    private var timerDial: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.primary.opacity(0.07), lineWidth: 16)
+
+            Circle()
+                .trim(from: 0, to: progress)
+                .stroke(theme.ringGradient, style: StrokeStyle(lineWidth: 16, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+                .glow(theme.accent, radius: 14, opacity: phase == .running ? 0.6 : 0.2)
+                .animation(.linear(duration: 1), value: progress)
+
+            VStack(spacing: 4) {
+                Text(DurationFormatter.clock(seconds: remainingSeconds))
+                    .font(.system(size: 46, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                    .contentTransition(.numericText())
+
+                Text(phaseLabel)
+                    .font(.questCaption)
+                    .foregroundStyle(.secondary)
+
+                if kind == .focus, completedRounds > 0 {
+                    HStack(spacing: 3) {
+                        ForEach(0..<min(completedRounds, settings.sessionsBeforeLongBreak), id: \.self) { _ in
+                            Circle()
+                                .fill(theme.accent)
+                                .frame(width: 5, height: 5)
+                        }
+                    }
+                }
+            }
+        }
+        .frame(width: 250, height: 250)
+        .padding(.vertical, Metrics.spacingS)
+    }
+
+    private var phaseLabel: String {
+        switch phase {
+        case .idle: return "Prêt à plonger"
+        case .running: return kind.label + " en cours"
+        case .paused: return "En pause"
+        case .finished: return "Session terminée"
+        }
+    }
+
+    // MARK: Cible
+
+    private var targetCard: some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: Metrics.spacingS) {
+                HStack {
+                    Label(selectedTask == nil ? "Aucune quête ciblée" : "Cible", systemImage: "scope")
+                        .font(.questCaption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Button(selectedTask == nil ? "Choisir" : "Changer") {
+                        showsTaskPicker = true
+                    }
+                    .font(.questMicro)
+                    .foregroundStyle(theme.accent)
+                }
+
+                if let task = selectedTask {
+                    Text(task.title)
+                        .font(.questHeadline)
+
+                    if task.isBoss {
+                        BossHealthBar(
+                            fraction: bossFraction(for: task),
+                            remainingMinutes: max(0, task.bossRemainingHP - liveMinutes)
+                        )
+                        Text("Chaque minute de concentration retire 1 PV.")
+                            .font(.questMicro)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        HStack(spacing: Metrics.spacingS) {
+                            DifficultyBadge(difficulty: task.difficulty)
+                            if task.focusedMinutes > 0 {
+                                Label(
+                                    DurationFormatter.short(minutes: task.focusedMinutes),
+                                    systemImage: "timer"
+                                )
+                                .font(.questMicro)
+                                .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                } else {
+                    Text("Une session sans cible compte quand même dans tes statistiques.")
+                        .font(.questCaption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private var liveMinutes: Int {
+        kind == .focus ? elapsedSeconds / 60 : 0
+    }
+
+    private func bossFraction(for task: TaskItem) -> Double {
+        let total = Double(task.difficulty.bossHitPoints)
+        guard total > 0 else { return 0 }
+        let remaining = Double(max(0, task.bossRemainingHP - liveMinutes))
+        return max(0, min(1, remaining / total))
+    }
+
+    // MARK: Commandes
+
+    private var controls: some View {
+        HStack(spacing: Metrics.spacingM) {
+            if phase == .running || phase == .paused {
+                Button {
+                    stop(save: true)
+                } label: {
+                    Image(systemName: "stop.fill")
+                        .font(.system(size: 18, weight: .bold))
+                        .frame(width: 54, height: 54)
+                        .background { Circle().fill(Color.primary.opacity(0.08)) }
+                }
+                .buttonStyle(PressableStyle())
+            }
+
+            Button {
+                toggleRun()
+            } label: {
+                Image(systemName: phase == .running ? "pause.fill" : "play.fill")
+                    .font(.system(size: 26, weight: .bold))
+                    .foregroundStyle(.white)
+                    .frame(width: 76, height: 76)
+                    .background {
+                        Circle()
+                            .fill(theme.gradient)
+                            .shadow(color: theme.accent.opacity(0.45), radius: 18, y: 8)
+                    }
+            }
+            .buttonStyle(PressableStyle(scale: 0.92))
+
+            if phase == .idle {
+                Menu {
+                    ForEach([15, 25, 30, 45, 50, 60, 90], id: \.self) { minutes in
+                        Button("\(minutes) minutes") {
+                            settings.focusDuration = minutes
+                        }
+                    }
+                } label: {
+                    Image(systemName: "slider.horizontal.3")
+                        .font(.system(size: 18, weight: .bold))
+                        .frame(width: 54, height: 54)
+                        .background { Circle().fill(Color.primary.opacity(0.08)) }
+                }
+            }
+        }
+    }
+
+    private var distractionCard: some View {
+        GlassCard {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Distractions")
+                        .font(.questCallout)
+                    Text("Note-les au lieu d'y céder.")
+                        .font(.questMicro)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Text("\(distractions)")
+                    .font(.questNumber(22))
+                    .monospacedDigit()
+                Button {
+                    distractions += 1
+                    Haptics.light()
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 14, weight: .bold))
+                        .frame(width: 34, height: 34)
+                        .background { Circle().fill(Color.primary.opacity(0.08)) }
+                }
+                .buttonStyle(PressableStyle())
+            }
+        }
+    }
+
+    // MARK: Récapitulatif
+
+    private var todaySummary: some View {
+        let todaySessions = sessions.filter {
+            calendar.isSameDay($0.start, Date()) && !$0.isBreak
+        }
+        let minutes = todaySessions.reduce(0) { $0 + $1.actualMinutes }
+
+        return VStack(alignment: .leading, spacing: Metrics.spacingS) {
+            HStack(spacing: 6) {
+                Image(systemName: "chart.bar.fill")
+                    .font(.system(size: 12))
+                    .foregroundStyle(theme.accent)
+                Text("Aujourd'hui")
+                    .font(.questCallout)
+                    .foregroundStyle(.secondary)
+            }
+
+            GlassCard {
+                VStack(alignment: .leading, spacing: Metrics.spacingS) {
+                    HStack {
+                        statBlock(value: "\(todaySessions.count)", label: "sessions")
+                        Divider().frame(height: 30)
+                        statBlock(value: DurationFormatter.short(minutes: minutes), label: "concentration")
+                        Divider().frame(height: 30)
+                        statBlock(
+                            value: "\(todaySessions.reduce(0) { $0 + $1.distractions })",
+                            label: "distractions"
+                        )
+                    }
+
+                    if !todaySessions.isEmpty {
+                        Divider().opacity(0.4)
+                        ForEach(todaySessions.sorted { $0.start > $1.start }.prefix(4)) { session in
+                            HStack {
+                                Image(systemName: session.wasCompleted ? "checkmark.circle.fill" : "xmark.circle")
+                                    .font(.system(size: 12))
+                                    .foregroundStyle(session.wasCompleted ? Color(hex: "30D158") : .secondary)
+                                Text(session.taskTitle.isEmpty ? "Session libre" : session.taskTitle)
+                                    .font(.questCaption)
+                                    .lineLimit(1)
+                                Spacer()
+                                Text(DurationFormatter.short(minutes: session.actualMinutes))
+                                    .font(.questMicro)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func statBlock(value: String, label: String) -> some View {
+        VStack(spacing: 1) {
+            Text(value)
+                .font(.questNumber(18))
+                .monospacedDigit()
+            Text(label)
+                .font(.questMicro)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: Machine à états
+
+    private func toggleRun() {
+        switch phase {
+        case .idle, .finished:
+            start()
+        case .running:
+            pause()
+        case .paused:
+            resume()
+        }
+    }
+
+    private func start() {
+        elapsedBeforePause = 0
+        distractions = 0
+        startedAt = Date()
+        tick = Date()
+        withAnimation(Motion.snappy) { phase = .running }
+        Haptics.play(.medium)
+    }
+
+    private func pause() {
+        elapsedBeforePause = elapsedSeconds
+        startedAt = nil
+        withAnimation(Motion.snappy) { phase = .paused }
+        Haptics.light()
+    }
+
+    private func resume() {
+        startedAt = Date()
+        tick = Date()
+        withAnimation(Motion.snappy) { phase = .running }
+        Haptics.light()
+    }
+
+    /// Arrêt manuel : on enregistre quand même le temps déjà passé.
+    private func stop(save: Bool) {
+        let minutes = elapsedSeconds / 60
+        if save && minutes >= 1 && kind == .focus {
+            store.recordFocus(
+                minutes: minutes,
+                on: selectedTask,
+                completed: false,
+                distractions: distractions
+            )
+        }
+        reset()
+        Haptics.warning()
+    }
+
+    private func finish() {
+        let minutes = max(1, plannedMinutes)
+        if kind == .focus {
+            store.recordFocus(
+                minutes: minutes,
+                on: selectedTask,
+                completed: true,
+                distractions: distractions
+            )
+            completedRounds += 1
+            notifications.notifyFocusFinished(
+                taskTitle: selectedTask?.title ?? "",
+                minutes: minutes
+            )
+            Haptics.play(.levelUp)
+
+            // Boss vaincu : la quête se termine d'elle-même.
+            if let task = selectedTask, task.isBoss, task.bossRemainingHP == 0, task.isOpen {
+                _ = store.complete(task)
+            }
+
+            // Enchaînement automatique vers la pause qui convient.
+            kind = completedRounds % settings.sessionsBeforeLongBreak == 0 ? .longBreak : .shortBreak
+        } else {
+            kind = .focus
+            Haptics.success()
+        }
+
+        reset()
+        withAnimation(Motion.celebration) { phase = .finished }
+    }
+
+    private func reset() {
+        startedAt = nil
+        elapsedBeforePause = 0
+        distractions = 0
+        withAnimation(Motion.snappy) { phase = .idle }
+    }
+}
+
+// MARK: - Choix de la cible
+
+struct FocusTaskPicker: View {
+
+    @Binding var selectedTaskID: UUID?
+
+    @Environment(SettingsStore.self) private var settings
+    @Environment(\.questlyTheme) private var theme
+    @Environment(\.dismiss) private var dismiss
+
+    @Query private var tasks: [TaskItem]
+    @State private var searchText = ""
+
+    private var calendar: Calendar { settings.calendar }
+
+    private var candidates: [TaskItem] {
+        let open = tasks.filter(\.isOpen)
+        guard !searchText.isEmpty else {
+            return open.sorted(by: TaskSorting.smart(calendar: calendar))
+        }
+        let needle = searchText.lowercased()
+        return open.filter { $0.title.lowercased().contains(needle) }
+    }
+
+    private var bosses: [TaskItem] {
+        candidates.filter(\.isBoss)
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    Button {
+                        selectedTaskID = nil
+                        dismiss()
+                    } label: {
+                        Label("Session libre", systemImage: "wind")
+                    }
+                }
+
+                if !bosses.isEmpty {
+                    Section("Boss") {
+                        ForEach(bosses) { task in
+                            row(task)
+                        }
+                    }
+                }
+
+                Section("Quêtes ouvertes") {
+                    ForEach(candidates.filter { !$0.isBoss }) { task in
+                        row(task)
+                    }
+                }
+            }
+            .searchable(text: $searchText, prompt: "Chercher")
+            .navigationTitle("Cibler une quête")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Fermer") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func row(_ task: TaskItem) -> some View {
+        Button {
+            selectedTaskID = task.identifier
+            Haptics.selection()
+            dismiss()
+        } label: {
+            HStack {
+                if task.isBoss {
+                    Image(systemName: "crown.fill")
+                        .foregroundStyle(Color(hex: "BF5AF2"))
+                }
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(task.title).font(.questBody)
+                    if task.isBoss {
+                        Text("\(task.bossRemainingHP) PV restants")
+                            .font(.questMicro)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer()
+                if selectedTaskID == task.identifier {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(theme.accent)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/QuestlyApp/Questly/Features/Hero/AchievementsView.swift
+++ b/QuestlyApp/Questly/Features/Hero/AchievementsView.swift
@@ -1,0 +1,279 @@
+import SwiftUI
+import SwiftData
+import QuestlyKit
+
+/// Galerie des hauts faits, groupée par catégorie. Les secrets restent
+/// masqués tant qu'ils ne sont pas obtenus — c'est ce qui donne envie de
+/// fouiller.
+struct AchievementsView: View {
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(\.questlyTheme) private var theme
+
+    @Query private var profiles: [PlayerProfile]
+
+    @State private var selectedCategory: AchievementCategory?
+    @State private var selected: AchievementProgress?
+    @State private var showsUnlockedOnly = false
+
+    private var progressList: [AchievementProgress] {
+        store.achievementProgress()
+    }
+
+    private var filtered: [AchievementProgress] {
+        progressList.filter { item in
+            let categoryMatches = selectedCategory == nil || item.definition.category == selectedCategory
+            let unlockMatches = !showsUnlockedOnly || item.isUnlocked
+            return categoryMatches && unlockMatches
+        }
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Metrics.spacingM) {
+                summary
+                categoryFilter
+                grid
+                Color.clear.frame(height: 100)
+            }
+            .padding(.horizontal, Metrics.spacingM)
+        }
+        .scrollIndicators(.hidden)
+        .navigationTitle("Hauts faits")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    withAnimation(Motion.snappy) { showsUnlockedOnly.toggle() }
+                } label: {
+                    Image(systemName: showsUnlockedOnly ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle")
+                }
+            }
+        }
+        .sheet(item: $selected) { item in
+            AchievementDetailSheet(progress: item)
+                .presentationDetents([.height(380)])
+        }
+    }
+
+    private var summary: some View {
+        let unlocked = progressList.filter(\.isUnlocked)
+        let points = unlocked.reduce(0) { $0 + $1.definition.xpReward }
+
+        return GlassCard {
+            HStack(spacing: Metrics.spacingM) {
+                ProgressRing(
+                    fraction: progressList.isEmpty ? 0 : Double(unlocked.count) / Double(progressList.count),
+                    size: 58,
+                    lineWidth: 7,
+                    color: theme.accent,
+                    content: AnyView(
+                        Text("\(unlocked.count)")
+                            .font(.questNumber(18))
+                            .monospacedDigit()
+                    )
+                )
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("\(unlocked.count) sur \(progressList.count)")
+                        .font(.questHeadline)
+                    Text("\(QuestlyFormat.compactNumber(points)) XP gagnés en trophées")
+                        .font(.questMicro)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+            }
+        }
+    }
+
+    private var categoryFilter: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                filterChip(title: "Tout", symbol: "square.grid.2x2", isSelected: selectedCategory == nil) {
+                    selectedCategory = nil
+                }
+                ForEach(AchievementCategory.allCases) { category in
+                    filterChip(
+                        title: category.label,
+                        symbol: category.symbolName,
+                        isSelected: selectedCategory == category
+                    ) {
+                        selectedCategory = category
+                    }
+                }
+            }
+            .padding(.vertical, 2)
+        }
+    }
+
+    private func filterChip(title: String, symbol: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+        Button {
+            withAnimation(Motion.snappy) { action() }
+            Haptics.selection()
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: symbol).font(.system(size: 10))
+                Text(title).font(.questMicro)
+            }
+            .foregroundStyle(isSelected ? .white : .primary)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .background {
+                Capsule().fill(isSelected
+                               ? AnyShapeStyle(theme.gradient)
+                               : AnyShapeStyle(Color.primary.opacity(0.06)))
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var grid: some View {
+        LazyVGrid(
+            columns: Array(repeating: GridItem(.flexible(), spacing: Metrics.spacingS), count: 3),
+            spacing: Metrics.spacingS
+        ) {
+            ForEach(filtered) { item in
+                AchievementBadge(progress: item)
+                    .onTapGesture {
+                        selected = item
+                        Haptics.light()
+                    }
+            }
+        }
+    }
+}
+
+// MARK: - Badge
+
+struct AchievementBadge: View {
+    let progress: AchievementProgress
+
+    private var definition: AchievementDefinition { progress.definition }
+    private var color: Color { Color(hex: definition.rarity.hex) }
+    private var isHidden: Bool { definition.isSecret && !progress.isUnlocked }
+
+    var body: some View {
+        VStack(spacing: 6) {
+            ZStack {
+                Circle()
+                    .fill(progress.isUnlocked ? color.opacity(0.18) : Color.primary.opacity(0.05))
+                    .frame(width: 56, height: 56)
+
+                if progress.isUnlocked {
+                    Circle()
+                        .strokeBorder(color.opacity(0.6), lineWidth: 1.5)
+                        .frame(width: 56, height: 56)
+                }
+
+                Image(systemName: isHidden ? "questionmark" : definition.symbolName)
+                    .font(.system(size: 22, weight: .semibold))
+                    .foregroundStyle(progress.isUnlocked ? color : Color.secondary.opacity(0.5))
+            }
+            .overlay(alignment: .bottomTrailing) {
+                if !progress.isUnlocked && progress.fraction > 0 {
+                    Text("\(Int(progress.fraction * 100))%")
+                        .font(.system(size: 8, weight: .bold, design: .rounded))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .background { Capsule().fill(color.opacity(0.8)) }
+                }
+            }
+
+            Text(isHidden ? "Secret" : definition.title)
+                .font(.system(size: 10, weight: .medium, design: .rounded))
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+                .foregroundStyle(progress.isUnlocked ? .primary : .secondary)
+                .frame(height: 26)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, Metrics.spacingS)
+        .background {
+            RoundedRectangle(cornerRadius: Metrics.cornerRadiusSmall, style: .continuous)
+                .fill(.ultraThinMaterial)
+                .opacity(progress.isUnlocked ? 1 : 0.6)
+        }
+        .applyIf(progress.isUnlocked && definition.rarity >= .legendary) { view in
+            view.shimmer()
+        }
+    }
+}
+
+// MARK: - Détail
+
+struct AchievementDetailSheet: View {
+    let progress: AchievementProgress
+
+    @Environment(\.dismiss) private var dismiss
+
+    private var definition: AchievementDefinition { progress.definition }
+    private var color: Color { Color(hex: definition.rarity.hex) }
+
+    var body: some View {
+        VStack(spacing: Metrics.spacingM) {
+            ZStack {
+                Circle()
+                    .fill(
+                        RadialGradient(
+                            colors: [color.opacity(0.4), color.opacity(0.05)],
+                            center: .center, startRadius: 4, endRadius: 60
+                        )
+                    )
+                    .frame(width: 120, height: 120)
+                Image(systemName: definition.symbolName)
+                    .font(.system(size: 48, weight: .bold))
+                    .foregroundStyle(progress.isUnlocked ? color : Color.secondary)
+            }
+            .padding(.top, Metrics.spacingL)
+
+            RarityChip(rarity: definition.rarity)
+
+            Text(definition.title)
+                .font(.questTitle)
+                .multilineTextAlignment(.center)
+
+            Text(definition.detail)
+                .font(.questCallout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, Metrics.spacingL)
+
+            if progress.isUnlocked {
+                if let date = progress.unlockedAt {
+                    Label("Obtenu le \(QuestlyFormat.longDate(date))", systemImage: "checkmark.seal.fill")
+                        .font(.questCaption)
+                        .foregroundStyle(Color(hex: "30D158"))
+                } else {
+                    Label("Obtenu", systemImage: "checkmark.seal.fill")
+                        .font(.questCaption)
+                        .foregroundStyle(Color(hex: "30D158"))
+                }
+            } else {
+                VStack(spacing: 4) {
+                    ProgressView(value: progress.fraction)
+                        .progressViewStyle(.linear)
+                        .tint(color)
+                        .frame(maxWidth: 220)
+                    Text("\(progress.value) / \(definition.goal) — encore \(progress.remaining)")
+                        .font(.questMicro)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            HStack(spacing: Metrics.spacingM) {
+                Label("\(definition.xpReward) XP", systemImage: "bolt.fill")
+                Label("\(definition.coinReward)", systemImage: "dollarsign.circle.fill")
+                if definition.gemReward > 0 {
+                    Label("\(definition.gemReward)", systemImage: "diamond.fill")
+                }
+            }
+            .font(.questCaption)
+            .foregroundStyle(.secondary)
+
+            Spacer()
+        }
+        .padding(Metrics.spacingM)
+    }
+}

--- a/QuestlyApp/Questly/Features/Hero/HeroView.swift
+++ b/QuestlyApp/Questly/Features/Hero/HeroView.swift
@@ -1,0 +1,383 @@
+import SwiftUI
+import SwiftData
+import QuestlyKit
+
+/// Le Héros : identité, attributs, hauts faits, échoppe et réglages.
+/// C'est la vitrine de la progression — l'écran que l'on ouvre pour se
+/// rappeler d'où l'on vient.
+struct HeroView: View {
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(SettingsStore.self) private var settings
+    @Environment(\.questlyTheme) private var theme
+
+    @Query private var profiles: [PlayerProfile]
+    @Query private var events: [CompletionEvent]
+
+    @State private var showsAvatarBuilder = false
+
+    private var player: PlayerProfile? { profiles.first }
+    private var calendar: Calendar { settings.calendar }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: Metrics.spacingL) {
+                    heroCard
+                    attributeSection
+                    statsGrid
+                    achievementsPreview
+                    navigationCards
+                    Color.clear.frame(height: 110)
+                }
+                .padding(.horizontal, Metrics.spacingM)
+                .padding(.top, Metrics.spacingS)
+            }
+            .scrollIndicators(.hidden)
+            .navigationTitle("Héros")
+            .navigationBarTitleDisplayMode(.inline)
+            .sheet(isPresented: $showsAvatarBuilder) {
+                AvatarBuilderView()
+            }
+        }
+    }
+
+    // MARK: Carte du héros
+
+    private var heroCard: some View {
+        VStack(spacing: Metrics.spacingM) {
+            ZStack {
+                if let aura = player?.avatarPart(for: .aura), aura.id != "aura.none" {
+                    Image(systemName: aura.symbolName)
+                        .font(.system(size: 130))
+                        .foregroundStyle(theme.accent.opacity(0.12))
+                        .blur(radius: 2)
+                }
+
+                Button {
+                    showsAvatarBuilder = true
+                    Haptics.light()
+                } label: {
+                    LevelRing(
+                        progress: player?.levelProgress ?? .zero,
+                        size: 118,
+                        lineWidth: 9,
+                        emoji: player?.avatarPart(for: .face)?.emoji ?? "🧭"
+                    )
+                }
+                .buttonStyle(PressableStyle())
+
+                if let hat = player?.avatarPart(for: .headgear), hat.id != "hat.none" {
+                    Image(systemName: hat.symbolName)
+                        .font(.system(size: 26))
+                        .foregroundStyle(Color(hex: hat.rarity.hex))
+                        .offset(y: -68)
+                }
+
+                if let pet = player?.avatarPart(for: .companion), pet.id != "pet.none",
+                   let emoji = pet.emoji {
+                    Text(emoji)
+                        .font(.system(size: 28))
+                        .offset(x: 58, y: 40)
+                }
+            }
+            .frame(height: 140)
+
+            VStack(spacing: 3) {
+                Text(player?.displayName ?? "Aventurier·ère")
+                    .font(.questTitle)
+                HStack(spacing: 6) {
+                    Image(systemName: player?.rank.symbolName ?? "leaf")
+                        .font(.system(size: 12))
+                    Text(player?.rank.title ?? "Novice")
+                        .font(.questCallout)
+                }
+                .foregroundStyle(Color(hex: player?.rank.hex ?? "9CA3AF"))
+            }
+
+            XPBar(progress: player?.levelProgress ?? .zero)
+
+            HStack(spacing: Metrics.spacingS) {
+                CurrencyPill(kind: .coins, amount: player?.coins ?? 0)
+                CurrencyPill(kind: .gems, amount: player?.gems ?? 0)
+                Spacer()
+                StreakFlame(days: store.streak.current, isAtRisk: store.streak.isAtRisk, size: 18)
+            }
+        }
+        .padding(Metrics.spacingM)
+        .background {
+            RoundedRectangle(cornerRadius: Metrics.cornerRadiusLarge, style: .continuous)
+                .fill(.ultraThinMaterial)
+                .overlay {
+                    RoundedRectangle(cornerRadius: Metrics.cornerRadiusLarge, style: .continuous)
+                        .fill(theme.softGradient)
+                }
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: Metrics.cornerRadiusLarge, style: .continuous)
+                .strokeBorder(theme.accent.opacity(0.25), lineWidth: 1)
+        }
+    }
+
+    // MARK: Attributs
+
+    private var attributeSection: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacingS) {
+            sectionHeader("Attributs", symbol: "circle.hexagongrid.fill")
+
+            GlassCard {
+                VStack(spacing: Metrics.spacingS) {
+                    ForEach(LifeArea.allCases) { area in
+                        AttributeBar(
+                            area: area,
+                            xp: player?.attributeXP(for: area) ?? 0,
+                            completions: completions(in: area)
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private func completions(in area: LifeArea) -> Int {
+        events.filter { $0.lifeArea == area }.count
+    }
+
+    // MARK: Statistiques rapides
+
+    private var statsGrid: some View {
+        let stats = store.currentStats(days: 3650)
+
+        return VStack(alignment: .leading, spacing: Metrics.spacingS) {
+            sectionHeader("En chiffres", symbol: "chart.bar.fill")
+
+            LazyVGrid(
+                columns: Array(repeating: GridItem(.flexible(), spacing: Metrics.spacingS), count: 2),
+                spacing: Metrics.spacingS
+            ) {
+                statTile("Quêtes accomplies", value: "\(player?.tasksCompleted ?? 0)", symbol: "checkmark.seal.fill", hex: "30D158")
+                statTile("XP total", value: QuestlyFormat.compactNumber(player?.totalXP ?? 0), symbol: "bolt.fill", hex: "FFD60A")
+                statTile("Meilleure série", value: "\(player?.longestStreak ?? 0) j", symbol: "flame.fill", hex: "FF7A00")
+                statTile("Concentration", value: DurationFormatter.short(minutes: player?.focusMinutes ?? 0), symbol: "timer", hex: "5E9BFF")
+                statTile("Boss vaincus", value: "\(player?.bossesDefeated ?? 0)", symbol: "crown.fill", hex: "BF5AF2")
+                statTile("Ponctualité", value: QuestlyFormat.percent(stats.onTimeRate), symbol: "clock.badge.checkmark.fill", hex: "34D399")
+            }
+        }
+    }
+
+    private func statTile(_ label: String, value: String, symbol: String, hex: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Image(systemName: symbol)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(Color(hex: hex))
+            Text(value)
+                .font(.questNumber(20))
+                .monospacedDigit()
+            Text(label)
+                .font(.questMicro)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Metrics.spacingS + 2)
+        .background {
+            RoundedRectangle(cornerRadius: Metrics.cornerRadiusSmall, style: .continuous)
+                .fill(.ultraThinMaterial)
+        }
+    }
+
+    // MARK: Hauts faits
+
+    private var achievementsPreview: some View {
+        let progress = store.achievementProgress()
+        let unlocked = progress.filter(\.isUnlocked)
+        let almost = AchievementEngine.almostThere(
+            snapshot: store.playerSnapshot(),
+            unlockDates: player?.unlockedAchievements ?? [:],
+            limit: 3
+        )
+
+        return VStack(alignment: .leading, spacing: Metrics.spacingS) {
+            HStack {
+                sectionHeader("Hauts faits", symbol: "trophy.fill")
+                Spacer()
+                NavigationLink("Tout voir") {
+                    AchievementsView()
+                }
+                .font(.questMicro)
+                .foregroundStyle(theme.accent)
+            }
+
+            GlassCard {
+                VStack(alignment: .leading, spacing: Metrics.spacingS) {
+                    HStack {
+                        Text("\(unlocked.count) / \(progress.count)")
+                            .font(.questNumber(22))
+                            .monospacedDigit()
+                        Text("débloqués")
+                            .font(.questCaption)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        ProgressRing(
+                            fraction: progress.isEmpty ? 0 : Double(unlocked.count) / Double(progress.count),
+                            size: 38,
+                            lineWidth: 5,
+                            color: theme.accent
+                        )
+                    }
+
+                    if !almost.isEmpty {
+                        Divider().opacity(0.4)
+                        Text("Bientôt")
+                            .font(.questMicro)
+                            .foregroundStyle(.secondary)
+                        ForEach(almost) { item in
+                            HStack(spacing: Metrics.spacingS) {
+                                Image(systemName: item.definition.symbolName)
+                                    .font(.system(size: 13))
+                                    .foregroundStyle(Color(hex: item.definition.rarity.hex))
+                                    .frame(width: 20)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(item.definition.title).font(.questCaption)
+                                    ProgressView(value: item.fraction)
+                                        .progressViewStyle(.linear)
+                                        .tint(Color(hex: item.definition.rarity.hex))
+                                }
+                                Text("\(item.value)/\(item.definition.goal)")
+                                    .font(.questMicro)
+                                    .monospacedDigit()
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: Accès
+
+    private var navigationCards: some View {
+        VStack(spacing: Metrics.spacingS) {
+            NavigationLink {
+                ShopView()
+            } label: {
+                navigationRow(
+                    title: "Échoppe",
+                    subtitle: "Potions, ambiances, apparence",
+                    symbol: "bag.fill",
+                    hex: "FF9F0A"
+                )
+            }
+
+            NavigationLink {
+                StatsView()
+            } label: {
+                navigationRow(
+                    title: "Chroniques",
+                    subtitle: "Statistiques et tendances",
+                    symbol: "chart.xyaxis.line",
+                    hex: "5E9BFF"
+                )
+            }
+
+            NavigationLink {
+                SettingsView()
+            } label: {
+                navigationRow(
+                    title: "Réglages",
+                    subtitle: "Thèmes, notifications, données",
+                    symbol: "gearshape.fill",
+                    hex: "8E8E93"
+                )
+            }
+        }
+    }
+
+    private func navigationRow(title: String, subtitle: String, symbol: String, hex: String) -> some View {
+        HStack(spacing: Metrics.spacingM) {
+            Image(systemName: symbol)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(Color(hex: hex))
+                .frame(width: 38, height: 38)
+                .background { Circle().fill(Color(hex: hex).opacity(0.14)) }
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title).font(.questBody).foregroundStyle(.primary)
+                Text(subtitle).font(.questMicro).foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(Metrics.spacingS + 2)
+        .background {
+            RoundedRectangle(cornerRadius: Metrics.cornerRadius, style: .continuous)
+                .fill(.ultraThinMaterial)
+        }
+    }
+
+    private func sectionHeader(_ title: String, symbol: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: symbol)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(theme.accent)
+            Text(title)
+                .font(.questCallout)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - Barre d'attribut
+
+struct AttributeBar: View {
+    let area: LifeArea
+    let xp: Int
+    let completions: Int
+
+    private var progress: (level: Int, into: Int, required: Int, fraction: Double) {
+        AttributeCurve.progress(forTotalXP: xp)
+    }
+
+    var body: some View {
+        let color = Color(hex: area.hex)
+
+        HStack(spacing: Metrics.spacingS) {
+            Image(systemName: area.symbolName)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(color)
+                .frame(width: 26, height: 26)
+                .background { Circle().fill(color.opacity(0.14)) }
+
+            VStack(alignment: .leading, spacing: 3) {
+                HStack {
+                    Text(area.label).font(.questCaption)
+                    Spacer()
+                    Text("Niv. \(progress.level)")
+                        .font(.questMicro)
+                        .foregroundStyle(color)
+                }
+
+                GeometryReader { geo in
+                    ZStack(alignment: .leading) {
+                        Capsule().fill(color.opacity(0.12))
+                        Capsule()
+                            .fill(color)
+                            .frame(width: max(4, geo.size.width * progress.fraction))
+                    }
+                }
+                .frame(height: 6)
+            }
+
+            Text("\(completions)")
+                .font(.questMicro)
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+                .frame(width: 26, alignment: .trailing)
+        }
+    }
+}

--- a/QuestlyApp/Questly/Features/Hero/ShopView.swift
+++ b/QuestlyApp/Questly/Features/Hero/ShopView.swift
@@ -1,0 +1,507 @@
+import SwiftUI
+import SwiftData
+import QuestlyKit
+
+/// L'Échoppe : la seule chose à faire des pièces gagnées. Elle vend du confort
+/// (gels de série, jours de repos) et du plaisir (ambiances, apparence),
+/// jamais de l'avantage déloyal sur soi-même.
+struct ShopView: View {
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(SettingsStore.self) private var settings
+    @Environment(ThemeManager.self) private var themeManager
+    @Environment(\.questlyTheme) private var theme
+
+    @Query private var profiles: [PlayerProfile]
+
+    @State private var category: ShopCategory = .consumable
+    @State private var lastPurchase: ShopItem?
+    @State private var lootDrops: [LootDrop] = []
+    @State private var showsLoot = false
+    @State private var errorMessage: String?
+
+    private var player: PlayerProfile? { profiles.first }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Metrics.spacingM) {
+                walletBar
+                categoryPicker
+                itemGrid
+                Color.clear.frame(height: 100)
+            }
+            .padding(.horizontal, Metrics.spacingM)
+        }
+        .scrollIndicators(.hidden)
+        .navigationTitle("Échoppe")
+        .navigationBarTitleDisplayMode(.inline)
+        .overlay {
+            if showsLoot {
+                LootRevealOverlay(drops: lootDrops) {
+                    withAnimation(Motion.snappy) { showsLoot = false }
+                }
+            }
+        }
+        .alert("Achat impossible", isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )) {
+            Button("OK", role: .cancel) { errorMessage = nil }
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    // MARK: Bourse
+
+    private var walletBar: some View {
+        GlassCard {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Ta bourse")
+                        .font(.questMicro)
+                        .foregroundStyle(.secondary)
+                    HStack(spacing: Metrics.spacingS) {
+                        CurrencyPill(kind: .coins, amount: player?.coins ?? 0)
+                        CurrencyPill(kind: .gems, amount: player?.gems ?? 0)
+                    }
+                }
+                Spacer()
+                VStack(alignment: .trailing, spacing: 2) {
+                    if let expiry = player?.boostExpiresAt, expiry > Date() {
+                        Label(
+                            "Potion active ×\(String(format: "%.2f", player?.boostMultiplier ?? 1))",
+                            systemImage: "flask.fill"
+                        )
+                        .font(.questMicro)
+                        .foregroundStyle(Color(hex: "BF5AF2"))
+                    }
+                    Label("\(player?.streakFreezes ?? 0) gels", systemImage: "snowflake")
+                        .font(.questMicro)
+                        .foregroundStyle(Color(hex: "64D2FF"))
+                }
+            }
+        }
+    }
+
+    private var categoryPicker: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                ForEach(ShopCategory.allCases) { value in
+                    Button {
+                        withAnimation(Motion.snappy) { category = value }
+                        Haptics.selection()
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: value.symbolName).font(.system(size: 10))
+                            Text(value.label).font(.questMicro)
+                        }
+                        .foregroundStyle(category == value ? .white : .primary)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background {
+                            Capsule().fill(category == value
+                                           ? AnyShapeStyle(theme.gradient)
+                                           : AnyShapeStyle(Color.primary.opacity(0.06)))
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.vertical, 2)
+        }
+    }
+
+    // MARK: Articles
+
+    private var items: [ShopItem] {
+        ShopCatalog.all
+            .filter { $0.category == category }
+            .sorted { lhs, rhs in
+                if lhs.requiredLevel != rhs.requiredLevel { return lhs.requiredLevel < rhs.requiredLevel }
+                return lhs.price.coins < rhs.price.coins
+            }
+    }
+
+    private var itemGrid: some View {
+        LazyVGrid(
+            columns: Array(repeating: GridItem(.flexible(), spacing: Metrics.spacingS), count: 2),
+            spacing: Metrics.spacingS
+        ) {
+            ForEach(items) { item in
+                ShopItemCard(
+                    item: item,
+                    isOwned: player?.owns(itemID: item.id) ?? false,
+                    isLocked: (player?.level ?? 1) < item.requiredLevel,
+                    canAfford: player.map { Wallet(coins: $0.coins, gems: $0.gems).canAfford(item.price) } ?? false
+                ) {
+                    buy(item)
+                }
+            }
+        }
+    }
+
+    private func buy(_ item: ShopItem) {
+        guard let player else { return }
+
+        if player.level < item.requiredLevel {
+            errorMessage = "Cet objet se débloque au niveau \(item.requiredLevel)."
+            Haptics.warning()
+            return
+        }
+        if !item.isConsumable && player.owns(itemID: item.id) {
+            errorMessage = "Tu possèdes déjà cet objet."
+            return
+        }
+
+        let before = player.unlockedItems
+        guard store.purchase(item) else {
+            errorMessage = "Il te manque des pièces ou des gemmes."
+            Haptics.warning()
+            return
+        }
+
+        Haptics.success()
+        lastPurchase = item
+
+        // Un coffre révèle son butin.
+        if case .openChest(let tier) = item.effect {
+            let seed = UInt64(abs(item.id.hashValue % 1_000_000))
+            lootDrops = LootEngine.openChest(tier: tier, seed: seed)
+            withAnimation(Motion.celebration) { showsLoot = true }
+        }
+
+        // Une ambiance achetée s'applique tout de suite.
+        if case .unlockTheme(let id) = item.effect {
+            settings.themeID = id
+            themeManager.select(id: id)
+        }
+
+        _ = before
+    }
+}
+
+// MARK: - Carte d'article
+
+struct ShopItemCard: View {
+    let item: ShopItem
+    let isOwned: Bool
+    let isLocked: Bool
+    let canAfford: Bool
+    let onBuy: () -> Void
+
+    @Environment(\.questlyTheme) private var theme
+
+    private var color: Color { Color(hex: item.rarity.hex) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacingS) {
+            HStack {
+                Image(systemName: item.symbolName)
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(color)
+                Spacer()
+                RarityChip(rarity: item.rarity)
+            }
+
+            Text(item.name)
+                .font(.questCallout)
+                .lineLimit(1)
+
+            Text(item.detail)
+                .font(.questMicro)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+                .frame(height: 28, alignment: .top)
+
+            Spacer(minLength: 0)
+
+            if isLocked {
+                Label("Niveau \(item.requiredLevel)", systemImage: "lock.fill")
+                    .font(.questMicro)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 7)
+                    .background { Capsule().fill(Color.primary.opacity(0.06)) }
+            } else if isOwned && !item.isConsumable {
+                Label("Possédé", systemImage: "checkmark.seal.fill")
+                    .font(.questMicro)
+                    .foregroundStyle(Color(hex: "30D158"))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 7)
+                    .background { Capsule().fill(Color(hex: "30D158").opacity(0.12)) }
+            } else {
+                Button(action: onBuy) {
+                    HStack(spacing: 5) {
+                        if item.price.coins > 0 {
+                            Image(systemName: "dollarsign.circle.fill").font(.system(size: 10))
+                            Text("\(item.price.coins)").font(.questMicro).monospacedDigit()
+                        }
+                        if item.price.gems > 0 {
+                            Image(systemName: "diamond.fill").font(.system(size: 10))
+                            Text("\(item.price.gems)").font(.questMicro).monospacedDigit()
+                        }
+                        if item.price.isFree {
+                            Text("Offert").font(.questMicro)
+                        }
+                    }
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 7)
+                    .background {
+                        Capsule().fill(canAfford
+                                       ? AnyShapeStyle(theme.gradient)
+                                       : AnyShapeStyle(Color.secondary.opacity(0.4)))
+                    }
+                }
+                .buttonStyle(PressableStyle())
+            }
+        }
+        .padding(Metrics.spacingS + 2)
+        .frame(height: 176)
+        .background {
+            RoundedRectangle(cornerRadius: Metrics.cornerRadius, style: .continuous)
+                .fill(.ultraThinMaterial)
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: Metrics.cornerRadius, style: .continuous)
+                .strokeBorder(color.opacity(isOwned ? 0.4 : 0.15), lineWidth: 1)
+        }
+        .opacity(isLocked ? 0.65 : 1)
+    }
+}
+
+// MARK: - Révélation du butin
+
+struct LootRevealOverlay: View {
+    let drops: [LootDrop]
+    let onDismiss: () -> Void
+
+    @State private var revealed = 0
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.55).ignoresSafeArea()
+                .onTapGesture(perform: onDismiss)
+
+            VStack(spacing: Metrics.spacingM) {
+                Text("Coffre ouvert")
+                    .font(.questTitle)
+                    .foregroundStyle(.white)
+
+                ForEach(Array(drops.enumerated()), id: \.element.id) { index, drop in
+                    if index < revealed {
+                        HStack(spacing: Metrics.spacingS) {
+                            Image(systemName: drop.symbolName)
+                                .font(.system(size: 22))
+                                .foregroundStyle(Color(hex: drop.rarity.hex))
+                                .frame(width: 44, height: 44)
+                                .background {
+                                    Circle().fill(Color(hex: drop.rarity.hex).opacity(0.18))
+                                }
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(drop.name)
+                                    .font(.questCallout)
+                                    .foregroundStyle(.white)
+                                RarityChip(rarity: drop.rarity)
+                            }
+                            Spacer()
+                        }
+                        .padding(Metrics.spacingS)
+                        .frame(maxWidth: 300)
+                        .background {
+                            RoundedRectangle(cornerRadius: Metrics.cornerRadius, style: .continuous)
+                                .fill(.ultraThinMaterial)
+                        }
+                        .transition(.scale.combined(with: .opacity))
+                    }
+                }
+
+                Button("Récupérer", action: onDismiss)
+                    .font(.questHeadline)
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, Metrics.spacingL)
+                    .padding(.vertical, 12)
+                    .background { Capsule().fill(Color.white.opacity(0.2)) }
+                    .padding(.top, Metrics.spacingS)
+            }
+
+            ConfettiView(pieceCount: 70, duration: 2.2)
+                .ignoresSafeArea()
+        }
+        .onAppear(perform: revealSequentially)
+    }
+
+    private func revealSequentially() {
+        for index in drops.indices {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Double(index) * 0.45) {
+                withAnimation(Motion.bouncy) { revealed = index + 1 }
+                Haptics.play(.medium)
+            }
+        }
+    }
+}
+
+// MARK: - Personnalisation de l'avatar
+
+struct AvatarBuilderView: View {
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(\.questlyTheme) private var theme
+    @Environment(\.dismiss) private var dismiss
+
+    @Query private var profiles: [PlayerProfile]
+
+    @State private var slot: AvatarSlot = .face
+    @State private var name = ""
+
+    private var player: PlayerProfile? { profiles.first }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: Metrics.spacingM) {
+                preview
+                slotPicker
+                partGrid
+            }
+            .padding(.horizontal, Metrics.spacingM)
+            .navigationTitle("Apparence")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Terminé") {
+                        if let player, !name.trimmingCharacters(in: .whitespaces).isEmpty {
+                            player.displayName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+                            store.save()
+                        }
+                        dismiss()
+                    }
+                    .fontWeight(.semibold)
+                }
+            }
+            .onAppear { name = player?.displayName ?? "" }
+        }
+    }
+
+    private var preview: some View {
+        VStack(spacing: Metrics.spacingS) {
+            ZStack {
+                if let aura = player?.avatarPart(for: .aura), aura.id != "aura.none" {
+                    Image(systemName: aura.symbolName)
+                        .font(.system(size: 120))
+                        .foregroundStyle(theme.accent.opacity(0.15))
+                }
+                LevelRing(
+                    progress: player?.levelProgress ?? .zero,
+                    size: 110,
+                    lineWidth: 8,
+                    emoji: player?.avatarPart(for: .face)?.emoji ?? "🧭",
+                    showsLevelBadge: false
+                )
+                if let hat = player?.avatarPart(for: .headgear), hat.id != "hat.none" {
+                    Image(systemName: hat.symbolName)
+                        .font(.system(size: 24))
+                        .foregroundStyle(Color(hex: hat.rarity.hex))
+                        .offset(y: -63)
+                }
+                if let pet = player?.avatarPart(for: .companion), pet.id != "pet.none", let emoji = pet.emoji {
+                    Text(emoji).font(.system(size: 26)).offset(x: 54, y: 36)
+                }
+            }
+            .frame(height: 130)
+
+            TextField("Ton nom d'aventurier", text: $name)
+                .font(.questHeadline)
+                .multilineTextAlignment(.center)
+                .textFieldStyle(.plain)
+        }
+    }
+
+    private var slotPicker: some View {
+        QuestlySegmentedPicker(
+            items: AvatarSlot.allCases,
+            label: { $0.label },
+            selection: $slot
+        )
+    }
+
+    private var partGrid: some View {
+        ScrollView {
+            LazyVGrid(
+                columns: Array(repeating: GridItem(.flexible(), spacing: Metrics.spacingS), count: 3),
+                spacing: Metrics.spacingS
+            ) {
+                ForEach(AvatarCatalog.parts(in: slot)) { part in
+                    partCell(part)
+                }
+            }
+            .padding(.bottom, Metrics.spacingL)
+        }
+    }
+
+    private func partCell(_ part: AvatarPart) -> some View {
+        let owned = isOwned(part)
+        let isEquipped = player?.avatarLoadout[part.slot.rawValue] == part.id
+        let color = Color(hex: part.rarity.hex)
+
+        return Button {
+            guard owned, let player else {
+                Haptics.warning()
+                return
+            }
+            store.equip(part: part, on: player)
+            Haptics.selection()
+        } label: {
+            VStack(spacing: 5) {
+                ZStack {
+                    Circle()
+                        .fill(isEquipped ? color.opacity(0.22) : Color.primary.opacity(0.05))
+                        .frame(width: 52, height: 52)
+                    if let emoji = part.emoji, part.id != "pet.none" {
+                        Text(emoji).font(.system(size: 24))
+                    } else {
+                        Image(systemName: part.symbolName)
+                            .font(.system(size: 20, weight: .semibold))
+                            .foregroundStyle(owned ? color : .secondary)
+                    }
+                    if !owned {
+                        Image(systemName: "lock.fill")
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundStyle(.white)
+                            .padding(4)
+                            .background { Circle().fill(Color.black.opacity(0.55)) }
+                            .offset(x: 18, y: 18)
+                    }
+                }
+
+                Text(part.name)
+                    .font(.system(size: 10, weight: .medium, design: .rounded))
+                    .lineLimit(1)
+                    .foregroundStyle(owned ? .primary : .secondary)
+
+                if !owned {
+                    Text(part.price.isFree ? "Niv. \(part.requiredLevel)" : "\(part.price.coins) 🪙")
+                        .font(.system(size: 9, weight: .semibold, design: .rounded))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, Metrics.spacingS)
+            .background {
+                RoundedRectangle(cornerRadius: Metrics.cornerRadiusSmall, style: .continuous)
+                    .fill(.ultraThinMaterial)
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: Metrics.cornerRadiusSmall, style: .continuous)
+                    .strokeBorder(isEquipped ? color : .clear, lineWidth: 1.5)
+            }
+        }
+        .buttonStyle(PressableStyle())
+    }
+
+    private func isOwned(_ part: AvatarPart) -> Bool {
+        guard let player else { return false }
+        if part.price.isFree { return player.level >= part.requiredLevel }
+        return player.owns(itemID: part.id) || player.owns(itemID: "avatar.\(part.id)")
+    }
+}

--- a/QuestlyApp/Questly/Features/Onboarding/OnboardingView.swift
+++ b/QuestlyApp/Questly/Features/Onboarding/OnboardingView.swift
@@ -1,0 +1,402 @@
+import SwiftUI
+import SwiftData
+import QuestlyKit
+
+/// Première ouverture : quatre écrans pour poser le décor, choisir son héros,
+/// ses domaines de vie, et repartir avec des quêtes déjà prêtes.
+struct OnboardingView: View {
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(SettingsStore.self) private var settings
+    @Environment(ThemeManager.self) private var themeManager
+    @Environment(NotificationService.self) private var notifications
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var page = 0
+    @State private var name = ""
+    @State private var faceID = "face.explorer"
+    @State private var selectedAreas: Set<LifeArea> = [.body, .mind, .craft]
+    @State private var themeID = ThemeCatalog.default.id
+    @State private var wantsNotifications = true
+
+    private var theme: QuestlyTheme { ThemeCatalog.theme(id: themeID) }
+
+    var body: some View {
+        ZStack {
+            AuroraBackground(theme: theme)
+
+            VStack(spacing: 0) {
+                TabView(selection: $page) {
+                    welcomePage.tag(0)
+                    heroPage.tag(1)
+                    areasPage.tag(2)
+                    readyPage.tag(3)
+                }
+                .tabViewStyle(.page(indexDisplayMode: .never))
+
+                pageIndicator
+                actionButton
+            }
+            .padding(.bottom, Metrics.spacingL)
+        }
+        .environment(\.questlyTheme, theme)
+        .interactiveDismissDisabled()
+    }
+
+    // MARK: Pages
+
+    private var welcomePage: some View {
+        VStack(spacing: Metrics.spacingL) {
+            Spacer()
+
+            ZStack {
+                RadiantBurst(color: theme.accent)
+                    .frame(width: 260, height: 260)
+                Text("⚔️")
+                    .font(.system(size: 84))
+            }
+
+            VStack(spacing: Metrics.spacingS) {
+                Text("Questly")
+                    .font(.system(size: 44, weight: .heavy, design: .rounded))
+                    .shimmer()
+
+                Text("Ta liste de tâches devient une aventure.")
+                    .font(.questHeadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            VStack(alignment: .leading, spacing: Metrics.spacingM) {
+                featureRow("bolt.fill", "Chaque quête accomplie rapporte de l'XP", "Difficulté, priorité et ponctualité comptent.")
+                featureRow("flame.fill", "Les séries récompensent la régularité", "Avec des gels pour les jours sans.")
+                featureRow("calendar", "Un vrai calendrier", "Jour, semaine, mois, année, agenda et time-blocking.")
+            }
+            .padding(.horizontal, Metrics.spacingL)
+
+            Spacer()
+        }
+        .padding(Metrics.spacingM)
+    }
+
+    private func featureRow(_ symbol: String, _ title: String, _ detail: String) -> some View {
+        HStack(alignment: .top, spacing: Metrics.spacingM) {
+            Image(systemName: symbol)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(theme.accent)
+                .frame(width: 30, height: 30)
+                .background { Circle().fill(theme.accent.opacity(0.15)) }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title).font(.questCallout)
+                Text(detail).font(.questMicro).foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var heroPage: some View {
+        VStack(spacing: Metrics.spacingL) {
+            Spacer()
+
+            Text("Qui part à l'aventure ?")
+                .font(.questTitle)
+                .multilineTextAlignment(.center)
+
+            Text(AvatarCatalog.part(id: faceID)?.emoji ?? "🧭")
+                .font(.system(size: 76))
+                .frame(width: 130, height: 130)
+                .background {
+                    Circle().fill(theme.softGradient)
+                }
+                .overlay {
+                    Circle().strokeBorder(theme.accent.opacity(0.4), lineWidth: 2)
+                }
+
+            TextField("Ton nom d'aventurier", text: $name)
+                .font(.questHeadline)
+                .multilineTextAlignment(.center)
+                .padding(Metrics.spacingS)
+                .background {
+                    RoundedRectangle(cornerRadius: Metrics.cornerRadiusSmall, style: .continuous)
+                        .fill(.ultraThinMaterial)
+                }
+                .padding(.horizontal, Metrics.spacingXL)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: Metrics.spacingS) {
+                    ForEach(AvatarCatalog.parts(in: .face).filter { $0.requiredLevel <= 1 && $0.price.isFree }) { part in
+                        Button {
+                            faceID = part.id
+                            Haptics.selection()
+                        } label: {
+                            Text(part.emoji ?? "🙂")
+                                .font(.system(size: 30))
+                                .frame(width: 58, height: 58)
+                                .background {
+                                    Circle().fill(faceID == part.id
+                                                  ? theme.accent.opacity(0.25)
+                                                  : Color.primary.opacity(0.05))
+                                }
+                                .overlay {
+                                    Circle().strokeBorder(faceID == part.id ? theme.accent : .clear, lineWidth: 2)
+                                }
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, Metrics.spacingL)
+            }
+
+            themePicker
+
+            Spacer()
+        }
+        .padding(Metrics.spacingM)
+    }
+
+    private var themePicker: some View {
+        VStack(spacing: Metrics.spacingS) {
+            Text("Ambiance")
+                .font(.questCaption)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: Metrics.spacingS) {
+                ForEach(ThemeCatalog.all.filter { $0.unlockItemID == nil || $0.id == "aurora" || $0.id == "forest" }) { candidate in
+                    Button {
+                        withAnimation(Motion.gentle) { themeID = candidate.id }
+                        Haptics.selection()
+                    } label: {
+                        Circle()
+                            .fill(candidate.gradient)
+                            .frame(width: 36, height: 36)
+                            .overlay {
+                                Circle().strokeBorder(themeID == candidate.id ? Color.primary : .clear, lineWidth: 2)
+                            }
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    private var areasPage: some View {
+        VStack(spacing: Metrics.spacingL) {
+            Spacer()
+
+            VStack(spacing: Metrics.spacingS) {
+                Text("Quels domaines veux-tu faire progresser ?")
+                    .font(.questTitle)
+                    .multilineTextAlignment(.center)
+                Text("Chaque quête accomplie fera monter l'attribut correspondant.")
+                    .font(.questCallout)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            LazyVGrid(
+                columns: Array(repeating: GridItem(.flexible(), spacing: Metrics.spacingS), count: 2),
+                spacing: Metrics.spacingS
+            ) {
+                ForEach(LifeArea.allCases) { area in
+                    areaCard(area)
+                }
+            }
+
+            Spacer()
+        }
+        .padding(Metrics.spacingM)
+    }
+
+    private func areaCard(_ area: LifeArea) -> some View {
+        let isSelected = selectedAreas.contains(area)
+        let color = Color(hex: area.hex)
+
+        return Button {
+            withAnimation(Motion.snappy) {
+                if isSelected { selectedAreas.remove(area) } else { selectedAreas.insert(area) }
+            }
+            Haptics.selection()
+        } label: {
+            VStack(alignment: .leading, spacing: 5) {
+                Image(systemName: area.symbolName)
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(isSelected ? .white : color)
+                Text(area.label)
+                    .font(.questCallout)
+                    .foregroundStyle(isSelected ? .white : .primary)
+                Text(area.subtitle)
+                    .font(.questMicro)
+                    .foregroundStyle(isSelected ? .white.opacity(0.85) : .secondary)
+                    .lineLimit(2)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(Metrics.spacingS + 2)
+            .frame(height: 96)
+            .background {
+                RoundedRectangle(cornerRadius: Metrics.cornerRadius, style: .continuous)
+                    .fill(isSelected
+                          ? AnyShapeStyle(LinearGradient(colors: [color, color.opacity(0.7)],
+                                                         startPoint: .topLeading, endPoint: .bottomTrailing))
+                          : AnyShapeStyle(Color.primary.opacity(0.05)))
+            }
+        }
+        .buttonStyle(PressableStyle())
+    }
+
+    private var readyPage: some View {
+        VStack(spacing: Metrics.spacingL) {
+            Spacer()
+
+            Image(systemName: "sparkles")
+                .font(.system(size: 60))
+                .foregroundStyle(theme.gradient)
+                .glow(theme.accent, radius: 20, opacity: 0.6)
+
+            VStack(spacing: Metrics.spacingS) {
+                Text("Tout est prêt")
+                    .font(.questTitle)
+                Text("Quelques quêtes de départ t'attendent pour prendre le pli.")
+                    .font(.questCallout)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            Toggle(isOn: $wantsNotifications) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Rappels et revue du soir").font(.questCallout)
+                    Text("Modifiable à tout moment dans les réglages.")
+                        .font(.questMicro)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(Metrics.spacingM)
+            .background {
+                RoundedRectangle(cornerRadius: Metrics.cornerRadius, style: .continuous)
+                    .fill(.ultraThinMaterial)
+            }
+            .padding(.horizontal, Metrics.spacingM)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Astuce : écris naturellement")
+                    .font(.questCaption)
+                Text("« Appeler le dentiste demain 14h30 #santé p2 »")
+                    .font(.system(size: 13, weight: .medium, design: .monospaced))
+                    .foregroundStyle(theme.accent)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(Metrics.spacingM)
+            .background {
+                RoundedRectangle(cornerRadius: Metrics.cornerRadius, style: .continuous)
+                    .fill(theme.accent.opacity(0.08))
+            }
+            .padding(.horizontal, Metrics.spacingM)
+
+            Spacer()
+        }
+        .padding(Metrics.spacingM)
+    }
+
+    // MARK: Navigation
+
+    private var pageIndicator: some View {
+        HStack(spacing: 6) {
+            ForEach(0..<4, id: \.self) { index in
+                Capsule()
+                    .fill(page == index ? theme.accent : Color.primary.opacity(0.18))
+                    .frame(width: page == index ? 20 : 7, height: 7)
+                    .animation(Motion.snappy, value: page)
+            }
+        }
+        .padding(.bottom, Metrics.spacingM)
+    }
+
+    private var actionButton: some View {
+        Button(page == 3 ? "Commencer l'aventure" : "Continuer") {
+            if page < 3 {
+                withAnimation(Motion.snappy) { page += 1 }
+                Haptics.light()
+            } else {
+                finish()
+            }
+        }
+        .buttonStyle(PrimaryButtonStyle(theme: theme))
+        .padding(.horizontal, Metrics.spacingL)
+    }
+
+    private func finish() {
+        let player = store.profile()
+        if !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            player.displayName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        var loadout = player.avatarLoadout
+        loadout[AvatarSlot.face.rawValue] = faceID
+        player.avatarLoadout = loadout
+        player.hasCompletedOnboarding = true
+
+        settings.themeID = themeID
+        themeManager.select(id: themeID)
+
+        SampleData.seedStarterQuests(store: store, areas: Array(selectedAreas), calendar: settings.calendar)
+        store.bootstrap()
+
+        if wantsNotifications {
+            Task {
+                let granted = await notifications.requestAuthorization()
+                if granted {
+                    notifications.scheduleDailyReview(hour: settings.dailyReviewHour)
+                }
+            }
+        }
+
+        settings.hasSeenOnboarding = true
+        Haptics.success()
+        dismiss()
+    }
+}
+
+// MARK: - Quêtes de départ
+
+enum SampleData {
+
+    /// Quelques quêtes concrètes pour que le premier écran ne soit pas vide —
+    /// et pour montrer au passage ce que l'app sait faire.
+    static func seedStarterQuests(store: QuestlyStore, areas: [LifeArea], calendar: Calendar) {
+        let today = Date()
+
+        struct Seed {
+            let text: String
+            let area: LifeArea?
+        }
+
+        var seeds: [Seed] = [
+            Seed(text: "Découvrir Questly : accomplir cette quête *facile", area: nil),
+            Seed(text: "Planifier ma semaine dimanche 18h #rituel", area: .craft),
+            Seed(text: "Boire un grand verre d'eau tous les jours %corps", area: .body)
+        ]
+
+        if areas.contains(.body) {
+            seeds.append(Seed(text: "Marcher 20min aujourd'hui %corps", area: .body))
+        }
+        if areas.contains(.mind) {
+            seeds.append(Seed(text: "Lire 10 pages ce soir %esprit", area: .mind))
+        }
+        if areas.contains(.heart) {
+            seeds.append(Seed(text: "Appeler quelqu'un qui compte demain %cœur", area: .heart))
+        }
+        if areas.contains(.home) {
+            seeds.append(Seed(text: "Ranger une surface 15min %foyer", area: .home))
+        }
+        if areas.contains(.wealth) {
+            seeds.append(Seed(text: "Vérifier mes comptes vendredi %fortune", area: .wealth))
+        }
+        if areas.contains(.craft) {
+            seeds.append(Seed(text: "!boss Avancer mon projet principal pendant 1h *ardu", area: .craft))
+        }
+
+        for seed in seeds {
+            var parsed = NaturalLanguageParser.parse(seed.text, reference: today, calendar: calendar)
+            if parsed.lifeArea == nil { parsed.lifeArea = seed.area }
+            store.createTask(from: parsed)
+        }
+    }
+}

--- a/QuestlyApp/Questly/Features/QuickAdd/QuickAddView.swift
+++ b/QuestlyApp/Questly/Features/QuickAdd/QuickAddView.swift
@@ -1,0 +1,340 @@
+import SwiftUI
+import SwiftData
+import QuestlyKit
+
+/// Saisie rapide. Une seule zone de texte : on écrit comme on parle, l'app
+/// comprend la date, l'heure, la durée, la priorité, le projet et la répétition.
+struct QuickAddView: View {
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(SettingsStore.self) private var settings
+    @Environment(\.questlyTheme) private var theme
+    @Environment(\.dismiss) private var dismiss
+
+    @Query private var projects: [Project]
+
+    @State private var text = ""
+    @State private var parsed = ParsedInput()
+    @State private var selectedProject: Project?
+    @State private var difficulty: Difficulty = .medium
+    @State private var showsHelp = false
+    @State private var lastCreatedTitle: String?
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacingM) {
+            handle
+            field
+            if parsed.hasMetadata { tokenStrip }
+            quickChips
+            footer
+        }
+        .padding(Metrics.spacingM)
+        .background(Color.clear)
+        .onAppear { isFocused = true }
+        .onChange(of: text) { _, newValue in
+            parsed = NaturalLanguageParser.parse(newValue, reference: Date(), calendar: settings.calendar)
+        }
+        .sheet(isPresented: $showsHelp) {
+            QuickAddHelpView()
+                .presentationDetents([.medium, .large])
+        }
+    }
+
+    // MARK: Sous-vues
+
+    private var handle: some View {
+        HStack {
+            Text("Nouvelle quête")
+                .font(.questHeadline)
+            Spacer()
+            Button {
+                showsHelp = true
+            } label: {
+                Image(systemName: "questionmark.circle")
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var field: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            TextField("Ex. : Appeler le dentiste demain 14h30 #santé p2", text: $text, axis: .vertical)
+                .font(.questBody)
+                .lineLimit(1...4)
+                .focused($isFocused)
+                .submitLabel(.done)
+                .onSubmit { submit() }
+                .padding(Metrics.spacingS + 2)
+                .background {
+                    RoundedRectangle(cornerRadius: Metrics.cornerRadiusSmall, style: .continuous)
+                        .fill(Color.primary.opacity(0.05))
+                }
+                .overlay {
+                    RoundedRectangle(cornerRadius: Metrics.cornerRadiusSmall, style: .continuous)
+                        .strokeBorder(theme.accent.opacity(isFocused ? 0.45 : 0.1), lineWidth: 1)
+                }
+
+            if !parsed.title.isEmpty && parsed.hasMetadata {
+                HStack(spacing: 4) {
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 9))
+                    Text("Titre retenu : « \(parsed.title) »")
+                        .font(.questMicro)
+                }
+                .foregroundStyle(theme.accent)
+            }
+        }
+    }
+
+    /// Pastilles de ce que l'analyseur a compris — le retour immédiat qui
+    /// donne confiance dans la saisie naturelle.
+    private var tokenStrip: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                ForEach(parsed.tokens) { token in
+                    HStack(spacing: 4) {
+                        Image(systemName: token.symbolName)
+                            .font(.system(size: 9, weight: .semibold))
+                        Text(token.display.isEmpty ? token.text : token.display)
+                            .font(.questMicro)
+                    }
+                    .foregroundStyle(Color(hex: token.hex))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 5)
+                    .background {
+                        Capsule().fill(Color(hex: token.hex).opacity(0.14))
+                    }
+                    .transition(.scale.combined(with: .opacity))
+                }
+            }
+            .padding(.vertical, 2)
+        }
+        .animation(Motion.snappy, value: parsed.tokens.count)
+    }
+
+    private var quickChips: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacingS) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    chip("Aujourd'hui", symbol: "sun.max.fill") { append("aujourd'hui") }
+                    chip("Demain", symbol: "arrow.right.circle.fill") { append("demain") }
+                    chip("Ce soir", symbol: "moon.fill") { append("ce soir") }
+                    chip("Lundi", symbol: "calendar") { append("lundi") }
+                    chip("P1", symbol: "flame.fill") { append("p1") }
+                    chip("30 min", symbol: "hourglass") { append("30min") }
+                    chip("Chaque jour", symbol: "repeat") { append("tous les jours") }
+                    chip("Boss", symbol: "crown.fill") { append("!boss") }
+                }
+            }
+
+            HStack(spacing: Metrics.spacingS) {
+                Menu {
+                    Button("Aucun projet") { selectedProject = nil }
+                    ForEach(projects.filter { !$0.isArchived }) { project in
+                        Button("\(project.emoji) \(project.name)") { selectedProject = project }
+                    }
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "folder.fill").font(.system(size: 10))
+                        Text(selectedProject?.name ?? "Projet")
+                            .font(.questMicro)
+                    }
+                    .foregroundStyle(selectedProject == nil ? .secondary : Color(hex: selectedProject?.colorHex ?? "5E5CE6"))
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background { Capsule().fill(Color.primary.opacity(0.06)) }
+                }
+
+                Menu {
+                    ForEach(Difficulty.allCases) { level in
+                        Button {
+                            difficulty = level
+                        } label: {
+                            Label(level.label, systemImage: level.symbolName)
+                        }
+                    }
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: difficulty.symbolName).font(.system(size: 10))
+                        Text(difficulty.label).font(.questMicro)
+                    }
+                    .foregroundStyle(Color(hex: difficulty.hex))
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background { Capsule().fill(Color(hex: difficulty.hex).opacity(0.14)) }
+                }
+
+                Spacer()
+
+                XPPill(amount: previewXP, isPreview: true)
+            }
+        }
+    }
+
+    private var footer: some View {
+        VStack(spacing: Metrics.spacingS) {
+            if let lastCreatedTitle {
+                HStack(spacing: 5) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(Color(hex: "30D158"))
+                    Text("« \(lastCreatedTitle) » ajoutée")
+                        .font(.questMicro)
+                        .foregroundStyle(.secondary)
+                }
+                .transition(.opacity)
+            }
+
+            HStack(spacing: Metrics.spacingS) {
+                Button {
+                    submit(keepOpen: true)
+                } label: {
+                    Label("Ajouter et continuer", systemImage: "plus.circle")
+                        .font(.questCaption)
+                }
+                .buttonStyle(SoftButtonStyle(tint: theme.accent))
+                .disabled(text.trimmingCharacters(in: .whitespaces).isEmpty)
+
+                Button("Ajouter") { submit() }
+                    .buttonStyle(PrimaryButtonStyle(
+                        theme: theme,
+                        isEnabled: !text.trimmingCharacters(in: .whitespaces).isEmpty
+                    ))
+                    .disabled(text.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+        }
+    }
+
+    private func chip(_ title: String, symbol: String, action: @escaping () -> Void) -> some View {
+        Button {
+            action()
+            Haptics.selection()
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: symbol).font(.system(size: 10))
+                Text(title).font(.questMicro)
+            }
+            .foregroundStyle(.primary)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background { Capsule().fill(Color.primary.opacity(0.06)) }
+        }
+        .buttonStyle(PressableStyle())
+    }
+
+    // MARK: Logique
+
+    private var previewXP: Int {
+        let descriptor = XPTaskDescriptor(
+            difficulty: parsed.difficulty ?? difficulty,
+            priority: parsed.priority ?? .p4,
+            estimatedMinutes: parsed.durationMinutes,
+            dueDate: parsed.dueDate,
+            hasTimeComponent: parsed.hasTime,
+            isBoss: parsed.isBoss,
+            lifeArea: parsed.lifeArea
+        )
+        return XPEngine.previewXP(for: descriptor)
+    }
+
+    private func append(_ fragment: String) {
+        if text.isEmpty {
+            text = fragment
+        } else if text.hasSuffix(" ") {
+            text += fragment
+        } else {
+            text += " " + fragment
+        }
+    }
+
+    private func submit(keepOpen: Bool = false) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        var input = parsed
+        if input.difficulty == nil { input.difficulty = difficulty }
+
+        let task = store.createTask(from: input, defaultProject: selectedProject)
+        Haptics.success()
+
+        withAnimation(Motion.snappy) {
+            lastCreatedTitle = task.title
+        }
+
+        text = ""
+        parsed = ParsedInput()
+
+        if keepOpen {
+            isFocused = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                withAnimation { lastCreatedTitle = nil }
+            }
+        } else {
+            dismiss()
+        }
+    }
+}
+
+// MARK: - Aide à la syntaxe
+
+struct QuickAddHelpView: View {
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.questlyTheme) private var theme
+
+    private struct Rule: Identifiable {
+        let id = UUID()
+        let syntax: String
+        let meaning: String
+        let example: String
+    }
+
+    private let rules: [Rule] = [
+        Rule(syntax: "demain, lundi, 15/03…", meaning: "Date d'échéance", example: "Courses samedi"),
+        Rule(syntax: "14h30, 9h, 2pm", meaning: "Heure précise", example: "Dentiste demain 14h30"),
+        Rule(syntax: "30min, 2 heures, pendant 1h30", meaning: "Durée estimée", example: "Réviser pendant 2h"),
+        Rule(syntax: "p1 … p4", meaning: "Priorité (p1 = critique)", example: "Payer le loyer p1"),
+        Rule(syntax: "#étiquette", meaning: "Étiquette", example: "Lait #courses"),
+        Rule(syntax: "@contexte", meaning: "Contexte, devient une étiquette", example: "Imprimer @bureau"),
+        Rule(syntax: "+projet", meaning: "Projet", example: "Maquette +Refonte"),
+        Rule(syntax: "*facile … *légendaire", meaning: "Difficulté, donc XP", example: "Thèse *légendaire"),
+        Rule(syntax: "%corps, %esprit…", meaning: "Domaine de vie", example: "Squats %corps"),
+        Rule(syntax: "!boss", meaning: "Marque un boss (XP ×2)", example: "!boss Refonte"),
+        Rule(syntax: "tous les jours, chaque lundi", meaning: "Répétition", example: "Yoga chaque lundi 9h"),
+        Rule(syntax: "rappel 30min avant", meaning: "Rappel", example: "Visio 15h rappel 30min avant")
+    ]
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    Text("Écris naturellement : l'app repère les informations et les retire du titre.")
+                        .font(.questCallout)
+                        .foregroundStyle(.secondary)
+                }
+                Section("Syntaxe reconnue") {
+                    ForEach(rules) { rule in
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(rule.syntax)
+                                .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                                .foregroundStyle(theme.accent)
+                            Text(rule.meaning).font(.questCaption)
+                            Text(rule.example)
+                                .font(.questMicro)
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.vertical, 2)
+                    }
+                }
+            }
+            .navigationTitle("Saisie rapide")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Fermer") { dismiss() }
+                }
+            }
+        }
+    }
+}

--- a/QuestlyApp/Questly/Features/Settings/SettingsView.swift
+++ b/QuestlyApp/Questly/Features/Settings/SettingsView.swift
@@ -1,0 +1,560 @@
+import SwiftUI
+import SwiftData
+import UIKit
+import QuestlyKit
+
+/// Réglages. Chaque option existe parce qu'une personne réelle pourrait avoir
+/// besoin de l'inverse du réglage par défaut.
+struct SettingsView: View {
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(SettingsStore.self) private var settings
+    @Environment(ThemeManager.self) private var themeManager
+    @Environment(NotificationService.self) private var notifications
+    @Environment(CalendarService.self) private var calendarService
+    @Environment(\.questlyTheme) private var theme
+
+    @Query private var profiles: [PlayerProfile]
+    @Query private var tasks: [TaskItem]
+
+    @State private var showsResetConfirmation = false
+    @State private var exportURL: URL?
+    @State private var exportError: String?
+
+    private var player: PlayerProfile? { profiles.first }
+
+    var body: some View {
+        Form {
+            appearanceSection
+            notificationSection
+            calendarSection
+            focusSection
+            planningSection
+            dataSection
+            aboutSection
+        }
+        .navigationTitle("Réglages")
+        .navigationBarTitleDisplayMode(.inline)
+        .confirmationDialog(
+            "Tout réinitialiser ?",
+            isPresented: $showsResetConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Réinitialiser les réglages", role: .destructive) {
+                settings.resetToDefaults()
+                themeManager.select(id: settings.themeID)
+            }
+        } message: {
+            Text("Tes quêtes et ta progression ne sont pas touchées.")
+        }
+        .sheet(item: exportBinding) { wrapper in
+            ShareSheet(url: wrapper.url)
+        }
+    }
+
+    // MARK: Apparence
+
+    private var appearanceSection: some View {
+        Section("Ambiance") {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: Metrics.spacingS) {
+                    ForEach(ThemeCatalog.all) { candidate in
+                        themeChip(candidate)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+
+            Toggle(isOn: Binding(
+                get: { settings.confettiEnabled },
+                set: { settings.confettiEnabled = $0 }
+            )) {
+                Label("Confettis et fanfares", systemImage: "sparkles")
+            }
+
+            Toggle(isOn: Binding(
+                get: { settings.hapticsEnabled },
+                set: { settings.hapticsEnabled = $0 }
+            )) {
+                Label("Retour haptique", systemImage: "iphone.radiowaves.left.and.right")
+            }
+
+            Toggle(isOn: Binding(
+                get: { settings.reduceMotion },
+                set: { settings.reduceMotion = $0 }
+            )) {
+                Label("Réduire les animations", systemImage: "tortoise.fill")
+            }
+        }
+    }
+
+    private func themeChip(_ candidate: QuestlyTheme) -> some View {
+        let owned = themeManager.isUnlocked(candidate, ownedItems: player?.unlockedItems ?? [])
+        let isSelected = settings.themeID == candidate.id
+
+        return Button {
+            guard owned else {
+                Haptics.warning()
+                return
+            }
+            settings.themeID = candidate.id
+            themeManager.select(id: candidate.id)
+            Haptics.selection()
+        } label: {
+            VStack(spacing: 5) {
+                ZStack {
+                    Circle()
+                        .fill(candidate.gradient)
+                        .frame(width: 44, height: 44)
+                    if !owned {
+                        Image(systemName: "lock.fill")
+                            .font(.system(size: 14, weight: .bold))
+                            .foregroundStyle(.white)
+                    } else if isSelected {
+                        Image(systemName: "checkmark")
+                            .font(.system(size: 16, weight: .bold))
+                            .foregroundStyle(.white)
+                    }
+                }
+                .overlay {
+                    Circle().strokeBorder(isSelected ? Color.primary : .clear, lineWidth: 2)
+                }
+
+                Text(candidate.name)
+                    .font(.system(size: 10, weight: .medium, design: .rounded))
+                    .foregroundStyle(owned ? .primary : .secondary)
+            }
+            .frame(width: 62)
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: Notifications
+
+    private var notificationSection: some View {
+        Section {
+            HStack {
+                Label("Autorisation", systemImage: "bell.badge.fill")
+                Spacer()
+                switch notifications.authorization {
+                case .granted:
+                    Text("Accordée").foregroundStyle(Color(hex: "30D158")).font(.questCaption)
+                case .denied:
+                    Text("Refusée").foregroundStyle(Color(hex: "FF453A")).font(.questCaption)
+                case .unknown:
+                    Button("Autoriser") {
+                        Task {
+                            let granted = await notifications.requestAuthorization()
+                            if granted { rescheduleAllReminders() }
+                        }
+                    }
+                    .font(.questCaption)
+                }
+            }
+
+            Picker(selection: Binding(
+                get: { settings.dailyReviewHour },
+                set: {
+                    settings.dailyReviewHour = $0
+                    notifications.scheduleDailyReview(hour: $0)
+                }
+            )) {
+                ForEach(6...23, id: \.self) { hour in
+                    Text("\(hour) h").tag(hour)
+                }
+            } label: {
+                Label("Revue du soir", systemImage: "moon.stars.fill")
+            }
+
+            Picker(selection: Binding(
+                get: { settings.defaultReminderMinutes },
+                set: { settings.defaultReminderMinutes = $0 }
+            )) {
+                Text("À l'heure").tag(0)
+                Text("5 min avant").tag(5)
+                Text("15 min avant").tag(15)
+                Text("30 min avant").tag(30)
+                Text("1 h avant").tag(60)
+            } label: {
+                Label("Rappel par défaut", systemImage: "bell.fill")
+            }
+
+            Button {
+                rescheduleAllReminders()
+            } label: {
+                Label("Reprogrammer tous les rappels", systemImage: "arrow.clockwise")
+            }
+        } header: {
+            Text("Notifications")
+        } footer: {
+            Text("Un rappel de série est envoyé en soirée uniquement si ta série est en danger.")
+        }
+    }
+
+    private func rescheduleAllReminders() {
+        notifications.rescheduleAll(
+            tasks: tasks.filter(\.isOpen),
+            calendar: settings.calendar,
+            defaultHour: settings.defaultDueHour
+        )
+        notifications.scheduleDailyReview(hour: settings.dailyReviewHour)
+        notifications.scheduleStreakReminder(streak: store.streak.current)
+        Haptics.success()
+    }
+
+    // MARK: Calendrier
+
+    private var calendarSection: some View {
+        Section {
+            Toggle(isOn: Binding(
+                get: { settings.calendarSyncEnabled },
+                set: { newValue in
+                    settings.calendarSyncEnabled = newValue
+                    if newValue {
+                        Task { await calendarService.requestAccess() }
+                    }
+                }
+            )) {
+                Label("Afficher le calendrier iOS", systemImage: "calendar.badge.clock")
+            }
+
+            Picker(selection: Binding(
+                get: { settings.firstWeekday },
+                set: { settings.firstWeekday = $0 }
+            )) {
+                Text("Lundi").tag(2)
+                Text("Dimanche").tag(1)
+                Text("Samedi").tag(7)
+            } label: {
+                Label("Premier jour de la semaine", systemImage: "calendar")
+            }
+
+            Picker(selection: Binding(
+                get: { settings.defaultDueHour },
+                set: { settings.defaultDueHour = $0 }
+            )) {
+                ForEach(6...22, id: \.self) { hour in
+                    Text("\(hour) h").tag(hour)
+                }
+            } label: {
+                Label("Heure par défaut", systemImage: "clock")
+            }
+        } header: {
+            Text("Calendrier")
+        } footer: {
+            Text("Les évènements du calendrier système restent en lecture seule : ils bloquent les créneaux sans jamais être modifiés.")
+        }
+    }
+
+    // MARK: Concentration
+
+    private var focusSection: some View {
+        Section("Concentration") {
+            Stepper(value: Binding(
+                get: { settings.focusDuration },
+                set: { settings.focusDuration = $0 }
+            ), in: 5...120, step: 5) {
+                Label("Session : \(settings.focusDuration) min", systemImage: "timer")
+            }
+
+            Stepper(value: Binding(
+                get: { settings.breakDuration },
+                set: { settings.breakDuration = $0 }
+            ), in: 1...30) {
+                Label("Pause : \(settings.breakDuration) min", systemImage: "cup.and.saucer.fill")
+            }
+
+            Stepper(value: Binding(
+                get: { settings.longBreakDuration },
+                set: { settings.longBreakDuration = $0 }
+            ), in: 5...60, step: 5) {
+                Label("Grande pause : \(settings.longBreakDuration) min", systemImage: "figure.walk")
+            }
+
+            Stepper(value: Binding(
+                get: { settings.sessionsBeforeLongBreak },
+                set: { settings.sessionsBeforeLongBreak = $0 }
+            ), in: 2...8) {
+                Label("Cycles avant grande pause : \(settings.sessionsBeforeLongBreak)", systemImage: "repeat")
+            }
+        }
+    }
+
+    // MARK: Planification
+
+    private var planningSection: some View {
+        Section {
+            HStack {
+                Label("Journée de travail", systemImage: "sun.max.fill")
+                Spacer()
+                Text("\(settings.workStartMinute / 60) h – \(settings.workEndMinute / 60) h")
+                    .font(.questCaption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Stepper(value: Binding(
+                get: { settings.workStartMinute / 60 },
+                set: { settings.workStartMinute = $0 * 60 }
+            ), in: 0...12) {
+                Text("Début : \(settings.workStartMinute / 60) h").font(.questCaption)
+            }
+
+            Stepper(value: Binding(
+                get: { settings.workEndMinute / 60 },
+                set: { settings.workEndMinute = $0 * 60 }
+            ), in: 13...23) {
+                Text("Fin : \(settings.workEndMinute / 60) h").font(.questCaption)
+            }
+
+            HStack {
+                Label("Pic d'énergie", systemImage: "bolt.fill")
+                Spacer()
+                Text("\(settings.peakStartMinute / 60) h – \(settings.peakEndMinute / 60) h")
+                    .font(.questCaption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Stepper(value: Binding(
+                get: { settings.peakStartMinute / 60 },
+                set: {
+                    settings.peakStartMinute = $0 * 60
+                    if settings.peakEndMinute <= settings.peakStartMinute {
+                        settings.peakEndMinute = min(23, $0 + 3) * 60
+                    }
+                }
+            ), in: 0...20) {
+                Text("Début du pic : \(settings.peakStartMinute / 60) h").font(.questCaption)
+            }
+
+            weekdaySelector
+        } header: {
+            Text("Planification")
+        } footer: {
+            Text("Le planificateur place les quêtes exigeantes dans ta fenêtre de pointe et laisse les petites boucher les trous.")
+        }
+    }
+
+    private var weekdaySelector: some View {
+        let names = ["D", "L", "M", "M", "J", "V", "S"]
+        return HStack(spacing: 6) {
+            ForEach(1...7, id: \.self) { weekday in
+                let isOn = settings.workingWeekdays.contains(weekday)
+                Button {
+                    var current = Set(settings.workingWeekdays)
+                    if isOn { current.remove(weekday) } else { current.insert(weekday) }
+                    settings.workingWeekdays = Array(current).sorted()
+                    Haptics.selection()
+                } label: {
+                    Text(names[weekday - 1])
+                        .font(.questCaption)
+                        .foregroundStyle(isOn ? .white : .secondary)
+                        .frame(width: 32, height: 32)
+                        .background {
+                            Circle().fill(isOn
+                                          ? AnyShapeStyle(theme.gradient)
+                                          : AnyShapeStyle(Color.primary.opacity(0.07)))
+                        }
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: Données
+
+    private var dataSection: some View {
+        Section {
+            Button {
+                exportData()
+            } label: {
+                Label("Exporter mes données (JSON)", systemImage: "square.and.arrow.up")
+            }
+
+            Button {
+                store.rescheduleOverdueToToday()
+                Haptics.success()
+            } label: {
+                Label("Reporter tout le retard à aujourd'hui", systemImage: "arrow.uturn.forward")
+            }
+
+            Button(role: .destructive) {
+                showsResetConfirmation = true
+            } label: {
+                Label("Réinitialiser les réglages", systemImage: "arrow.counterclockwise")
+            }
+        } header: {
+            Text("Données")
+        } footer: {
+            if let exportError {
+                Text(exportError).foregroundStyle(Color(hex: "FF453A"))
+            } else {
+                Text("L'export contient tes quêtes, projets, sessions et progression, dans un format lisible.")
+            }
+        }
+    }
+
+    // MARK: À propos
+
+    private var aboutSection: some View {
+        Section("À propos") {
+            HStack {
+                Label("Version", systemImage: "info.circle")
+                Spacer()
+                Text(Bundle.main.appVersion).foregroundStyle(.secondary).font(.questCaption)
+            }
+            HStack {
+                Label("Quêtes en base", systemImage: "tray.full")
+                Spacer()
+                Text("\(tasks.count)").foregroundStyle(.secondary).font(.questCaption)
+            }
+            HStack {
+                Label("Aventure démarrée le", systemImage: "flag.fill")
+                Spacer()
+                Text(player.map { QuestlyFormat.longDate($0.createdAt) } ?? "—")
+                    .foregroundStyle(.secondary)
+                    .font(.questCaption)
+            }
+        }
+    }
+
+    // MARK: Export
+
+    private struct ExportWrapper: Identifiable {
+        let id = UUID()
+        let url: URL
+    }
+
+    private var exportBinding: Binding<ExportWrapper?> {
+        Binding(
+            get: { exportURL.map { ExportWrapper(url: $0) } },
+            set: { if $0 == nil { exportURL = nil } }
+        )
+    }
+
+    private func exportData() {
+        do {
+            let url = try DataExporter.export(
+                tasks: tasks,
+                player: player,
+                events: store.completionEvents(),
+                calendar: settings.calendar
+            )
+            exportURL = url
+            exportError = nil
+            Haptics.success()
+        } catch {
+            exportError = "Export impossible : \(error.localizedDescription)"
+            Haptics.warning()
+        }
+    }
+}
+
+// MARK: - Partage
+
+struct ShareSheet: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: [url], applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ controller: UIActivityViewController, context: Context) {}
+}
+
+// MARK: - Export JSON
+
+enum DataExporter {
+
+    struct Payload: Encodable {
+        struct ExportedTask: Encodable {
+            let title: String
+            let notes: String
+            let dueDate: Date?
+            let completedAt: Date?
+            let priority: Int
+            let difficulty: Int
+            let lifeArea: String?
+            let isBoss: Bool
+            let estimatedMinutes: Int
+            let focusedMinutes: Int
+            let earnedXP: Int
+            let tags: [String]
+            let project: String?
+            let subtasks: [String]
+        }
+
+        struct ExportedEvent: Encodable {
+            let date: Date
+            let title: String
+            let xp: Int
+            let onTime: Bool
+        }
+
+        let exportedAt: Date
+        let level: Int
+        let totalXP: Int
+        let coins: Int
+        let gems: Int
+        let longestStreak: Int
+        let tasks: [ExportedTask]
+        let history: [ExportedEvent]
+    }
+
+    static func export(
+        tasks: [TaskItem],
+        player: PlayerProfile?,
+        events: [CompletionEvent],
+        calendar: Calendar
+    ) throws -> URL {
+        let payload = Payload(
+            exportedAt: Date(),
+            level: player?.level ?? 1,
+            totalXP: player?.totalXP ?? 0,
+            coins: player?.coins ?? 0,
+            gems: player?.gems ?? 0,
+            longestStreak: player?.longestStreak ?? 0,
+            tasks: tasks.map { task in
+                Payload.ExportedTask(
+                    title: task.title,
+                    notes: task.notes,
+                    dueDate: task.dueDate,
+                    completedAt: task.completedAt,
+                    priority: task.priorityRaw,
+                    difficulty: task.difficultyRaw,
+                    lifeArea: task.lifeAreaRaw,
+                    isBoss: task.isBoss,
+                    estimatedMinutes: task.estimatedMinutes,
+                    focusedMinutes: task.focusedMinutes,
+                    earnedXP: task.earnedXP,
+                    tags: task.sortedTags.map(\.name),
+                    project: task.project?.name,
+                    subtasks: task.orderedSubtasks.map(\.title)
+                )
+            },
+            history: events.map {
+                Payload.ExportedEvent(date: $0.date, title: $0.taskTitle, xp: $0.xp, onTime: $0.wasOnTime)
+            }
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(payload)
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        let filename = "questly-\(formatter.string(from: Date())).json"
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
+        try data.write(to: url, options: .atomic)
+        return url
+    }
+}
+
+extension Bundle {
+    var appVersion: String {
+        let version = infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
+        let build = infoDictionary?["CFBundleVersion"] as? String ?? "1"
+        return "\(version) (\(build))"
+    }
+}

--- a/QuestlyApp/Questly/Features/Shared/Formatters.swift
+++ b/QuestlyApp/Questly/Features/Shared/Formatters.swift
@@ -1,0 +1,124 @@
+import Foundation
+import QuestlyKit
+
+/// Mise en forme des dates dans le vocabulaire de l'app : relatif quand c'est
+/// utile, absolu quand c'est nécessaire, jamais les deux à la fois.
+enum QuestlyFormat {
+
+    static let locale = Locale(identifier: "fr_FR")
+
+    private static func formatter(_ format: String, calendar: Calendar) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.timeZone = calendar.timeZone
+        formatter.locale = locale
+        formatter.dateFormat = format
+        return formatter
+    }
+
+    /// « 14:30 »
+    static func time(_ date: Date, calendar: Calendar = .questly()) -> String {
+        formatter("HH:mm", calendar: calendar).string(from: date)
+    }
+
+    /// « lun. 9 mars »
+    static func mediumDate(_ date: Date, calendar: Calendar = .questly()) -> String {
+        formatter("EEE d MMM", calendar: calendar).string(from: date)
+    }
+
+    /// « 9 mars 2026 »
+    static func longDate(_ date: Date, calendar: Calendar = .questly()) -> String {
+        formatter("d MMMM yyyy", calendar: calendar).string(from: date)
+    }
+
+    /// « mars 2026 »
+    static func monthYear(_ date: Date, calendar: Calendar = .questly()) -> String {
+        formatter("MMMM yyyy", calendar: calendar).string(from: date).capitalizedFirstLetter
+    }
+
+    /// « mars »
+    static func month(_ date: Date, calendar: Calendar = .questly()) -> String {
+        formatter("MMMM", calendar: calendar).string(from: date).capitalizedFirstLetter
+    }
+
+    /// « lun. »
+    static func weekdayShort(_ date: Date, calendar: Calendar = .questly()) -> String {
+        formatter("EEE", calendar: calendar).string(from: date)
+    }
+
+    /// « L » — initiale du jour, pour les en-têtes compacts du calendrier.
+    static func weekdayInitial(_ date: Date, calendar: Calendar = .questly()) -> String {
+        let text = formatter("EEEEE", calendar: calendar).string(from: date)
+        return text.uppercased()
+    }
+
+    /// « lundi 9 mars »
+    static func fullDay(_ date: Date, calendar: Calendar = .questly()) -> String {
+        formatter("EEEE d MMMM", calendar: calendar).string(from: date).capitalizedFirstLetter
+    }
+
+    static func dayNumber(_ date: Date, calendar: Calendar = .questly()) -> String {
+        String(calendar.component(.day, from: date))
+    }
+
+    /// Étiquette d'échéance affichée sur une ligne de quête.
+    static func dueLabel(
+        for date: Date,
+        hasTime: Bool,
+        now: Date = Date(),
+        calendar: Calendar = .questly()
+    ) -> String {
+        let delta = calendar.daysBetween(now, date)
+        let dayPart: String
+
+        switch delta {
+        case 0: dayPart = "Aujourd'hui"
+        case 1: dayPart = "Demain"
+        case -1: dayPart = "Hier"
+        case 2...6: dayPart = weekdayShort(date, calendar: calendar).capitalizedFirstLetter
+        case -6...(-2): dayPart = "Il y a \(-delta) j"
+        default: dayPart = mediumDate(date, calendar: calendar)
+        }
+
+        guard hasTime else { return dayPart }
+        return "\(dayPart) · \(time(date, calendar: calendar))"
+    }
+
+    /// « En retard de 3 jours »
+    static func overdueLabel(
+        for date: Date,
+        now: Date = Date(),
+        calendar: Calendar = .questly()
+    ) -> String {
+        let days = calendar.daysBetween(date, now)
+        if days <= 0 { return "En retard" }
+        if days == 1 { return "En retard d'un jour" }
+        return "En retard de \(days) jours"
+    }
+
+    /// Salutation adaptée à l'heure.
+    static func greeting(for date: Date = Date(), calendar: Calendar = .questly()) -> String {
+        switch calendar.component(.hour, from: date) {
+        case 0..<5: return "Bonne nuit"
+        case 5..<12: return "Bonjour"
+        case 12..<18: return "Bon après-midi"
+        case 18..<23: return "Bonsoir"
+        default: return "Bonne nuit"
+        }
+    }
+
+    /// Nombre compact : 1 240 → « 1,2 k »
+    static func compactNumber(_ value: Int) -> String {
+        if value < 1000 { return "\(value)" }
+        if value < 1_000_000 {
+            let thousands = Double(value) / 1000
+            return String(format: "%.1f k", thousands).replacingOccurrences(of: ".", with: ",")
+        }
+        let millions = Double(value) / 1_000_000
+        return String(format: "%.1f M", millions).replacingOccurrences(of: ".", with: ",")
+    }
+
+    static func percent(_ fraction: Double) -> String {
+        "\(Int((fraction * 100).rounded())) %"
+    }
+}

--- a/QuestlyApp/Questly/Features/Shared/TaskRow.swift
+++ b/QuestlyApp/Questly/Features/Shared/TaskRow.swift
@@ -1,0 +1,343 @@
+import SwiftUI
+import SwiftData
+import QuestlyKit
+
+/// La ligne de quête, réutilisée partout. C'est l'élément le plus vu de l'app :
+/// dense en information mais lisible d'un coup d'œil, et validable d'un pouce.
+struct TaskRow: View {
+
+    let task: TaskItem
+    var showsProject: Bool = true
+    var showsDueDate: Bool = true
+    var isCompact: Bool = false
+    var onTap: (() -> Void)?
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(SettingsStore.self) private var settings
+    @Environment(\.questlyTheme) private var theme
+
+    @State private var showsBurst = false
+    @State private var floatingXP: Int?
+
+    private var accent: Color {
+        if task.isBoss { return Color(hex: "BF5AF2") }
+        if let area = task.lifeArea { return Color(hex: area.hex) }
+        return Color(hex: task.priority.hex)
+    }
+
+    private var isOverdue: Bool {
+        task.isOverdue(now: Date(), calendar: settings.calendar)
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: Metrics.spacingS) {
+            checkbox
+            details
+            Spacer(minLength: 0)
+            trailing
+        }
+        .padding(.vertical, isCompact ? 6 : 9)
+        .padding(.horizontal, Metrics.spacingS)
+        .background {
+            RoundedRectangle(cornerRadius: Metrics.cornerRadiusSmall, style: .continuous)
+                .fill(task.isBoss ? accent.opacity(0.08) : Color.clear)
+        }
+        .overlay {
+            if task.isBoss {
+                RoundedRectangle(cornerRadius: Metrics.cornerRadiusSmall, style: .continuous)
+                    .strokeBorder(accent.opacity(0.28), lineWidth: 1)
+            }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture { onTap?() }
+        .opacity(task.isCompleted ? 0.55 : 1)
+        .animation(Motion.snappy, value: task.isCompleted)
+    }
+
+    // MARK: Sous-vues
+
+    private var checkbox: some View {
+        ZStack {
+            QuestCheckbox(
+                isCompleted: task.isCompleted,
+                tint: accent,
+                size: isCompact ? 22 : 26,
+                isBoss: task.isBoss
+            ) {
+                toggle()
+            }
+
+            if showsBurst {
+                CompletionBurst(color: accent)
+                    .frame(width: 90, height: 90)
+                    .allowsHitTesting(false)
+            }
+
+            if let floatingXP {
+                FloatingXPText(amount: floatingXP)
+                    .offset(x: 20)
+            }
+        }
+    }
+
+    private var details: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(task.title)
+                .font(isCompact ? .questCallout : .questBody)
+                .strikethrough(task.isCompleted, color: .secondary)
+                .foregroundStyle(task.isCompleted ? Color.secondary : Color.primary)
+                .lineLimit(2)
+
+            if !metadataItems.isEmpty {
+                HStack(spacing: 6) {
+                    ForEach(metadataItems) { item in
+                        metadataChip(item)
+                    }
+                }
+            }
+
+            if !task.orderedSubtasks.isEmpty && !isCompact {
+                subtaskProgress
+            }
+
+            if !task.sortedTags.isEmpty && !isCompact {
+                HStack(spacing: 4) {
+                    ForEach(task.sortedTags.prefix(3)) { tag in
+                        TagChip(name: tag.name, colorHex: tag.colorHex)
+                    }
+                    if task.sortedTags.count > 3 {
+                        Text("+\(task.sortedTags.count - 3)")
+                            .font(.questMicro)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+    }
+
+    private var subtaskProgress: some View {
+        HStack(spacing: 6) {
+            ProgressView(value: task.progress)
+                .progressViewStyle(.linear)
+                .tint(accent)
+                .frame(width: 62)
+            Text("\(task.completedSubtaskCount)/\(task.orderedSubtasks.count)")
+                .font(.questMicro)
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+        }
+    }
+
+    private var trailing: some View {
+        VStack(alignment: .trailing, spacing: 4) {
+            if !task.isCompleted {
+                XPPill(amount: task.previewXP, isPreview: true)
+            } else if task.earnedXP > 0 {
+                XPPill(amount: task.earnedXP)
+            }
+
+            if task.priority != .p4 {
+                PriorityBadge(priority: task.priority, compact: true)
+            }
+        }
+    }
+
+    // MARK: Métadonnées
+
+    private struct MetadataItem: Identifiable {
+        let id: String
+        let symbolName: String
+        let text: String
+        let color: Color
+    }
+
+    private var metadataItems: [MetadataItem] {
+        var items: [MetadataItem] = []
+
+        if showsDueDate, let due = task.dueDate {
+            items.append(MetadataItem(
+                id: "due",
+                symbolName: isOverdue ? "exclamationmark.triangle.fill" : "calendar",
+                text: isOverdue
+                    ? QuestlyFormat.overdueLabel(for: due, calendar: settings.calendar)
+                    : QuestlyFormat.dueLabel(for: due, hasTime: task.hasTime, calendar: settings.calendar),
+                color: isOverdue ? Color(hex: "FF453A") : .secondary
+            ))
+        }
+
+        if task.estimatedMinutes > 0 {
+            items.append(MetadataItem(
+                id: "duration",
+                symbolName: "hourglass",
+                text: DurationFormatter.short(minutes: task.estimatedMinutes),
+                color: .secondary
+            ))
+        }
+
+        if task.isRecurring {
+            items.append(MetadataItem(
+                id: "repeat",
+                symbolName: "repeat",
+                text: "",
+                color: theme.accent
+            ))
+        }
+
+        if showsProject, let project = task.project {
+            items.append(MetadataItem(
+                id: "project",
+                symbolName: "folder.fill",
+                text: project.name,
+                color: Color(hex: project.colorHex)
+            ))
+        }
+
+        if task.focusedMinutes > 0 {
+            items.append(MetadataItem(
+                id: "focus",
+                symbolName: "timer",
+                text: DurationFormatter.short(minutes: task.focusedMinutes),
+                color: Color(hex: "30D158")
+            ))
+        }
+
+        return items
+    }
+
+    private func metadataChip(_ item: MetadataItem) -> some View {
+        HStack(spacing: 3) {
+            Image(systemName: item.symbolName)
+                .font(.system(size: 9, weight: .semibold))
+            if !item.text.isEmpty {
+                Text(item.text).font(.questMicro)
+            }
+        }
+        .foregroundStyle(item.color)
+    }
+
+    // MARK: Actions
+
+    private func toggle() {
+        if task.isCompleted {
+            store.uncomplete(task)
+            return
+        }
+
+        let bundle = store.complete(task)
+        floatingXP = bundle.award.totalXP
+        showsBurst = true
+        Haptics.play(bundle.comboCount > 1 ? .combo(bundle.comboCount) : .success)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+            showsBurst = false
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.1) {
+            floatingXP = nil
+        }
+    }
+}
+
+// MARK: - Actions de balayage
+
+/// Actions de balayage communes à toutes les listes de quêtes.
+struct TaskSwipeActions: ViewModifier {
+    let task: TaskItem
+    var onOpenDetail: (() -> Void)?
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(SettingsStore.self) private var settings
+
+    func body(content: Content) -> some View {
+        content
+            .swipeActions(edge: .leading, allowsFullSwipe: true) {
+                if task.isOpen {
+                    Button {
+                        store.snooze(task, to: Date(), keepTime: task.hasTime)
+                        Haptics.light()
+                    } label: {
+                        Label("Aujourd'hui", systemImage: "sun.max.fill")
+                    }
+                    .tint(Color(hex: "FF9F0A"))
+
+                    Button {
+                        store.snooze(task, to: Date().adding(days: 1, calendar: settings.calendar), keepTime: task.hasTime)
+                        Haptics.light()
+                    } label: {
+                        Label("Demain", systemImage: "arrow.right.circle.fill")
+                    }
+                    .tint(Color(hex: "5E5CE6"))
+                }
+            }
+            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                Button(role: .destructive) {
+                    store.delete(task)
+                    Haptics.warning()
+                } label: {
+                    Label("Supprimer", systemImage: "trash.fill")
+                }
+
+                Button {
+                    task.isFlagged.toggle()
+                    task.touch()
+                    store.save()
+                    Haptics.light()
+                } label: {
+                    Label(task.isFlagged ? "Retirer" : "Épingler", systemImage: "flag.fill")
+                }
+                .tint(Color(hex: "FFD60A"))
+
+                Button {
+                    task.isBoss.toggle()
+                    task.touch()
+                    store.save()
+                    Haptics.play(.medium)
+                } label: {
+                    Label("Boss", systemImage: "crown.fill")
+                }
+                .tint(Color(hex: "BF5AF2"))
+            }
+            .contextMenu {
+                Button {
+                    onOpenDetail?()
+                } label: {
+                    Label("Ouvrir", systemImage: "square.and.pencil")
+                }
+                Button {
+                    store.snooze(task, to: Date().adding(days: 7, calendar: settings.calendar))
+                } label: {
+                    Label("Dans une semaine", systemImage: "calendar.badge.clock")
+                }
+                Button {
+                    duplicate()
+                } label: {
+                    Label("Dupliquer", systemImage: "doc.on.doc")
+                }
+                Divider()
+                Button(role: .destructive) {
+                    store.delete(task)
+                } label: {
+                    Label("Supprimer", systemImage: "trash")
+                }
+            }
+    }
+
+    private func duplicate() {
+        let copy = store.createTask(title: task.title, dueDate: task.dueDate, hasTime: task.hasTime)
+        copy.notes = task.notes
+        copy.priority = task.priority
+        copy.difficulty = task.difficulty
+        copy.energy = task.energy
+        copy.estimatedMinutes = task.estimatedMinutes
+        copy.lifeArea = task.lifeArea
+        copy.isBoss = task.isBoss
+        copy.project = task.project
+        copy.tags = task.tags
+        store.save()
+    }
+}
+
+extension View {
+    func taskSwipeActions(for task: TaskItem, onOpenDetail: (() -> Void)? = nil) -> some View {
+        modifier(TaskSwipeActions(task: task, onOpenDetail: onOpenDetail))
+    }
+}

--- a/QuestlyApp/Questly/Features/Stats/StatsView.swift
+++ b/QuestlyApp/Questly/Features/Stats/StatsView.swift
@@ -1,0 +1,417 @@
+import SwiftUI
+import SwiftData
+import Charts
+import QuestlyKit
+
+/// Les Chroniques : ce que racontent les données. L'objectif n'est pas
+/// d'impressionner avec des courbes, mais de rendre visible ce qui se répète.
+struct StatsView: View {
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(SettingsStore.self) private var settings
+    @Environment(\.questlyTheme) private var theme
+
+    @Query private var profiles: [PlayerProfile]
+    @Query private var events: [CompletionEvent]
+
+    @State private var period: Period = .month
+
+    enum Period: String, CaseIterable, Identifiable, Hashable {
+        case week, month, quarter, year
+
+        var id: String { rawValue }
+
+        var label: String {
+            switch self {
+            case .week: return "7 j"
+            case .month: return "30 j"
+            case .quarter: return "90 j"
+            case .year: return "1 an"
+            }
+        }
+
+        var days: Int {
+            switch self {
+            case .week: return 7
+            case .month: return 30
+            case .quarter: return 90
+            case .year: return 365
+            }
+        }
+    }
+
+    private var calendar: Calendar { settings.calendar }
+    private var player: PlayerProfile? { profiles.first }
+
+    private var stats: ProductivityStats {
+        StatsEngine.compute(
+            records: events.map(\.record),
+            from: Date().adding(days: -period.days, calendar: calendar),
+            to: Date(),
+            calendar: calendar
+        )
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Metrics.spacingL) {
+                periodPicker
+                summaryTiles
+                xpChart
+                completionChart
+                weekdayChart
+                hourChart
+                areaChart
+                heatmapSection
+                insightsSection
+                Color.clear.frame(height: 100)
+            }
+            .padding(.horizontal, Metrics.spacingM)
+            .padding(.top, Metrics.spacingS)
+        }
+        .scrollIndicators(.hidden)
+        .navigationTitle("Chroniques")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    // MARK: Période
+
+    private var periodPicker: some View {
+        QuestlySegmentedPicker(
+            items: Period.allCases,
+            label: { $0.label },
+            selection: $period
+        )
+    }
+
+    // MARK: Résumé
+
+    private var summaryTiles: some View {
+        let current = stats
+        let change = StatsEngine.weekOverWeekChange(
+            records: events.map(\.record),
+            reference: Date(),
+            calendar: calendar
+        )
+
+        return LazyVGrid(
+            columns: Array(repeating: GridItem(.flexible(), spacing: Metrics.spacingS), count: 2),
+            spacing: Metrics.spacingS
+        ) {
+            tile("Quêtes accomplies", "\(current.totalCompleted)", "checkmark.seal.fill", "30D158",
+                 footnote: change.map { "\($0 >= 0 ? "+" : "")\(Int($0 * 100)) % vs semaine dernière" })
+            tile("XP gagné", QuestlyFormat.compactNumber(current.totalXP), "bolt.fill", "FFD60A",
+                 footnote: "\(Int(current.averageXPPerDay)) XP / jour")
+            tile("Concentration", DurationFormatter.short(minutes: current.totalFocusMinutes), "timer", "5E9BFF",
+                 footnote: "\(current.activeDays) jours actifs")
+            tile("Ponctualité", QuestlyFormat.percent(current.onTimeRate), "clock.badge.checkmark.fill", "34D399",
+                 footnote: current.bossesDefeated > 0 ? "\(current.bossesDefeated) boss vaincus" : nil)
+        }
+    }
+
+    private func tile(_ label: String, _ value: String, _ symbol: String, _ hex: String, footnote: String? = nil) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Image(systemName: symbol)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Color(hex: hex))
+                Spacer()
+            }
+            Text(value)
+                .font(.questNumber(22))
+                .monospacedDigit()
+            Text(label)
+                .font(.questMicro)
+                .foregroundStyle(.secondary)
+            if let footnote {
+                Text(footnote)
+                    .font(.system(size: 9, weight: .medium, design: .rounded))
+                    .foregroundStyle(Color(hex: hex))
+                    .lineLimit(1)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Metrics.spacingS + 2)
+        .background {
+            RoundedRectangle(cornerRadius: Metrics.cornerRadiusSmall, style: .continuous)
+                .fill(.ultraThinMaterial)
+        }
+    }
+
+    // MARK: Courbe d'XP
+
+    private var xpChart: some View {
+        chartCard(title: "Expérience gagnée", symbol: "bolt.fill") {
+            let points = stats.daily
+            let average = StatsEngine.rollingAverage(points, window: 7)
+
+            Chart {
+                ForEach(Array(points.enumerated()), id: \.element.id) { index, point in
+                    AreaMark(
+                        x: .value("Jour", point.date),
+                        y: .value("XP", point.xp)
+                    )
+                    .foregroundStyle(
+                        LinearGradient(
+                            colors: [theme.accent.opacity(0.35), theme.accent.opacity(0.02)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+                    .interpolationMethod(.catmullRom)
+
+                    if index < average.count {
+                        LineMark(
+                            x: .value("Jour", point.date),
+                            y: .value("Moyenne", average[index]),
+                            series: .value("Série", "moyenne")
+                        )
+                        .foregroundStyle(theme.secondary)
+                        .lineStyle(StrokeStyle(lineWidth: 2, dash: [4, 3]))
+                        .interpolationMethod(.catmullRom)
+                    }
+                }
+            }
+            .frame(height: 170)
+            .chartYAxis {
+                AxisMarks(position: .leading)
+            }
+        }
+    }
+
+    // MARK: Quêtes par jour
+
+    private var completionChart: some View {
+        chartCard(title: "Quêtes par jour", symbol: "checklist") {
+            Chart(stats.daily) { point in
+                BarMark(
+                    x: .value("Jour", point.date, unit: .day),
+                    y: .value("Quêtes", point.completed)
+                )
+                .foregroundStyle(theme.gradient)
+                .cornerRadius(3)
+            }
+            .frame(height: 150)
+            .chartYAxis { AxisMarks(position: .leading) }
+        }
+    }
+
+    // MARK: Par jour de semaine
+
+    private var weekdayChart: some View {
+        chartCard(title: "Ton rythme hebdomadaire", symbol: "calendar") {
+            Chart(stats.byWeekday) { bucket in
+                BarMark(
+                    x: .value("Jour", bucket.label),
+                    y: .value("Quêtes", bucket.value)
+                )
+                .foregroundStyle(
+                    bucket.index == stats.bestWeekday
+                        ? AnyShapeStyle(theme.gradient)
+                        : AnyShapeStyle(theme.accent.opacity(0.35))
+                )
+                .cornerRadius(4)
+            }
+            .frame(height: 140)
+            .chartYAxis { AxisMarks(position: .leading) }
+        }
+    }
+
+    // MARK: Par heure
+
+    private var hourChart: some View {
+        chartCard(
+            title: "Tes heures fortes",
+            symbol: "clock.fill",
+            subtitle: stats.bestHour.map { "Pic vers \($0) h" }
+        ) {
+            Chart(stats.byHour) { bucket in
+                BarMark(
+                    x: .value("Heure", bucket.index),
+                    y: .value("Quêtes", bucket.value)
+                )
+                .foregroundStyle(
+                    bucket.index == stats.bestHour
+                        ? AnyShapeStyle(Color(hex: "FF9F0A"))
+                        : AnyShapeStyle(theme.accent.opacity(0.45))
+                )
+                .cornerRadius(2)
+            }
+            .frame(height: 130)
+            .chartXScale(domain: 0...23)
+            .chartXAxis {
+                AxisMarks(values: [0, 6, 12, 18, 23]) { value in
+                    AxisValueLabel {
+                        if let hour = value.as(Int.self) {
+                            Text("\(hour) h").font(.questMicro)
+                        }
+                    }
+                }
+            }
+            .chartYAxis { AxisMarks(position: .leading) }
+        }
+    }
+
+    // MARK: Par domaine
+
+    /// Compteur par domaine — un type nommé plutôt qu'un tuple : `ForEach`
+    /// ne sait pas indexer les tuples par key-path.
+    private struct AreaCount: Identifiable {
+        let area: LifeArea
+        let count: Int
+        var id: String { area.rawValue }
+    }
+
+    private var areaChart: some View {
+        let entries = LifeArea.allCases.map { area in
+            AreaCount(area: area, count: stats.byArea[area] ?? 0)
+        }
+        let total = max(1, entries.reduce(0) { $0 + $1.count })
+
+        return chartCard(title: "Équilibre de vie", symbol: "circle.hexagongrid.fill") {
+            VStack(spacing: Metrics.spacingS) {
+                // Barre empilée : l'équilibre se lit d'un coup d'œil.
+                GeometryReader { geo in
+                    HStack(spacing: 2) {
+                        ForEach(entries.filter { $0.count > 0 }) { entry in
+                            RoundedRectangle(cornerRadius: 3)
+                                .fill(Color(hex: entry.area.hex))
+                                .frame(width: max(3, geo.size.width * Double(entry.count) / Double(total)))
+                        }
+                    }
+                }
+                .frame(height: 14)
+
+                LazyVGrid(
+                    columns: Array(repeating: GridItem(.flexible(), spacing: 4), count: 3),
+                    spacing: 6
+                ) {
+                    ForEach(entries) { entry in
+                        HStack(spacing: 4) {
+                            Circle()
+                                .fill(Color(hex: entry.area.hex))
+                                .frame(width: 7, height: 7)
+                            Text(entry.area.label)
+                                .font(.questMicro)
+                                .lineLimit(1)
+                            Spacer(minLength: 0)
+                            Text("\(entry.count)")
+                                .font(.questMicro)
+                                .monospacedDigit()
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: Carte de chaleur
+
+    private var heatmapSection: some View {
+        chartCard(title: "Une année en un regard", symbol: "square.grid.3x3.fill") {
+            let cells = store.heatmapCells(months: 12)
+            // Sept lignes = les sept jours de la semaine, empilés par colonne.
+            let rows = Array(repeating: GridItem(.fixed(11), spacing: 3), count: 7)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHGrid(rows: rows, spacing: 3) {
+                    ForEach(cells) { cell in
+                        RoundedRectangle(cornerRadius: 2.5, style: .continuous)
+                            .fill(heatColor(level: cell.level))
+                            .frame(width: 11, height: 11)
+                    }
+                }
+                .frame(height: 100)
+            }
+        }
+    }
+
+    private func heatColor(level: Int) -> Color {
+        switch level {
+        case 0: return Color.primary.opacity(0.07)
+        case 1: return theme.accent.opacity(0.28)
+        case 2: return theme.accent.opacity(0.5)
+        case 3: return theme.accent.opacity(0.75)
+        default: return theme.accent
+        }
+    }
+
+    // MARK: Observations
+
+    private var insightsSection: some View {
+        let insights = InsightEngine.insights(
+            stats: stats,
+            streak: store.streak,
+            totalXP: player?.totalXP ?? 0,
+            overdueCount: 0,
+            calendar: calendar
+        )
+
+        return Group {
+            if !insights.isEmpty {
+                VStack(alignment: .leading, spacing: Metrics.spacingS) {
+                    Text("Ce que ça raconte")
+                        .font(.questCallout)
+                        .foregroundStyle(.secondary)
+
+                    ForEach(insights) { insight in
+                        GlassCard {
+                            HStack(alignment: .top, spacing: Metrics.spacingS) {
+                                Image(systemName: insight.symbolName)
+                                    .font(.system(size: 15))
+                                    .foregroundStyle(tone(insight.tone))
+                                    .frame(width: 24)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(insight.title).font(.questCallout)
+                                    Text(insight.detail)
+                                        .font(.questMicro)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func tone(_ tone: Insight.Tone) -> Color {
+        switch tone {
+        case .positive: return Color(hex: "30D158")
+        case .warning: return Color(hex: "FF9F0A")
+        case .neutral: return Color(hex: "5E9BFF")
+        }
+    }
+
+    // MARK: Habillage des graphiques
+
+    private func chartCard<Content: View>(
+        title: String,
+        symbol: String,
+        subtitle: String? = nil,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: Metrics.spacingS) {
+            HStack(spacing: 6) {
+                Image(systemName: symbol)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(theme.accent)
+                Text(title)
+                    .font(.questCallout)
+                Spacer()
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.questMicro)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            content()
+        }
+        .padding(Metrics.spacingM)
+        .background {
+            RoundedRectangle(cornerRadius: Metrics.cornerRadius, style: .continuous)
+                .fill(.ultraThinMaterial)
+        }
+    }
+}

--- a/QuestlyApp/Questly/Features/Tasks/QuestBoardView.swift
+++ b/QuestlyApp/Questly/Features/Tasks/QuestBoardView.swift
@@ -1,0 +1,600 @@
+import SwiftUI
+import SwiftData
+import QuestlyKit
+
+/// Le tableau des quêtes : listes intelligentes, projets, étiquettes,
+/// recherche, tri et regroupement. C'est la vue « gestionnaire » de l'app.
+struct QuestBoardView: View {
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(SettingsStore.self) private var settings
+    @Environment(\.questlyTheme) private var theme
+
+    @Query private var tasks: [TaskItem]
+    @Query(sort: \Project.sortIndex) private var projects: [Project]
+    @Query(sort: \Tag.name) private var tags: [Tag]
+
+    @State private var smartList: SmartList = .today
+    @State private var searchText = ""
+    @State private var sortOrder: TaskSortOrder = .smart
+    @State private var grouping: TaskGrouping = .date
+    @State private var selectedTask: TaskItem?
+    @State private var selectedTag: Tag?
+    @State private var showsNewProject = false
+
+    private var calendar: Calendar { settings.calendar }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                smartListSection
+                if !projects.isEmpty { projectSection }
+                if !tags.isEmpty { tagSection }
+                taskSection
+                Section { Color.clear.frame(height: 90).listRowBackground(Color.clear) }
+            }
+            .listStyle(.insetGrouped)
+            .scrollContentBackground(.hidden)
+            .searchable(text: $searchText, prompt: "Rechercher une quête")
+            .navigationTitle("Quêtes")
+            .toolbar { toolbarContent }
+            .sheet(item: $selectedTask) { task in
+                TaskDetailView(task: task)
+            }
+            .sheet(isPresented: $showsNewProject) {
+                ProjectEditorView()
+                    .presentationDetents([.height(420)])
+            }
+        }
+    }
+
+    // MARK: Barre d'outils
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        ToolbarItem(placement: .topBarTrailing) {
+            Menu {
+                Picker("Trier par", selection: $sortOrder) {
+                    ForEach(TaskSortOrder.allCases) { order in
+                        Text(order.label).tag(order)
+                    }
+                }
+                Picker("Grouper par", selection: $grouping) {
+                    ForEach(TaskGrouping.allCases) { group in
+                        Text(group.label).tag(group)
+                    }
+                }
+                Divider()
+                Button {
+                    showsNewProject = true
+                } label: {
+                    Label("Nouveau projet", systemImage: "folder.badge.plus")
+                }
+                Toggle("Afficher les accomplies", isOn: Binding(
+                    get: { settings.showCompletedTasks },
+                    set: { settings.showCompletedTasks = $0 }
+                ))
+            } label: {
+                Image(systemName: "line.3.horizontal.decrease.circle")
+            }
+        }
+    }
+
+    // MARK: Listes intelligentes
+
+    private var smartListSection: some View {
+        Section {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: Metrics.spacingS) {
+                    ForEach(SmartList.allCases) { list in
+                        SmartListChip(
+                            list: list,
+                            count: count(for: list),
+                            isSelected: smartList == list && selectedTag == nil
+                        ) {
+                            withAnimation(Motion.snappy) {
+                                smartList = list
+                                selectedTag = nil
+                            }
+                            Haptics.selection()
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            .listRowInsets(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 12))
+            .listRowBackground(Color.clear)
+        }
+    }
+
+    private func count(for list: SmartList) -> Int {
+        items(in: list).count
+    }
+
+    // MARK: Projets
+
+    private var projectSection: some View {
+        Section("Campagnes") {
+            ForEach(projects.filter { !$0.isArchived }) { project in
+                NavigationLink {
+                    ProjectDetailView(project: project)
+                } label: {
+                    ProjectRow(project: project)
+                }
+            }
+        }
+    }
+
+    // MARK: Étiquettes
+
+    private var tagSection: some View {
+        Section("Étiquettes") {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach(tags) { tag in
+                        Button {
+                            withAnimation(Motion.snappy) {
+                                selectedTag = selectedTag?.identifier == tag.identifier ? nil : tag
+                            }
+                            Haptics.selection()
+                        } label: {
+                            TagChip(
+                                name: "\(tag.name) · \(tag.openTaskCount)",
+                                colorHex: tag.colorHex,
+                                isSelected: selectedTag?.identifier == tag.identifier
+                            )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.vertical, 2)
+            }
+            .listRowInsets(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 12))
+        }
+    }
+
+    // MARK: Quêtes
+
+    private var taskSection: some View {
+        ForEach(groupedTasks, id: \.title) { group in
+            Section(group.title) {
+                if group.tasks.isEmpty {
+                    Text("Rien ici.")
+                        .font(.questCaption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(group.tasks) { task in
+                        TaskRow(task: task) { selectedTask = task }
+                            .taskSwipeActions(for: task) { selectedTask = task }
+                            .listRowInsets(EdgeInsets(top: 2, leading: 8, bottom: 2, trailing: 12))
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: Filtrage
+
+    private func items(in list: SmartList) -> [TaskItem] {
+        let now = Date()
+        switch list {
+        case .inbox:
+            return tasks.filter { $0.status == .inbox }
+        case .today:
+            return tasks.filter { task in
+                guard task.isOpen, let due = task.dueDate else { return false }
+                return calendar.startOfDay(for: due) <= calendar.startOfDay(for: now)
+            }
+        case .upcoming:
+            return tasks.filter { task in
+                guard task.isOpen, let due = task.dueDate else { return false }
+                return calendar.startOfDay(for: due) > calendar.startOfDay(for: now)
+            }
+        case .overdue:
+            return tasks.filter { $0.isOverdue(now: now, calendar: calendar) }
+        case .anytime:
+            return tasks.filter { $0.isOpen && $0.dueDate == nil && $0.status == .active }
+        case .someday:
+            return tasks.filter { $0.status == .archived }
+        case .flagged:
+            return tasks.filter { $0.isFlagged && $0.isOpen }
+        case .bosses:
+            return tasks.filter { $0.isBoss && $0.isOpen }
+        case .completed:
+            return tasks.filter(\.isCompleted)
+        }
+    }
+
+    private var filteredTasks: [TaskItem] {
+        var result = selectedTag == nil
+            ? items(in: smartList)
+            : tasks.filter { task in
+                task.isOpen && (task.tags ?? []).contains { $0.identifier == selectedTag?.identifier }
+            }
+
+        if !searchText.isEmpty {
+            let needle = searchText.folding(options: .diacriticInsensitive, locale: QuestlyFormat.locale).lowercased()
+            result = tasks.filter { task in
+                let haystack = (task.title + " " + task.notes + " " + task.sortedTags.map(\.name).joined(separator: " "))
+                    .folding(options: .diacriticInsensitive, locale: QuestlyFormat.locale)
+                    .lowercased()
+                return haystack.contains(needle)
+            }
+        }
+
+        if !settings.showCompletedTasks && smartList != .completed {
+            result = result.filter { !$0.isCompleted }
+        }
+
+        return result.sorted(by: TaskSorting.comparator(for: sortOrder, calendar: calendar))
+    }
+
+    private struct TaskGroup {
+        let title: String
+        let tasks: [TaskItem]
+    }
+
+    private var groupedTasks: [TaskGroup] {
+        let items = filteredTasks
+        guard !items.isEmpty else {
+            return [TaskGroup(title: smartList.label, tasks: [])]
+        }
+
+        switch grouping {
+        case .none:
+            return [TaskGroup(title: "\(items.count) quête\(items.count > 1 ? "s" : "")", tasks: items)]
+
+        case .date:
+            var buckets: [(String, [TaskItem])] = []
+            let now = Date()
+            let overdue = items.filter { $0.isOverdue(now: now, calendar: calendar) }
+            let today = items.filter { !$0.isOverdue(now: now, calendar: calendar) && $0.isDueToday(now: now, calendar: calendar) }
+            let upcoming = items.filter { task in
+                guard let due = task.dueDate else { return false }
+                return calendar.startOfDay(for: due) > calendar.startOfDay(for: now)
+            }
+            let undated = items.filter { $0.dueDate == nil }
+
+            if !overdue.isEmpty { buckets.append(("En retard", overdue)) }
+            if !today.isEmpty { buckets.append(("Aujourd'hui", today)) }
+            if !upcoming.isEmpty { buckets.append(("À venir", upcoming)) }
+            if !undated.isEmpty { buckets.append(("Sans date", undated)) }
+            return buckets.map { TaskGroup(title: $0.0, tasks: $0.1) }
+
+        case .priority:
+            return Priority.allCases.compactMap { priority in
+                let matching = items.filter { $0.priority == priority }
+                return matching.isEmpty ? nil : TaskGroup(title: priority.label, tasks: matching)
+            }
+
+        case .project:
+            var groups: [TaskGroup] = []
+            for project in projects {
+                let matching = items.filter { $0.project?.identifier == project.identifier }
+                if !matching.isEmpty {
+                    groups.append(TaskGroup(title: "\(project.emoji) \(project.name)", tasks: matching))
+                }
+            }
+            let orphans = items.filter { $0.project == nil }
+            if !orphans.isEmpty { groups.append(TaskGroup(title: "Sans projet", tasks: orphans)) }
+            return groups
+
+        case .lifeArea:
+            var groups = LifeArea.allCases.compactMap { area -> TaskGroup? in
+                let matching = items.filter { $0.lifeArea == area }
+                return matching.isEmpty ? nil : TaskGroup(title: area.label, tasks: matching)
+            }
+            let none = items.filter { $0.lifeArea == nil }
+            if !none.isEmpty { groups.append(TaskGroup(title: "Sans domaine", tasks: none)) }
+            return groups
+
+        case .difficulty:
+            return Difficulty.allCases.reversed().compactMap { difficulty in
+                let matching = items.filter { $0.difficulty == difficulty }
+                return matching.isEmpty ? nil : TaskGroup(title: difficulty.label, tasks: matching)
+            }
+        }
+    }
+}
+
+// MARK: - Pastille de liste intelligente
+
+struct SmartListChip: View {
+    let list: SmartList
+    let count: Int
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        let color = Color(hex: list.hex)
+
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Image(systemName: list.symbolName)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(isSelected ? .white : color)
+                    Spacer()
+                    Text("\(count)")
+                        .font(.questNumber(16))
+                        .monospacedDigit()
+                        .foregroundStyle(isSelected ? .white : .primary)
+                }
+                Text(list.label)
+                    .font(.questMicro)
+                    .foregroundStyle(isSelected ? .white.opacity(0.9) : .secondary)
+                    .lineLimit(1)
+            }
+            .padding(10)
+            .frame(width: 108, height: 66, alignment: .leading)
+            .background {
+                RoundedRectangle(cornerRadius: Metrics.cornerRadiusSmall, style: .continuous)
+                    .fill(isSelected
+                          ? AnyShapeStyle(LinearGradient(colors: [color, color.opacity(0.75)],
+                                                         startPoint: .topLeading, endPoint: .bottomTrailing))
+                          : AnyShapeStyle(Color.primary.opacity(0.05)))
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: Metrics.cornerRadiusSmall, style: .continuous)
+                    .strokeBorder(color.opacity(isSelected ? 0 : 0.2), lineWidth: 1)
+            }
+        }
+        .buttonStyle(PressableStyle())
+    }
+}
+
+// MARK: - Ligne de projet
+
+struct ProjectRow: View {
+    let project: Project
+
+    var body: some View {
+        HStack(spacing: Metrics.spacingS) {
+            ProgressRing(
+                fraction: project.progress,
+                size: 34,
+                lineWidth: 4,
+                color: Color(hex: project.colorHex),
+                content: AnyView(Text(project.emoji).font(.system(size: 13)))
+            )
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(project.name).font(.questBody)
+                Text("\(project.completedTasks.count)/\(project.allTasks.count) quêtes")
+                    .font(.questMicro)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if let target = project.targetDate {
+                Text(QuestlyFormat.mediumDate(target))
+                    .font(.questMicro)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+// MARK: - Détail d'un projet
+
+struct ProjectDetailView: View {
+    @Bindable var project: Project
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(SettingsStore.self) private var settings
+    @Environment(\.questlyTheme) private var theme
+
+    @State private var selectedTask: TaskItem?
+    @State private var showsEditor = false
+
+    var body: some View {
+        List {
+            Section {
+                VStack(alignment: .leading, spacing: Metrics.spacingS) {
+                    HStack(spacing: Metrics.spacingM) {
+                        ProgressRing(
+                            fraction: project.progress,
+                            size: 64,
+                            lineWidth: 7,
+                            color: Color(hex: project.colorHex),
+                            content: AnyView(Text(project.emoji).font(.system(size: 24)))
+                        )
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(QuestlyFormat.percent(project.progress))
+                                .font(.questTitle)
+                            Text("\(project.openTasks.count) quête\(project.openTasks.count > 1 ? "s" : "") restante\(project.openTasks.count > 1 ? "s" : "")")
+                                .font(.questCaption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    if !project.notes.isEmpty {
+                        Text(project.notes)
+                            .font(.questCallout)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+
+            Section("À faire") {
+                ForEach(project.openTasks.sorted(by: TaskSorting.smart(calendar: settings.calendar))) { task in
+                    TaskRow(task: task, showsProject: false) { selectedTask = task }
+                        .taskSwipeActions(for: task) { selectedTask = task }
+                }
+                if project.openTasks.isEmpty {
+                    Text("Campagne terminée. Beau travail.")
+                        .font(.questCaption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if !project.completedTasks.isEmpty {
+                Section("Accomplies") {
+                    ForEach(project.completedTasks.sorted { ($0.completedAt ?? .distantPast) > ($1.completedAt ?? .distantPast) }) { task in
+                        TaskRow(task: task, showsProject: false, isCompact: true) { selectedTask = task }
+                    }
+                }
+            }
+        }
+        .navigationTitle(project.name)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    showsEditor = true
+                } label: {
+                    Image(systemName: "slider.horizontal.3")
+                }
+            }
+        }
+        .sheet(item: $selectedTask) { task in
+            TaskDetailView(task: task)
+        }
+        .sheet(isPresented: $showsEditor) {
+            ProjectEditorView(project: project)
+                .presentationDetents([.height(420)])
+        }
+    }
+}
+
+// MARK: - Éditeur de projet
+
+struct ProjectEditorView: View {
+    var project: Project?
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(\.questlyTheme) private var theme
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name = ""
+    @State private var emoji = "📁"
+    @State private var colorHex = "5E5CE6"
+    @State private var notes = ""
+    @State private var hasTarget = false
+    @State private var targetDate = Date().addingTimeInterval(60 * 60 * 24 * 14)
+    @State private var area: LifeArea?
+
+    private let emojiChoices = ["📁", "🚀", "🏔️", "🎯", "🏗️", "📚", "💪", "🎨", "💼", "🏡", "💰", "❤️"]
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("Nom de la campagne", text: $name)
+                        .font(.questHeadline)
+
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 8) {
+                            ForEach(emojiChoices, id: \.self) { choice in
+                                Button {
+                                    emoji = choice
+                                    Haptics.selection()
+                                } label: {
+                                    Text(choice)
+                                        .font(.system(size: 22))
+                                        .frame(width: 40, height: 40)
+                                        .background {
+                                            Circle().fill(emoji == choice
+                                                          ? Color(hex: colorHex).opacity(0.25)
+                                                          : Color.primary.opacity(0.05))
+                                        }
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                        .padding(.vertical, 2)
+                    }
+
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 8) {
+                            ForEach(Palette.projectHexes, id: \.self) { hex in
+                                Button {
+                                    colorHex = hex
+                                    Haptics.selection()
+                                } label: {
+                                    Circle()
+                                        .fill(Color(hex: hex))
+                                        .frame(width: 28, height: 28)
+                                        .overlay {
+                                            if colorHex == hex {
+                                                Circle().strokeBorder(.white, lineWidth: 2)
+                                            }
+                                        }
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                        .padding(.vertical, 2)
+                    }
+                }
+
+                Section("Options") {
+                    Picker(selection: $area) {
+                        Text("Aucun domaine").tag(LifeArea?.none)
+                        ForEach(LifeArea.allCases) { value in
+                            Label(value.label, systemImage: value.symbolName).tag(LifeArea?.some(value))
+                        }
+                    } label: {
+                        Label("Domaine", systemImage: "circle.hexagongrid.fill")
+                    }
+
+                    Toggle("Date cible", isOn: $hasTarget)
+                    if hasTarget {
+                        DatePicker("Échéance", selection: $targetDate, displayedComponents: [.date])
+                    }
+
+                    TextField("Notes", text: $notes, axis: .vertical)
+                        .lineLimit(2...5)
+                }
+            }
+            .navigationTitle(project == nil ? "Nouvelle campagne" : "Modifier")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Annuler") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Enregistrer") { save() }
+                        .fontWeight(.semibold)
+                        .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+            }
+            .onAppear(perform: load)
+        }
+    }
+
+    private func load() {
+        guard let project else { return }
+        name = project.name
+        emoji = project.emoji
+        colorHex = project.colorHex
+        notes = project.notes
+        area = project.lifeArea
+        if let target = project.targetDate {
+            hasTarget = true
+            targetDate = target
+        }
+    }
+
+    private func save() {
+        let target: Project
+        if let project {
+            target = project
+        } else {
+            let created = Project(name: name, emoji: emoji, colorHex: colorHex)
+            store.modelContext.insert(created)
+            target = created
+        }
+        target.name = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        target.emoji = emoji
+        target.colorHex = colorHex
+        target.notes = notes
+        target.lifeArea = area
+        target.targetDate = hasTarget ? targetDate : nil
+        store.save()
+        Haptics.success()
+        dismiss()
+    }
+}

--- a/QuestlyApp/Questly/Features/Tasks/RecurrenceEditorView.swift
+++ b/QuestlyApp/Questly/Features/Tasks/RecurrenceEditorView.swift
@@ -1,0 +1,459 @@
+import SwiftUI
+import SwiftData
+import QuestlyKit
+
+/// Éditeur de répétition. Il couvre les cas courants en deux gestes et laisse
+/// accessibles les cas rares (tous les 3 mois, le dernier jour, 12 fois).
+struct RecurrenceEditorView: View {
+
+    @Bindable var task: TaskItem
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(SettingsStore.self) private var settings
+    @Environment(\.questlyTheme) private var theme
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var isEnabled = false
+    @State private var frequency: RecurrenceRule.Frequency = .daily
+    @State private var interval = 1
+    @State private var weekdays: Set<Int> = []
+    @State private var daysOfMonth: Set<Int> = []
+    @State private var usesLastDay = false
+    @State private var mode: RecurrenceRule.Mode = .fixed
+    @State private var skipWeekends = false
+    @State private var endKind: EndKind = .never
+    @State private var occurrenceCount = 10
+    @State private var endDate = Date().addingTimeInterval(60 * 60 * 24 * 30)
+
+    private enum EndKind: String, CaseIterable, Identifiable {
+        case never, afterCount, onDate
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .never: return "Jamais"
+            case .afterCount: return "Après N fois"
+            case .onDate: return "À une date"
+            }
+        }
+    }
+
+    private var calendar: Calendar { settings.calendar }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Toggle(isOn: $isEnabled.animation(Motion.snappy)) {
+                        Label("Répéter cette quête", systemImage: "repeat")
+                    }
+                    if isEnabled {
+                        Text(previewRule.humanDescription(calendar: calendar))
+                            .font(.questCallout)
+                            .foregroundStyle(theme.accent)
+                    }
+                }
+
+                if isEnabled {
+                    presetSection
+                    frequencySection
+                    if frequency == .weekly { weekdaySection }
+                    if frequency == .monthly { monthDaySection }
+                    modeSection
+                    endSection
+                    previewSection
+                }
+            }
+            .navigationTitle("Répétition")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Annuler") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Enregistrer") { apply(); dismiss() }
+                        .fontWeight(.semibold)
+                }
+            }
+            .onAppear(perform: load)
+        }
+    }
+
+    // MARK: Sections
+
+    private var presetSection: some View {
+        Section("Raccourcis") {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    presetChip("Chaque jour", rule: .daily)
+                    presetChip("Jours ouvrés", rule: .weekdaysOnly)
+                    presetChip("Chaque semaine", rule: .weekly)
+                    presetChip("Week-ends", rule: .weekendsOnly)
+                    presetChip("Chaque mois", rule: .monthly)
+                    presetChip("Chaque année", rule: .yearly)
+                }
+                .padding(.vertical, 2)
+            }
+        }
+    }
+
+    private func presetChip(_ title: String, rule: RecurrenceRule) -> some View {
+        Button {
+            adopt(rule)
+            Haptics.selection()
+        } label: {
+            Text(title)
+                .font(.questMicro)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background { Capsule().fill(Color.primary.opacity(0.07)) }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var frequencySection: some View {
+        Section("Rythme") {
+            Picker("Unité", selection: $frequency) {
+                ForEach(RecurrenceRule.Frequency.allCases) { value in
+                    Text(value.label).tag(value)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            Stepper(value: $interval, in: 1...99) {
+                Text(interval == 1
+                     ? "Chaque \(frequency.label.lowercased())"
+                     : "Tous les \(interval) \(frequency.pluralLabel)")
+            }
+
+            if frequency == .daily {
+                Toggle("Sauter les week-ends", isOn: $skipWeekends)
+            }
+        }
+    }
+
+    private var weekdaySection: some View {
+        Section("Jours de la semaine") {
+            HStack(spacing: 6) {
+                ForEach(orderedWeekdays, id: \.self) { weekday in
+                    Button {
+                        toggleWeekday(weekday)
+                    } label: {
+                        Text(weekdayInitial(weekday))
+                            .font(.questCaption)
+                            .foregroundStyle(weekdays.contains(weekday) ? .white : .primary)
+                            .frame(width: 36, height: 36)
+                            .background {
+                                Circle().fill(weekdays.contains(weekday)
+                                              ? AnyShapeStyle(theme.gradient)
+                                              : AnyShapeStyle(Color.primary.opacity(0.07)))
+                            }
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .frame(maxWidth: .infinity)
+        }
+    }
+
+    private var monthDaySection: some View {
+        Section("Jour du mois") {
+            Toggle("Dernier jour du mois", isOn: $usesLastDay.animation(Motion.quick))
+
+            if !usesLastDay {
+                LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 4), count: 7), spacing: 6) {
+                    ForEach(1...31, id: \.self) { day in
+                        Button {
+                            toggleDayOfMonth(day)
+                        } label: {
+                            Text("\(day)")
+                                .font(.questMicro)
+                                .foregroundStyle(daysOfMonth.contains(day) ? .white : .primary)
+                                .frame(width: 32, height: 32)
+                                .background {
+                                    Circle().fill(daysOfMonth.contains(day)
+                                                  ? AnyShapeStyle(theme.gradient)
+                                                  : AnyShapeStyle(Color.primary.opacity(0.07)))
+                                }
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        } footer: {
+            Text("Si le mois est trop court, l'occurrence tombe sur le dernier jour disponible.")
+        }
+    }
+
+    private var modeSection: some View {
+        Section {
+            Picker("Point de départ", selection: $mode) {
+                ForEach(RecurrenceRule.Mode.allCases, id: \.self) { value in
+                    Text(value.label).tag(value)
+                }
+            }
+        } footer: {
+            Text(mode == .fixed
+                 ? "Le calendrier commande : rater une occurrence ne décale pas les suivantes."
+                 : "La prochaine échéance part du jour où tu accomplis la quête. Idéal pour « arroser les plantes tous les 3 jours ».")
+        }
+    }
+
+    private var endSection: some View {
+        Section("Fin de la série") {
+            Picker("Se termine", selection: $endKind) {
+                ForEach(EndKind.allCases) { kind in
+                    Text(kind.label).tag(kind)
+                }
+            }
+
+            if endKind == .afterCount {
+                Stepper("Après \(occurrenceCount) occurrences", value: $occurrenceCount, in: 1...365)
+            }
+            if endKind == .onDate {
+                DatePicker("Jusqu'au", selection: $endDate, displayedComponents: [.date])
+            }
+        }
+    }
+
+    private var previewSection: some View {
+        Section("Prochaines occurrences") {
+            ForEach(previewDates, id: \.self) { date in
+                HStack {
+                    Image(systemName: "calendar")
+                        .font(.caption)
+                        .foregroundStyle(theme.accent)
+                    Text(QuestlyFormat.fullDay(date, calendar: calendar))
+                        .font(.questCaption)
+                    Spacer()
+                    if task.hasTime {
+                        Text(QuestlyFormat.time(date, calendar: calendar))
+                            .font(.questMicro)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            if previewDates.isEmpty {
+                Text("Aucune occurrence à venir avec ces réglages.")
+                    .font(.questCaption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: Données
+
+    private var orderedWeekdays: [Int] {
+        let first = calendar.firstWeekday
+        return (0..<7).map { ((first - 1 + $0) % 7) + 1 }
+    }
+
+    private func weekdayInitial(_ weekday: Int) -> String {
+        let initials = ["D", "L", "M", "M", "J", "V", "S"]
+        return initials[(weekday - 1) % 7]
+    }
+
+    private var previewRule: RecurrenceRule {
+        var days = daysOfMonth
+        if usesLastDay { days = [-1] }
+
+        let ending: RecurrenceRule.Ending
+        switch endKind {
+        case .never: ending = .never
+        case .afterCount: ending = .afterOccurrences(occurrenceCount)
+        case .onDate: ending = .onDate(endDate)
+        }
+
+        return RecurrenceRule(
+            frequency: frequency,
+            interval: interval,
+            weekdays: frequency == .weekly ? weekdays : [],
+            daysOfMonth: frequency == .monthly ? days : [],
+            monthsOfYear: [],
+            ending: ending,
+            mode: mode,
+            skipWeekends: skipWeekends
+        )
+    }
+
+    private var previewDates: [Date] {
+        let anchor = task.dueDate ?? Date()
+        return RecurrenceEngine.occurrences(
+            rule: previewRule,
+            anchor: anchor,
+            from: anchor,
+            to: calendar.date(byAdding: .month, value: 6, to: anchor) ?? anchor,
+            calendar: calendar,
+            limit: 5
+        )
+    }
+
+    // MARK: Chargement / enregistrement
+
+    private func load() {
+        guard let rule = task.recurrence else {
+            isEnabled = false
+            weekdays = [calendar.component(.weekday, from: task.dueDate ?? Date())]
+            return
+        }
+        isEnabled = true
+        frequency = rule.frequency
+        interval = rule.interval
+        weekdays = rule.weekdays.isEmpty
+            ? [calendar.component(.weekday, from: task.dueDate ?? Date())]
+            : rule.weekdays
+        usesLastDay = rule.daysOfMonth == [-1]
+        daysOfMonth = usesLastDay ? [] : rule.daysOfMonth
+        mode = rule.mode
+        skipWeekends = rule.skipWeekends
+
+        switch rule.ending {
+        case .never:
+            endKind = .never
+        case .afterOccurrences(let count):
+            endKind = .afterCount
+            occurrenceCount = count
+        case .onDate(let date):
+            endKind = .onDate
+            endDate = date
+        }
+    }
+
+    private func adopt(_ rule: RecurrenceRule) {
+        frequency = rule.frequency
+        interval = rule.interval
+        weekdays = rule.weekdays.isEmpty
+            ? [calendar.component(.weekday, from: task.dueDate ?? Date())]
+            : rule.weekdays
+        daysOfMonth = rule.daysOfMonth
+        usesLastDay = rule.daysOfMonth == [-1]
+        skipWeekends = rule.skipWeekends
+        mode = rule.mode
+    }
+
+    private func apply() {
+        if isEnabled {
+            if task.dueDate == nil {
+                task.dueDate = calendar.setting(hour: settings.defaultDueHour, minute: 0, of: Date())
+                task.status = .active
+            }
+            task.recurrenceAnchor = task.dueDate
+            task.recurrence = previewRule
+        } else {
+            task.recurrence = nil
+        }
+        task.touch()
+        store.save()
+    }
+
+    private func toggleWeekday(_ weekday: Int) {
+        if weekdays.contains(weekday) {
+            if weekdays.count > 1 { weekdays.remove(weekday) }
+        } else {
+            weekdays.insert(weekday)
+        }
+        Haptics.selection()
+    }
+
+    private func toggleDayOfMonth(_ day: Int) {
+        if daysOfMonth.contains(day) {
+            daysOfMonth.remove(day)
+        } else {
+            daysOfMonth.insert(day)
+        }
+        Haptics.selection()
+    }
+}
+
+// MARK: - Recherche de créneau
+
+/// Propose les prochains créneaux libres pour une quête et les réserve d'un tap.
+struct SchedulerSheet: View {
+
+    let task: TaskItem
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(SettingsStore.self) private var settings
+    @Environment(CalendarService.self) private var calendarService
+    @Environment(\.questlyTheme) private var theme
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var suggestions: [TimeSlot] = []
+
+    private var calendar: Calendar { settings.calendar }
+    private var duration: Int { task.estimatedMinutes > 0 ? task.estimatedMinutes : 30 }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    HStack {
+                        Label("Durée réservée", systemImage: "hourglass")
+                        Spacer()
+                        Text(DurationFormatter.short(minutes: duration))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Section("Créneaux libres") {
+                    if suggestions.isEmpty {
+                        Text("Aucun créneau libre trouvé dans les 7 prochains jours ouvrés.")
+                            .font(.questCaption)
+                            .foregroundStyle(.secondary)
+                    }
+                    ForEach(suggestions) { slot in
+                        Button {
+                            store.schedule(task, at: slot.start, minutes: duration)
+                            Haptics.success()
+                            dismiss()
+                        } label: {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(QuestlyFormat.fullDay(slot.start, calendar: calendar))
+                                        .font(.questCallout)
+                                    Text("\(QuestlyFormat.time(slot.start, calendar: calendar)) – \(QuestlyFormat.time(slot.end, calendar: calendar))")
+                                        .font(.questMicro)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Spacer()
+                                Image(systemName: "plus.circle.fill")
+                                    .foregroundStyle(theme.accent)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+            .navigationTitle("Trouver un créneau")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Fermer") { dismiss() }
+                }
+            }
+            .onAppear(perform: computeSuggestions)
+        }
+    }
+
+    private func computeSuggestions() {
+        var busyByDay: [Date: [BusyInterval]] = [:]
+        for offset in 0..<7 {
+            let day = calendar.startOfDay(for: Date().adding(days: offset, calendar: calendar))
+            var intervals = store.blocks(on: day).map {
+                BusyInterval(id: $0.identifier.uuidString, start: $0.start, end: $0.end, title: $0.title)
+            }
+            intervals.append(contentsOf: calendarService.busyIntervals(on: day, calendar: calendar))
+            busyByDay[day] = intervals
+        }
+
+        suggestions = ScheduleEngine.suggestSlots(
+            forMinutes: duration,
+            startingFrom: Date(),
+            days: 7,
+            busyByDay: busyByDay,
+            workingHours: settings.workingHours,
+            limit: 6,
+            calendar: calendar
+        )
+    }
+}

--- a/QuestlyApp/Questly/Features/Tasks/TaskDetailView.swift
+++ b/QuestlyApp/Questly/Features/Tasks/TaskDetailView.swift
@@ -1,0 +1,633 @@
+import SwiftUI
+import SwiftData
+import QuestlyKit
+
+/// Fiche complète d'une quête. Tout y est modifiable, et chaque réglage montre
+/// son effet sur la récompense — c'est ce qui rend la gamification honnête.
+struct TaskDetailView: View {
+
+    @Bindable var task: TaskItem
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(SettingsStore.self) private var settings
+    @Environment(NotificationService.self) private var notifications
+    @Environment(\.questlyTheme) private var theme
+    @Environment(\.dismiss) private var dismiss
+
+    @Query private var projects: [Project]
+
+    @State private var newSubtask = ""
+    @State private var showsRecurrenceEditor = false
+    @State private var showsScheduler = false
+    @State private var showsDeleteConfirmation = false
+    @State private var showsXPBreakdown = false
+
+    private var calendar: Calendar { settings.calendar }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                headerSection
+                scheduleSection
+                gameSection
+                subtaskSection
+                organizationSection
+                blocksSection
+                notesSection
+                dangerSection
+            }
+            .scrollDismissesKeyboard(.interactively)
+            .navigationTitle(task.isCompleted ? "Quête accomplie" : "Quête")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Fermer") { save(); dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    completeButton
+                }
+            }
+            .sheet(isPresented: $showsRecurrenceEditor) {
+                RecurrenceEditorView(task: task)
+            }
+            .sheet(isPresented: $showsScheduler) {
+                SchedulerSheet(task: task)
+                    .presentationDetents([.medium])
+            }
+            .confirmationDialog("Supprimer cette quête ?", isPresented: $showsDeleteConfirmation) {
+                Button("Supprimer", role: .destructive) {
+                    notifications.cancel(for: task)
+                    store.delete(task)
+                    dismiss()
+                }
+            }
+            .onDisappear { save() }
+        }
+    }
+
+    // MARK: En-tête
+
+    private var headerSection: some View {
+        Section {
+            TextField("Titre de la quête", text: $task.title, axis: .vertical)
+                .font(.questHeadline)
+                .lineLimit(1...3)
+
+            Button {
+                withAnimation(Motion.snappy) { showsXPBreakdown.toggle() }
+            } label: {
+                HStack {
+                    Image(systemName: "bolt.fill")
+                        .foregroundStyle(Color(hex: "FFD60A"))
+                    Text("Récompense estimée")
+                        .font(.questCallout)
+                        .foregroundStyle(.primary)
+                    Spacer()
+                    Text("\(task.previewXP) XP")
+                        .font(.questCallout)
+                        .foregroundStyle(theme.accent)
+                        .monospacedDigit()
+                    Image(systemName: showsXPBreakdown ? "chevron.up" : "chevron.down")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if showsXPBreakdown {
+                XPBreakdownList(task: task, streakDays: store.streak.current)
+            }
+        }
+    }
+
+    private var completeButton: some View {
+        Button {
+            if task.isCompleted {
+                store.uncomplete(task)
+            } else {
+                let bundle = store.complete(task)
+                Haptics.play(bundle.comboCount > 1 ? .combo(bundle.comboCount) : .success)
+                dismiss()
+            }
+        } label: {
+            Label(
+                task.isCompleted ? "Rouvrir" : "Accomplir",
+                systemImage: task.isCompleted ? "arrow.uturn.backward" : "checkmark.circle.fill"
+            )
+        }
+        .fontWeight(.semibold)
+    }
+
+    // MARK: Planification
+
+    private var scheduleSection: some View {
+        Section("Échéance") {
+            Toggle(isOn: dueDateBinding) {
+                Label("Date d'échéance", systemImage: "calendar")
+            }
+
+            if task.dueDate != nil {
+                DatePicker(
+                    "Jour",
+                    selection: Binding(
+                        get: { task.dueDate ?? Date() },
+                        set: { task.dueDate = $0; task.touch() }
+                    ),
+                    displayedComponents: task.hasTime ? [.date, .hourAndMinute] : [.date]
+                )
+
+                Toggle(isOn: $task.hasTime) {
+                    Label("Heure précise", systemImage: "clock")
+                }
+
+                Picker(selection: reminderBinding) {
+                    Text("Aucun").tag(0)
+                    Text("À l'heure").tag(1)
+                    Text("5 minutes avant").tag(5)
+                    Text("15 minutes avant").tag(15)
+                    Text("30 minutes avant").tag(30)
+                    Text("1 heure avant").tag(60)
+                    Text("1 jour avant").tag(1440)
+                } label: {
+                    Label("Rappel", systemImage: "bell.fill")
+                }
+            }
+
+            Button {
+                showsRecurrenceEditor = true
+            } label: {
+                HStack {
+                    Label("Répétition", systemImage: "repeat")
+                    Spacer()
+                    Text(task.recurrence?.humanDescription(calendar: calendar) ?? "Jamais")
+                        .font(.questCaption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+
+            durationPicker
+        }
+    }
+
+    private var dueDateBinding: Binding<Bool> {
+        Binding(
+            get: { task.dueDate != nil },
+            set: { isOn in
+                task.dueDate = isOn ? calendar.setting(hour: settings.defaultDueHour, minute: 0, of: Date()) : nil
+                if !isOn { task.hasTime = false }
+                task.status = isOn ? .active : .inbox
+                task.touch()
+            }
+        )
+    }
+
+    private var reminderBinding: Binding<Int> {
+        Binding(
+            get: { task.reminderMinutesBefore ?? 0 },
+            set: { task.reminderMinutesBefore = $0 == 0 ? nil : $0; task.touch() }
+        )
+    }
+
+    private var durationPicker: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Label("Durée estimée", systemImage: "hourglass")
+                Spacer()
+                Text(task.estimatedMinutes > 0
+                     ? DurationFormatter.short(minutes: task.estimatedMinutes)
+                     : "Non estimée")
+                    .font(.questCaption)
+                    .foregroundStyle(.secondary)
+            }
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach([0, 15, 25, 30, 45, 60, 90, 120, 180], id: \.self) { minutes in
+                        Button {
+                            task.estimatedMinutes = minutes
+                            task.touch()
+                            Haptics.selection()
+                        } label: {
+                            Text(minutes == 0 ? "—" : DurationFormatter.short(minutes: minutes))
+                                .font(.questMicro)
+                                .foregroundStyle(task.estimatedMinutes == minutes ? .white : .primary)
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 6)
+                                .background {
+                                    Capsule().fill(task.estimatedMinutes == minutes
+                                                   ? AnyShapeStyle(theme.gradient)
+                                                   : AnyShapeStyle(Color.primary.opacity(0.07)))
+                                }
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: Paramètres de jeu
+
+    private var gameSection: some View {
+        Section("Paramètres de quête") {
+            Picker(selection: $task.priority) {
+                ForEach(Priority.allCases) { priority in
+                    Label(priority.label, systemImage: priority.symbolName).tag(priority)
+                }
+            } label: {
+                Label("Priorité", systemImage: "flag.fill")
+            }
+
+            Picker(selection: $task.difficulty) {
+                ForEach(Difficulty.allCases) { difficulty in
+                    Label("\(difficulty.label) · \(difficulty.baseXP) XP", systemImage: difficulty.symbolName)
+                        .tag(difficulty)
+                }
+            } label: {
+                Label("Difficulté", systemImage: "bolt.shield.fill")
+            }
+
+            Picker(selection: $task.energy) {
+                ForEach(EnergyLevel.allCases) { energy in
+                    Label(energy.label, systemImage: energy.symbolName).tag(energy)
+                }
+            } label: {
+                Label("Énergie requise", systemImage: "battery.100.bolt")
+            }
+
+            Picker(selection: areaBinding) {
+                Text("Aucun").tag(String?.none)
+                ForEach(LifeArea.allCases) { area in
+                    Label(area.label, systemImage: area.symbolName).tag(String?.some(area.rawValue))
+                }
+            } label: {
+                Label("Domaine", systemImage: "circle.hexagongrid.fill")
+            }
+
+            Toggle(isOn: $task.isBoss) {
+                Label {
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("Boss")
+                        Text("XP doublé, barre de PV, session de concentration")
+                            .font(.questMicro)
+                            .foregroundStyle(.secondary)
+                    }
+                } icon: {
+                    Image(systemName: "crown.fill")
+                        .foregroundStyle(Color(hex: "BF5AF2"))
+                }
+            }
+
+            Toggle(isOn: $task.isFlagged) {
+                Label("Épinglée", systemImage: "flag.fill")
+            }
+        }
+    }
+
+    private var areaBinding: Binding<String?> {
+        Binding(
+            get: { task.lifeAreaRaw },
+            set: { task.lifeAreaRaw = $0; task.touch() }
+        )
+    }
+
+    // MARK: Sous-quêtes
+
+    private var subtaskSection: some View {
+        Section {
+            ForEach(task.orderedSubtasks) { subtask in
+                SubtaskRow(subtask: subtask) {
+                    subtask.isDone.toggle()
+                    subtask.completedAt = subtask.isDone ? Date() : nil
+                    task.touch()
+                    store.save()
+                    Haptics.light()
+                }
+            }
+            .onDelete(perform: deleteSubtasks)
+
+            HStack {
+                Image(systemName: "plus.circle")
+                    .foregroundStyle(theme.accent)
+                TextField("Ajouter une sous-quête", text: $newSubtask)
+                    .onSubmit(addSubtask)
+            }
+        } header: {
+            HStack {
+                Text("Sous-quêtes")
+                Spacer()
+                if !task.orderedSubtasks.isEmpty {
+                    Text("\(task.completedSubtaskCount)/\(task.orderedSubtasks.count)")
+                        .font(.questMicro)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        } footer: {
+            if !task.orderedSubtasks.isEmpty {
+                Text("Chaque sous-quête accomplie ajoute 2 XP, jusqu'à 20.")
+            }
+        }
+    }
+
+    private func addSubtask() {
+        let trimmed = newSubtask.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        let subtask = Subtask(title: trimmed, sortIndex: Double(task.orderedSubtasks.count))
+        subtask.task = task
+        store.modelContext.insert(subtask)
+        newSubtask = ""
+        task.touch()
+        store.save()
+        Haptics.light()
+    }
+
+    private func deleteSubtasks(at offsets: IndexSet) {
+        let items = task.orderedSubtasks
+        for index in offsets where index < items.count {
+            store.modelContext.delete(items[index])
+        }
+        task.touch()
+        store.save()
+    }
+
+    // MARK: Organisation
+
+    private var organizationSection: some View {
+        Section("Organisation") {
+            Picker(selection: projectBinding) {
+                Text("Aucun projet").tag(UUID?.none)
+                ForEach(projects.filter { !$0.isArchived }) { project in
+                    Text("\(project.emoji) \(project.name)").tag(UUID?.some(project.identifier))
+                }
+            } label: {
+                Label("Projet", systemImage: "folder.fill")
+            }
+
+            NavigationLink {
+                TagPickerView(task: task)
+            } label: {
+                HStack {
+                    Label("Étiquettes", systemImage: "number")
+                    Spacer()
+                    if task.sortedTags.isEmpty {
+                        Text("Aucune").font(.questCaption).foregroundStyle(.secondary)
+                    } else {
+                        Text(task.sortedTags.map(\.name).joined(separator: ", "))
+                            .font(.questCaption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+            }
+        }
+    }
+
+    private var projectBinding: Binding<UUID?> {
+        Binding(
+            get: { task.project?.identifier },
+            set: { newValue in
+                task.project = projects.first { $0.identifier == newValue }
+                task.touch()
+            }
+        )
+    }
+
+    // MARK: Blocs de temps
+
+    private var blocksSection: some View {
+        Section("Créneaux réservés") {
+            ForEach(task.scheduledBlocks) { block in
+                HStack {
+                    Image(systemName: "calendar.badge.clock")
+                        .foregroundStyle(Color(hex: block.colorHex))
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(QuestlyFormat.mediumDate(block.start, calendar: calendar))
+                            .font(.questCallout)
+                        Text("\(QuestlyFormat.time(block.start, calendar: calendar)) – \(QuestlyFormat.time(block.end, calendar: calendar))")
+                            .font(.questMicro)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    Button {
+                        store.delete(block)
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            Button {
+                showsScheduler = true
+            } label: {
+                Label("Trouver un créneau", systemImage: "wand.and.stars")
+            }
+        }
+    }
+
+    // MARK: Notes
+
+    private var notesSection: some View {
+        Section("Notes") {
+            TextField("Détails, liens, contexte…", text: $task.notes, axis: .vertical)
+                .lineLimit(3...10)
+                .font(.questBody)
+        }
+    }
+
+    // MARK: Zone sensible
+
+    private var dangerSection: some View {
+        Section {
+            if let completedAt = task.completedAt {
+                HStack {
+                    Label("Accomplie", systemImage: "checkmark.seal.fill")
+                        .foregroundStyle(Color(hex: "30D158"))
+                    Spacer()
+                    Text(QuestlyFormat.dueLabel(for: completedAt, hasTime: true, calendar: calendar))
+                        .font(.questCaption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if task.focusedMinutes > 0 {
+                HStack {
+                    Label("Concentration cumulée", systemImage: "timer")
+                    Spacer()
+                    Text(DurationFormatter.short(minutes: task.focusedMinutes))
+                        .font(.questCaption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Button(role: .destructive) {
+                showsDeleteConfirmation = true
+            } label: {
+                Label("Supprimer la quête", systemImage: "trash")
+            }
+        }
+    }
+
+    // MARK: Sauvegarde
+
+    private func save() {
+        task.touch()
+        store.save()
+        notifications.schedule(
+            for: task,
+            calendar: calendar,
+            defaultHour: settings.defaultDueHour
+        )
+    }
+}
+
+// MARK: - Ligne de sous-quête
+
+struct SubtaskRow: View {
+    @Bindable var subtask: Subtask
+    let onToggle: () -> Void
+
+    @Environment(\.questlyTheme) private var theme
+
+    var body: some View {
+        HStack(spacing: Metrics.spacingS) {
+            Button(action: onToggle) {
+                Image(systemName: subtask.isDone ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 18))
+                    .foregroundStyle(subtask.isDone ? theme.accent : .secondary)
+                    .contentTransition(.symbolEffect(.replace))
+            }
+            .buttonStyle(.plain)
+
+            TextField("Sous-quête", text: $subtask.title)
+                .strikethrough(subtask.isDone, color: .secondary)
+                .foregroundStyle(subtask.isDone ? .secondary : .primary)
+        }
+    }
+}
+
+// MARK: - Détail des XP
+
+struct XPBreakdownList: View {
+    let task: TaskItem
+    let streakDays: Int
+
+    private var award: XPAward {
+        XPEngine.award(
+            for: task.xpDescriptor(),
+            context: XPContext(
+                streakDays: streakDays,
+                comboCount: 1,
+                completionDate: task.dueDate ?? Date()
+            )
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            ForEach(award.breakdown) { line in
+                HStack(spacing: 8) {
+                    Image(systemName: line.symbolName)
+                        .font(.system(size: 11))
+                        .foregroundStyle(line.isPositive ? Color(hex: "30D158") : Color(hex: "FF9F0A"))
+                        .frame(width: 16)
+                    Text(line.label)
+                        .font(.questMicro)
+                    Spacer()
+                    Text(line.detail)
+                        .font(.questMicro)
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Divider()
+
+            HStack {
+                Text("Total")
+                    .font(.questCaption)
+                Spacer()
+                Text("\(award.totalXP) XP · \(award.coins) pièces")
+                    .font(.questCaption)
+                    .monospacedDigit()
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+// MARK: - Choix des étiquettes
+
+struct TagPickerView: View {
+    @Bindable var task: TaskItem
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(\.questlyTheme) private var theme
+    @Query(sort: \Tag.name) private var tags: [Tag]
+
+    @State private var newTag = ""
+
+    var body: some View {
+        List {
+            Section {
+                HStack {
+                    Image(systemName: "number")
+                        .foregroundStyle(theme.accent)
+                    TextField("Nouvelle étiquette", text: $newTag)
+                        .onSubmit(addTag)
+                }
+            }
+
+            Section("Étiquettes") {
+                ForEach(tags) { tag in
+                    Button {
+                        toggle(tag)
+                    } label: {
+                        HStack {
+                            TagChip(name: tag.name, colorHex: tag.colorHex, isSelected: isSelected(tag))
+                            Spacer()
+                            if isSelected(tag) {
+                                Image(systemName: "checkmark")
+                                    .foregroundStyle(theme.accent)
+                            }
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .navigationTitle("Étiquettes")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func isSelected(_ tag: Tag) -> Bool {
+        (task.tags ?? []).contains { $0.identifier == tag.identifier }
+    }
+
+    private func toggle(_ tag: Tag) {
+        var current = task.tags ?? []
+        if let index = current.firstIndex(where: { $0.identifier == tag.identifier }) {
+            current.remove(at: index)
+        } else {
+            current.append(tag)
+        }
+        task.tags = current
+        task.touch()
+        store.save()
+        Haptics.selection()
+    }
+
+    private func addTag() {
+        let trimmed = newTag.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        let tag = store.findOrCreateTag(named: trimmed)
+        var current = task.tags ?? []
+        if !current.contains(where: { $0.identifier == tag.identifier }) {
+            current.append(tag)
+            task.tags = current
+        }
+        newTag = ""
+        store.save()
+    }
+}

--- a/QuestlyApp/Questly/Features/Today/JournalSheet.swift
+++ b/QuestlyApp/Questly/Features/Today/JournalSheet.swift
@@ -1,0 +1,164 @@
+import SwiftUI
+import SwiftData
+import QuestlyKit
+
+/// Note de journal du soir. Deux gestes : une humeur, quelques mots.
+/// C'est ce qui transforme une liste de tâches en trace de vie.
+struct JournalSheet: View {
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(SettingsStore.self) private var settings
+    @Environment(\.questlyTheme) private var theme
+    @Environment(\.dismiss) private var dismiss
+
+    @Query(sort: \JournalEntry.createdAt, order: .reverse) private var entries: [JournalEntry]
+
+    @State private var text = ""
+    @State private var mood = 3
+
+    private var calendar: Calendar { settings.calendar }
+
+    private var todayEntry: JournalEntry? {
+        entries.first { calendar.isSameDay($0.day, Date()) }
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: Metrics.spacingM) {
+                moodPicker
+
+                TextField("Qu'est-ce qui a marqué la journée ?", text: $text, axis: .vertical)
+                    .font(.questBody)
+                    .lineLimit(4...8)
+                    .padding(Metrics.spacingS)
+                    .background {
+                        RoundedRectangle(cornerRadius: Metrics.cornerRadiusSmall, style: .continuous)
+                            .fill(Color.primary.opacity(0.05))
+                    }
+
+                dayRecap
+
+                if !entries.isEmpty {
+                    Text("Dernières notes")
+                        .font(.questCaption)
+                        .foregroundStyle(.secondary)
+
+                    ScrollView {
+                        VStack(spacing: Metrics.spacingS) {
+                            ForEach(entries.prefix(5)) { entry in
+                                HStack(alignment: .top, spacing: Metrics.spacingS) {
+                                    Text(entry.moodEmoji).font(.system(size: 20))
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(QuestlyFormat.mediumDate(entry.day, calendar: calendar))
+                                            .font(.questMicro)
+                                            .foregroundStyle(.secondary)
+                                        Text(entry.text)
+                                            .font(.questCaption)
+                                            .lineLimit(3)
+                                    }
+                                    Spacer()
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(Metrics.spacingM)
+            .navigationTitle("Journal du jour")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Fermer") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Enregistrer") { save() }
+                        .fontWeight(.semibold)
+                        .disabled(text.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+            }
+            .onAppear {
+                if let entry = todayEntry {
+                    text = entry.text
+                    mood = entry.mood
+                }
+            }
+        }
+    }
+
+    private var moodPicker: some View {
+        HStack(spacing: Metrics.spacingS) {
+            ForEach(1...5, id: \.self) { value in
+                Button {
+                    withAnimation(Motion.bouncy) { mood = value }
+                    Haptics.selection()
+                } label: {
+                    Text(emoji(for: value))
+                        .font(.system(size: mood == value ? 34 : 26))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                        .background {
+                            RoundedRectangle(cornerRadius: Metrics.cornerRadiusSmall, style: .continuous)
+                                .fill(mood == value ? theme.accent.opacity(0.16) : Color.clear)
+                        }
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private func emoji(for value: Int) -> String {
+        switch value {
+        case 1: return "😞"
+        case 2: return "😕"
+        case 3: return "😐"
+        case 4: return "🙂"
+        default: return "🤩"
+        }
+    }
+
+    private var dayRecap: some View {
+        let count = store.completionCount(on: Date())
+        let stats = store.currentStats(days: 1)
+
+        return HStack(spacing: Metrics.spacingM) {
+            recapItem("\(count)", "quêtes")
+            recapItem("\(stats.totalXP)", "XP")
+            recapItem(DurationFormatter.short(minutes: stats.totalFocusMinutes), "concentration")
+        }
+        .padding(Metrics.spacingS)
+        .frame(maxWidth: .infinity)
+        .background {
+            RoundedRectangle(cornerRadius: Metrics.cornerRadiusSmall, style: .continuous)
+                .fill(.ultraThinMaterial)
+        }
+    }
+
+    private func recapItem(_ value: String, _ label: String) -> some View {
+        VStack(spacing: 1) {
+            Text(value)
+                .font(.questNumber(17))
+                .monospacedDigit()
+            Text(label)
+                .font(.questMicro)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func save() {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        if let entry = todayEntry {
+            entry.text = trimmed
+            entry.mood = mood
+            store.save()
+        } else {
+            store.writeJournal(text: trimmed, mood: mood)
+        }
+        Haptics.success()
+        dismiss()
+    }
+}

--- a/QuestlyApp/Questly/Features/Today/TodayView.swift
+++ b/QuestlyApp/Questly/Features/Today/TodayView.swift
@@ -1,0 +1,627 @@
+import SwiftUI
+import SwiftData
+import QuestlyKit
+
+/// Le Repaire : l'écran d'accueil. Il répond à une seule question — « qu'est-ce
+/// que je fais maintenant ? » — puis récompense chaque réponse.
+struct TodayView: View {
+
+    var onQuickAdd: () -> Void
+
+    @Environment(QuestlyStore.self) private var store
+    @Environment(SettingsStore.self) private var settings
+    @Environment(\.questlyTheme) private var theme
+
+    @Query private var allTasks: [TaskItem]
+    @Query private var profiles: [PlayerProfile]
+    @Query private var quests: [QuestRecord]
+
+    @State private var selectedTask: TaskItem?
+    @State private var showsOverdue = true
+    @State private var showsJournal = false
+
+    private var calendar: Calendar { settings.calendar }
+    private var player: PlayerProfile? { profiles.first }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: Metrics.spacingL) {
+                header
+                questBoard
+                if let hero = focusTask { heroCard(hero) }
+                overdueSection
+                todaySection
+                habitsSection
+                insightsSection
+                Color.clear.frame(height: 110)
+            }
+            .padding(.horizontal, Metrics.spacingM)
+            .padding(.top, Metrics.spacingS)
+        }
+        .scrollIndicators(.hidden)
+        .sheet(item: $selectedTask) { task in
+            TaskDetailView(task: task)
+        }
+        .sheet(isPresented: $showsJournal) {
+            JournalSheet()
+                .presentationDetents([.height(420)])
+        }
+    }
+
+    // MARK: En-tête
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacingM) {
+            HStack(alignment: .center, spacing: Metrics.spacingM) {
+                LevelRing(
+                    progress: player?.levelProgress ?? .zero,
+                    size: 68,
+                    emoji: avatarEmoji
+                )
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(QuestlyFormat.greeting(for: Date(), calendar: calendar))
+                        .font(.questCaption)
+                        .foregroundStyle(.secondary)
+                    Text(player?.rank.title ?? "Novice")
+                        .font(.questHeadline)
+                    Text(QuestlyFormat.fullDay(Date(), calendar: calendar))
+                        .font(.questMicro)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                VStack(alignment: .trailing, spacing: 6) {
+                    StreakFlame(days: store.streak.current, isAtRisk: store.streak.isAtRisk, size: 20)
+                    HStack(spacing: 5) {
+                        CurrencyPill(kind: .coins, amount: player?.coins ?? 0)
+                        CurrencyPill(kind: .gems, amount: player?.gems ?? 0)
+                    }
+                }
+            }
+
+            XPBar(progress: player?.levelProgress ?? .zero)
+
+            dayProgressStrip
+        }
+        .padding(Metrics.spacingM)
+        .background {
+            RoundedRectangle(cornerRadius: Metrics.cornerRadiusLarge, style: .continuous)
+                .fill(.ultraThinMaterial)
+                .overlay {
+                    RoundedRectangle(cornerRadius: Metrics.cornerRadiusLarge, style: .continuous)
+                        .fill(theme.softGradient)
+                }
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: Metrics.cornerRadiusLarge, style: .continuous)
+                .strokeBorder(theme.accent.opacity(0.22), lineWidth: 1)
+        }
+    }
+
+    private var avatarEmoji: String {
+        player?.avatarPart(for: .face)?.emoji ?? "🧭"
+    }
+
+    /// Bandeau « x/y quêtes du jour » avec un anneau de complétion.
+    private var dayProgressStrip: some View {
+        let total = todayTasks.count + completedToday.count
+        let done = completedToday.count
+        let fraction = total > 0 ? Double(done) / Double(total) : 0
+
+        return HStack(spacing: Metrics.spacingM) {
+            ProgressRing(
+                fraction: fraction,
+                size: 38,
+                lineWidth: 4,
+                color: theme.accent,
+                content: AnyView(
+                    Text("\(done)")
+                        .font(.questCaption)
+                        .monospacedDigit()
+                )
+            )
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(total == 0 ? "Journée libre" : "\(done) sur \(total) quêtes")
+                    .font(.questCallout)
+                Text(dayMessage(done: done, total: total))
+                    .font(.questMicro)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Button {
+                showsJournal = true
+            } label: {
+                Image(systemName: "square.and.pencil")
+                    .font(.system(size: 14, weight: .semibold))
+            }
+            .buttonStyle(SoftButtonStyle(tint: theme.accent))
+        }
+    }
+
+    private func dayMessage(done: Int, total: Int) -> String {
+        if total == 0 { return "Ajoute une quête pour lancer la journée." }
+        if done == 0 { return "La première est toujours la plus dure." }
+        if done == total { return "Journée parfaite. Rien à ajouter." }
+        if Double(done) / Double(total) >= 0.66 { return "Le plus dur est derrière toi." }
+        return "Bon rythme, continue."
+    }
+
+    // MARK: Quêtes du jour
+
+    private var questBoard: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacingS) {
+            sectionTitle("Quêtes du jour", symbol: "scroll.fill")
+
+            if todayQuests.isEmpty {
+                Text("Le tableau se remplit au premier lancement de la journée.")
+                    .font(.questCaption)
+                    .foregroundStyle(.secondary)
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: Metrics.spacingS) {
+                        ForEach(todayQuests) { quest in
+                            DailyQuestCard(quest: quest) {
+                                if store.claim(quest) {
+                                    Haptics.play(.questComplete)
+                                }
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 2)
+                    .padding(.vertical, 4)
+                }
+                .scrollClipDisabled()
+            }
+        }
+    }
+
+    private var todayQuests: [QuestRecord] {
+        let today = calendar.startOfDay(for: Date())
+        let weekStart = calendar.startOfWeek(Date())
+        return quests
+            .filter { record in
+                record.period == .daily
+                    ? calendar.isSameDay(record.day, today)
+                    : calendar.isSameDay(record.day, weekStart)
+            }
+            .sorted { lhs, rhs in
+                if lhs.period != rhs.period { return lhs.period == .daily }
+                return lhs.title < rhs.title
+            }
+    }
+
+    // MARK: Quête vedette
+
+    /// La quête à attaquer maintenant : la plus urgente, la plus rentable.
+    private var focusTask: TaskItem? {
+        let candidates = todayTasks.filter { !$0.isCompleted }
+        return candidates.max { lhs, rhs in
+            score(for: lhs) < score(for: rhs)
+        }
+    }
+
+    private func score(for task: TaskItem) -> Double {
+        var value = Double(task.priority.urgencyScore) * 10
+        value += Double(task.difficulty.rawValue) * 3
+        if task.isBoss { value += 25 }
+        if task.isOverdue(now: Date(), calendar: calendar) { value += 30 }
+        if task.isFlagged { value += 8 }
+        return value
+    }
+
+    private func heroCard(_ task: TaskItem) -> some View {
+        VStack(alignment: .leading, spacing: Metrics.spacingS) {
+            sectionTitle("À attaquer maintenant", symbol: "target")
+
+            Button {
+                selectedTask = task
+            } label: {
+                GlassCard(tint: theme.accent) {
+                    VStack(alignment: .leading, spacing: Metrics.spacingS) {
+                        HStack {
+                            if task.isBoss {
+                                Label("BOSS", systemImage: "crown.fill")
+                                    .font(.system(size: 10, weight: .heavy, design: .rounded))
+                                    .foregroundStyle(Color(hex: "BF5AF2"))
+                            }
+                            DifficultyBadge(difficulty: task.difficulty)
+                            if let area = task.lifeArea {
+                                LifeAreaBadge(area: area)
+                            }
+                            Spacer()
+                            XPPill(amount: task.previewXP, isPreview: true)
+                        }
+
+                        Text(task.title)
+                            .font(.questHeadline)
+                            .multilineTextAlignment(.leading)
+                            .foregroundStyle(.primary)
+
+                        if task.isBoss {
+                            BossHealthBar(
+                                fraction: task.bossHealthFraction,
+                                remainingMinutes: task.bossRemainingHP
+                            )
+                        }
+
+                        HStack(spacing: Metrics.spacingS) {
+                            Button {
+                                let bundle = store.complete(task)
+                                Haptics.play(bundle.comboCount > 1 ? .combo(bundle.comboCount) : .success)
+                            } label: {
+                                Label("Accomplir", systemImage: "checkmark")
+                            }
+                            .buttonStyle(SoftButtonStyle(tint: Color(hex: "30D158")))
+
+                            Button {
+                                selectedTask = task
+                            } label: {
+                                Label("Détails", systemImage: "chevron.right")
+                            }
+                            .buttonStyle(SoftButtonStyle(tint: theme.accent))
+                        }
+                    }
+                }
+            }
+            .buttonStyle(PressableStyle(scale: 0.98))
+        }
+    }
+
+    // MARK: Sections de quêtes
+
+    private var overdueSection: some View {
+        Group {
+            if !overdueTasks.isEmpty {
+                VStack(alignment: .leading, spacing: Metrics.spacingS) {
+                    HStack {
+                        sectionTitle("En retard", symbol: "exclamationmark.triangle.fill", color: Color(hex: "FF453A"))
+                        Spacer()
+                        Button("Tout reporter à aujourd'hui") {
+                            withAnimation(Motion.gentle) {
+                                store.rescheduleOverdueToToday()
+                            }
+                            Haptics.success()
+                        }
+                        .font(.questMicro)
+                        .foregroundStyle(theme.accent)
+                    }
+
+                    GlassCard(tint: Color(hex: "FF453A")) {
+                        VStack(spacing: 0) {
+                            ForEach(overdueTasks.prefix(5)) { task in
+                                TaskRow(task: task) { selectedTask = task }
+                                if task.identifier != overdueTasks.prefix(5).last?.identifier {
+                                    Divider().opacity(0.4)
+                                }
+                            }
+                            if overdueTasks.count > 5 {
+                                Text("+ \(overdueTasks.count - 5) autres")
+                                    .font(.questMicro)
+                                    .foregroundStyle(.secondary)
+                                    .padding(.top, 6)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var todaySection: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacingS) {
+            sectionTitle("Aujourd'hui", symbol: "sun.max.fill", color: Color(hex: "FF9F0A"))
+
+            if todayTasks.isEmpty && completedToday.isEmpty {
+                GlassCard {
+                    EmptyStateView(
+                        symbolName: "sparkles",
+                        title: "Aucune quête pour aujourd'hui",
+                        message: "Profite du calme, ou lance-toi un défi.",
+                        actionTitle: "Ajouter une quête",
+                        action: onQuickAdd
+                    )
+                }
+            } else {
+                GlassCard {
+                    VStack(spacing: 0) {
+                        ForEach(todayTasks) { task in
+                            TaskRow(task: task) { selectedTask = task }
+                            if task.identifier != todayTasks.last?.identifier {
+                                Divider().opacity(0.4)
+                            }
+                        }
+
+                        if !completedToday.isEmpty {
+                            DisclosureGroup {
+                                ForEach(completedToday) { task in
+                                    TaskRow(task: task, isCompact: true) { selectedTask = task }
+                                }
+                            } label: {
+                                Text("\(completedToday.count) accomplie\(completedToday.count > 1 ? "s" : "")")
+                                    .font(.questCaption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            .padding(.top, todayTasks.isEmpty ? 0 : Metrics.spacingS)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var habitsSection: some View {
+        Group {
+            if !habitTasks.isEmpty {
+                VStack(alignment: .leading, spacing: Metrics.spacingS) {
+                    sectionTitle("Rituels", symbol: "repeat.circle.fill", color: Color(hex: "30D158"))
+                    GlassCard {
+                        VStack(spacing: 0) {
+                            ForEach(habitTasks) { task in
+                                TaskRow(task: task, isCompact: true) { selectedTask = task }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var insightsSection: some View {
+        let insights = InsightEngine.insights(
+            stats: store.currentStats(days: 30),
+            streak: store.streak,
+            totalXP: player?.totalXP ?? 0,
+            overdueCount: overdueTasks.count,
+            calendar: calendar
+        )
+
+        return Group {
+            if !insights.isEmpty {
+                VStack(alignment: .leading, spacing: Metrics.spacingS) {
+                    sectionTitle("Ce que disent tes chroniques", symbol: "sparkle.magnifyingglass")
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: Metrics.spacingS) {
+                            ForEach(insights.prefix(4)) { insight in
+                                InsightCard(insight: insight)
+                            }
+                        }
+                        .padding(.vertical, 4)
+                    }
+                    .scrollClipDisabled()
+                }
+            }
+        }
+    }
+
+    // MARK: Données dérivées
+
+    private var openTasks: [TaskItem] {
+        allTasks.filter(\.isOpen)
+    }
+
+    private var todayTasks: [TaskItem] {
+        openTasks
+            .filter { task in
+                guard let due = task.dueDate else { return false }
+                return calendar.startOfDay(for: due) <= calendar.startOfDay(for: Date())
+                    && !task.isOverdue(now: Date(), calendar: calendar)
+            }
+            .sorted(by: TaskSorting.smart(calendar: calendar))
+    }
+
+    private var overdueTasks: [TaskItem] {
+        openTasks
+            .filter { $0.isOverdue(now: Date(), calendar: calendar) }
+            .sorted { ($0.dueDate ?? .distantFuture) < ($1.dueDate ?? .distantFuture) }
+    }
+
+    private var completedToday: [TaskItem] {
+        allTasks.filter { task in
+            guard let completedAt = task.completedAt else { return false }
+            return calendar.isSameDay(completedAt, Date())
+        }
+        .sorted { ($0.completedAt ?? .distantPast) > ($1.completedAt ?? .distantPast) }
+    }
+
+    private var habitTasks: [TaskItem] {
+        openTasks.filter { $0.isRecurring && $0.isDueToday(now: Date(), calendar: calendar) }
+    }
+
+    // MARK: Utilitaires
+
+    private func sectionTitle(_ title: String, symbol: String, color: Color? = nil) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: symbol)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(color ?? theme.accent)
+            Text(title)
+                .font(.questCallout)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - Carte de quête quotidienne
+
+struct DailyQuestCard: View {
+    let quest: QuestRecord
+    let onClaim: () -> Void
+
+    @Environment(\.questlyTheme) private var theme
+
+    private var accent: Color { Color(hex: quest.rarity.hex) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacingS) {
+            HStack {
+                Image(systemName: quest.symbolName)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(accent)
+                Spacer()
+                if quest.period == .weekly {
+                    Text("SEMAINE")
+                        .font(.system(size: 8, weight: .heavy, design: .rounded))
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Text(quest.title)
+                .font(.questCallout)
+                .lineLimit(1)
+
+            Text(quest.detail)
+                .font(.questMicro)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+                .frame(height: 26, alignment: .top)
+
+            ProgressView(value: quest.fraction)
+                .progressViewStyle(.linear)
+                .tint(accent)
+
+            HStack(spacing: 6) {
+                Text("\(min(quest.progress, quest.target))/\(quest.target)")
+                    .font(.questMicro)
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if quest.isClaimed {
+                    Image(systemName: "checkmark.seal.fill")
+                        .font(.system(size: 12))
+                        .foregroundStyle(Color(hex: "30D158"))
+                } else if quest.isComplete {
+                    Button("Encaisser", action: onClaim)
+                        .font(.questMicro)
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background { Capsule().fill(accent) }
+                        .buttonStyle(.plain)
+                } else {
+                    Text("+\(quest.xpReward) XP")
+                        .font(.questMicro)
+                        .foregroundStyle(accent)
+                }
+            }
+        }
+        .padding(Metrics.spacingS + 2)
+        .frame(width: 190, height: 152)
+        .background {
+            RoundedRectangle(cornerRadius: Metrics.cornerRadius, style: .continuous)
+                .fill(.ultraThinMaterial)
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: Metrics.cornerRadius, style: .continuous)
+                .strokeBorder(accent.opacity(quest.isComplete ? 0.55 : 0.18), lineWidth: 1)
+        }
+        .shadow(color: .black.opacity(0.12), radius: 10, y: 5)
+        .applyIf(quest.isComplete && !quest.isClaimed) { view in
+            view.overlay(alignment: .topTrailing) {
+                PulsingHalo(color: accent, size: 26)
+                    .offset(x: -6, y: 6)
+            }
+        }
+    }
+}
+
+// MARK: - Carte d'observation
+
+struct InsightCard: View {
+    let insight: Insight
+
+    private var accent: Color {
+        switch insight.tone {
+        case .positive: return Color(hex: "30D158")
+        case .warning: return Color(hex: "FF9F0A")
+        case .neutral: return Color(hex: "5E9BFF")
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Image(systemName: insight.symbolName)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(accent)
+
+            Text(insight.title)
+                .font(.questCallout)
+                .lineLimit(2)
+
+            Text(insight.detail)
+                .font(.questMicro)
+                .foregroundStyle(.secondary)
+                .lineLimit(3)
+
+            Spacer(minLength: 0)
+        }
+        .padding(Metrics.spacingS + 2)
+        .frame(width: 210, height: 128, alignment: .topLeading)
+        .background {
+            RoundedRectangle(cornerRadius: Metrics.cornerRadius, style: .continuous)
+                .fill(.ultraThinMaterial)
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: Metrics.cornerRadius, style: .continuous)
+                .strokeBorder(accent.opacity(0.2), lineWidth: 1)
+        }
+    }
+}
+
+// MARK: - Tri des quêtes
+
+enum TaskSorting {
+
+    /// Tri « intelligent » : retard, puis heure du jour, puis priorité,
+    /// puis difficulté. C'est l'ordre par défaut partout dans l'app.
+    static func smart(calendar: Calendar) -> (TaskItem, TaskItem) -> Bool {
+        { lhs, rhs in
+            let lhsOverdue = lhs.isOverdue(now: Date(), calendar: calendar)
+            let rhsOverdue = rhs.isOverdue(now: Date(), calendar: calendar)
+            if lhsOverdue != rhsOverdue { return lhsOverdue }
+
+            switch (lhs.hasTime, rhs.hasTime) {
+            case (true, false): return true
+            case (false, true): return false
+            case (true, true):
+                let lhsDate = lhs.dueDate ?? .distantFuture
+                let rhsDate = rhs.dueDate ?? .distantFuture
+                if lhsDate != rhsDate { return lhsDate < rhsDate }
+            case (false, false):
+                break
+            }
+
+            if lhs.priority != rhs.priority {
+                return lhs.priority.urgencyScore > rhs.priority.urgencyScore
+            }
+            if lhs.isBoss != rhs.isBoss { return lhs.isBoss }
+            if lhs.difficulty != rhs.difficulty {
+                return lhs.difficulty.rawValue > rhs.difficulty.rawValue
+            }
+            return lhs.sortIndex < rhs.sortIndex
+        }
+    }
+
+    static func comparator(for order: TaskSortOrder, calendar: Calendar) -> (TaskItem, TaskItem) -> Bool {
+        switch order {
+        case .smart:
+            return smart(calendar: calendar)
+        case .dueDate:
+            return { ($0.dueDate ?? .distantFuture) < ($1.dueDate ?? .distantFuture) }
+        case .priority:
+            return { $0.priority.urgencyScore > $1.priority.urgencyScore }
+        case .difficulty:
+            return { $0.difficulty.rawValue > $1.difficulty.rawValue }
+        case .alphabetical:
+            return { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
+        case .created:
+            return { $0.createdAt > $1.createdAt }
+        case .xpValue:
+            return { $0.previewXP > $1.previewXP }
+        }
+    }
+}

--- a/QuestlyApp/Questly/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/QuestlyApp/Questly/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : { "alpha" : "1.000", "blue" : "1.000", "green" : "0.361", "red" : "0.486" }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [ { "appearance" : "luminosity", "value" : "dark" } ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : { "alpha" : "1.000", "blue" : "1.000", "green" : "0.490", "red" : "0.612" }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : { "author" : "xcode", "version" : 1 }
+}

--- a/QuestlyApp/Questly/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/QuestlyApp/Questly/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,10 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : { "author" : "xcode", "version" : 1 }
+}

--- a/QuestlyApp/Questly/Resources/Assets.xcassets/Contents.json
+++ b/QuestlyApp/Questly/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,3 @@
+{
+  "info" : { "author" : "xcode", "version" : 1 }
+}

--- a/QuestlyApp/Questly/Services/AppShortcuts.swift
+++ b/QuestlyApp/Questly/Services/AppShortcuts.swift
@@ -1,0 +1,129 @@
+import AppIntents
+import SwiftData
+import QuestlyKit
+
+// MARK: - Ajouter une quête
+
+/// « Dis Siri, ajoute une quête dans Questly. »
+/// L'intention passe par le même analyseur que la saisie rapide : dicter
+/// « courses demain 18h » crée une quête correctement datée.
+struct AddQuestIntent: AppIntent {
+
+    static var title: LocalizedStringResource = "Ajouter une quête"
+    static var description = IntentDescription(
+        "Crée une quête dans Questly. La date, l'heure, la priorité et les étiquettes sont comprises automatiquement."
+    )
+    static var openAppWhenRun = false
+
+    @Parameter(title: "Quête", requestValueDialog: "Que veux-tu accomplir ?")
+    var text: String
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let context = AppContainer.shared.mainContext
+        let store = QuestlyStore(modelContext: context)
+        let parsed = NaturalLanguageParser.parse(text)
+        let task = store.createTask(from: parsed)
+
+        let dialog: IntentDialog
+        if let due = task.dueDate {
+            let label = QuestlyFormat.dueLabel(for: due, hasTime: task.hasTime)
+            dialog = IntentDialog("« \(task.title) » ajoutée pour \(label).")
+        } else {
+            dialog = IntentDialog("« \(task.title) » ajoutée à ta boîte de réception.")
+        }
+        return .result(dialog: dialog)
+    }
+}
+
+// MARK: - Résumé du jour
+
+/// Un point rapide sans ouvrir l'app.
+struct DailyBriefIntent: AppIntent {
+
+    static var title: LocalizedStringResource = "Résumé de ma journée"
+    static var description = IntentDescription(
+        "Donne le nombre de quêtes du jour, la série en cours et le niveau atteint."
+    )
+    static var openAppWhenRun = false
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let context = AppContainer.shared.mainContext
+        let store = QuestlyStore(modelContext: context)
+        store.refreshStreak()
+
+        let calendar = Calendar.questly()
+        let open = store.openTasks()
+        let today = open.filter { task in
+            guard let due = task.dueDate else { return false }
+            return calendar.startOfDay(for: due) <= calendar.startOfDay(for: Date())
+        }
+        let overdue = open.filter { $0.isOverdue(now: Date(), calendar: calendar) }
+        let player = store.profile()
+
+        var parts: [String] = []
+        parts.append(today.isEmpty
+                     ? "Aucune quête prévue aujourd'hui."
+                     : "\(today.count) quête\(today.count > 1 ? "s" : "") au programme.")
+        if !overdue.isEmpty {
+            parts.append("\(overdue.count) en retard.")
+        }
+        parts.append("Niveau \(player.level), série de \(store.streak.current) jour\(store.streak.current > 1 ? "s" : "").")
+
+        return .result(dialog: IntentDialog(stringLiteral: parts.joined(separator: " ")))
+    }
+}
+
+// MARK: - Démarrer une session
+
+/// Ouvre l'app directement sur le Donjon.
+struct StartFocusIntent: AppIntent {
+
+    static var title: LocalizedStringResource = "Démarrer une session de concentration"
+    static var description = IntentDescription("Ouvre Questly sur le minuteur de concentration.")
+    static var openAppWhenRun = true
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        .result()
+    }
+}
+
+// MARK: - Raccourcis proposés
+
+struct QuestlyShortcuts: AppShortcutsProvider {
+
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: AddQuestIntent(),
+            phrases: [
+                "Ajouter une quête dans \(.applicationName)",
+                "Nouvelle quête \(.applicationName)",
+                "Note dans \(.applicationName)"
+            ],
+            shortTitle: "Nouvelle quête",
+            systemImageName: "plus.circle.fill"
+        )
+
+        AppShortcut(
+            intent: DailyBriefIntent(),
+            phrases: [
+                "Résumé de ma journée dans \(.applicationName)",
+                "Où j'en suis dans \(.applicationName)"
+            ],
+            shortTitle: "Résumé du jour",
+            systemImageName: "sun.max.fill"
+        )
+
+        AppShortcut(
+            intent: StartFocusIntent(),
+            phrases: [
+                "Démarrer une session dans \(.applicationName)",
+                "Concentration \(.applicationName)"
+            ],
+            shortTitle: "Concentration",
+            systemImageName: "timer"
+        )
+    }
+}

--- a/QuestlyApp/Questly/Services/CalendarService.swift
+++ b/QuestlyApp/Questly/Services/CalendarService.swift
@@ -1,0 +1,163 @@
+import Foundation
+import EventKit
+import SwiftUI
+import QuestlyKit
+
+/// Pont avec le calendrier système.
+///
+/// Les évènements iOS sont affichés en lecture seule dans la timeline, ce qui
+/// rend la planification honnête : on ne peut pas bloquer un créneau déjà pris.
+/// L'écriture est possible à la demande, pour pousser un bloc vers Apple
+/// Calendar.
+@MainActor
+@Observable
+final class CalendarService {
+
+    struct ExternalEvent: Identifiable, Equatable {
+        let id: String
+        let title: String
+        let start: Date
+        let end: Date
+        let isAllDay: Bool
+        let colorHex: String
+        let calendarName: String
+
+        var durationMinutes: Int { max(0, Int(end.timeIntervalSince(start) / 60)) }
+
+        var busyInterval: BusyInterval {
+            BusyInterval(id: id, start: start, end: end, title: title)
+        }
+    }
+
+    enum Access {
+        case unknown
+        case granted
+        case denied
+    }
+
+    private(set) var access: Access = .unknown
+    private(set) var events: [ExternalEvent] = []
+    private(set) var lastError: String?
+
+    private let store = EKEventStore()
+
+    // MARK: Autorisation
+
+    func refreshAuthorization() {
+        let status = EKEventStore.authorizationStatus(for: .event)
+        switch status {
+        case .fullAccess:
+            access = .granted
+        case .writeOnly:
+            access = .granted
+        case .denied, .restricted:
+            access = .denied
+        default:
+            access = .unknown
+        }
+    }
+
+    @discardableResult
+    func requestAccess() async -> Bool {
+        do {
+            let granted = try await store.requestFullAccessToEvents()
+            access = granted ? .granted : .denied
+            return granted
+        } catch {
+            lastError = error.localizedDescription
+            access = .denied
+            return false
+        }
+    }
+
+    // MARK: Lecture
+
+    /// Charge les évènements d'une plage. Appelé quand le calendrier change de
+    /// période affichée.
+    func load(from start: Date, to end: Date) {
+        guard access == .granted else {
+            events = []
+            return
+        }
+        let calendars = store.calendars(for: .event)
+        guard !calendars.isEmpty else {
+            events = []
+            return
+        }
+        let predicate = store.predicateForEvents(withStart: start, end: end, calendars: calendars)
+        let found = store.events(matching: predicate)
+
+        events = found.compactMap { event in
+            guard let identifier = event.eventIdentifier,
+                  let startDate = event.startDate,
+                  let endDate = event.endDate else { return nil }
+            return ExternalEvent(
+                id: identifier + "-" + String(startDate.timeIntervalSince1970),
+                title: event.title ?? "Évènement",
+                start: startDate,
+                end: endDate,
+                isAllDay: event.isAllDay,
+                colorHex: Self.hex(from: event.calendar),
+                calendarName: event.calendar?.title ?? ""
+            )
+        }
+        .sorted { $0.start < $1.start }
+    }
+
+    func events(on day: Date, calendar: Calendar = .questly()) -> [ExternalEvent] {
+        events.filter { calendar.isSameDay($0.start, day) }
+    }
+
+    func busyIntervals(on day: Date, calendar: Calendar = .questly()) -> [BusyInterval] {
+        events(on: day, calendar: calendar)
+            .filter { !$0.isAllDay }
+            .map(\.busyInterval)
+    }
+
+    // MARK: Écriture
+
+    /// Pousse un bloc Questly vers le calendrier système.
+    @discardableResult
+    func export(block: TimeBlock, calendarTitle: String = "Questly") -> String? {
+        guard access == .granted else { return nil }
+        let event = EKEvent(eventStore: store)
+        event.title = block.title
+        event.startDate = block.start
+        event.endDate = block.end
+        event.notes = block.notes.isEmpty ? nil : block.notes
+        event.calendar = store.defaultCalendarForNewEvents ?? store.calendars(for: .event).first
+
+        do {
+            try store.save(event, span: .thisEvent)
+            return event.eventIdentifier
+        } catch {
+            lastError = error.localizedDescription
+            return nil
+        }
+    }
+
+    func removeExportedEvent(identifier: String) {
+        guard access == .granted, let event = store.event(withIdentifier: identifier) else { return }
+        try? store.remove(event, span: .thisEvent)
+    }
+
+    // MARK: Outils
+
+    static func hex(from calendar: EKCalendar?) -> String {
+        guard let cgColor = calendar?.cgColor else { return "5E5CE6" }
+        #if canImport(UIKit)
+        let color = UIColor(cgColor: cgColor)
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        return String(
+            format: "%02X%02X%02X",
+            Int(red * 255), Int(green * 255), Int(blue * 255)
+        )
+        #else
+        return "5E5CE6"
+        #endif
+    }
+}

--- a/QuestlyApp/Questly/Services/Haptics.swift
+++ b/QuestlyApp/Questly/Services/Haptics.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// Retour haptique centralisé.
+///
+/// Chaque évènement du jeu a sa signature tactile : une validation ne se sent
+/// pas comme une montée de niveau. Le tout respecte le réglage utilisateur.
+enum Haptics {
+
+    /// Piloté par les réglages ; mis à jour au démarrage.
+    nonisolated(unsafe) static var isEnabled = true
+
+    enum Event {
+        case selection
+        case light
+        case medium
+        case heavy
+        case success
+        case warning
+        case error
+        case levelUp
+        case questComplete
+        case combo(Int)
+    }
+
+    static func play(_ event: Event) {
+        guard isEnabled else { return }
+        #if canImport(UIKit)
+        switch event {
+        case .selection:
+            UISelectionFeedbackGenerator().selectionChanged()
+        case .light:
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        case .medium:
+            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        case .heavy:
+            UIImpactFeedbackGenerator(style: .heavy).impactOccurred()
+        case .success:
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+        case .warning:
+            UINotificationFeedbackGenerator().notificationOccurred(.warning)
+        case .error:
+            UINotificationFeedbackGenerator().notificationOccurred(.error)
+        case .levelUp:
+            // Trois impacts croissants : on « sent » la montée.
+            let generator = UIImpactFeedbackGenerator(style: .heavy)
+            generator.impactOccurred(intensity: 0.6)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) {
+                generator.impactOccurred(intensity: 0.8)
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.26) {
+                UINotificationFeedbackGenerator().notificationOccurred(.success)
+            }
+        case .questComplete:
+            let generator = UIImpactFeedbackGenerator(style: .rigid)
+            generator.impactOccurred(intensity: 0.9)
+        case .combo(let count):
+            // Plus le combo monte, plus l'impact est franc.
+            let intensity = min(1.0, 0.45 + Double(count) * 0.11)
+            UIImpactFeedbackGenerator(style: .soft).impactOccurred(intensity: intensity)
+        }
+        #endif
+    }
+
+    static func selection() { play(.selection) }
+    static func success() { play(.success) }
+    static func light() { play(.light) }
+    static func warning() { play(.warning) }
+}

--- a/QuestlyApp/Questly/Services/NotificationService.swift
+++ b/QuestlyApp/Questly/Services/NotificationService.swift
@@ -1,0 +1,185 @@
+import Foundation
+import UserNotifications
+import QuestlyKit
+
+/// Rappels locaux : échéances, revue du soir, série en danger.
+///
+/// Le ton des notifications suit celui du jeu — jamais culpabilisant, toujours
+/// une porte de sortie en un geste.
+@MainActor
+@Observable
+final class NotificationService {
+
+    enum Authorization {
+        case unknown
+        case granted
+        case denied
+    }
+
+    private(set) var authorization: Authorization = .unknown
+
+    private let center = UNUserNotificationCenter.current()
+
+    static let taskCategory = "QUESTLY_TASK"
+    static let reviewCategory = "QUESTLY_REVIEW"
+
+    // MARK: Autorisation
+
+    func refreshAuthorization() async {
+        let settings = await center.notificationSettings()
+        switch settings.authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            authorization = .granted
+        case .denied:
+            authorization = .denied
+        default:
+            authorization = .unknown
+        }
+    }
+
+    @discardableResult
+    func requestAuthorization() async -> Bool {
+        do {
+            let granted = try await center.requestAuthorization(options: [.alert, .sound, .badge])
+            authorization = granted ? .granted : .denied
+            if granted { registerCategories() }
+            return granted
+        } catch {
+            authorization = .denied
+            return false
+        }
+    }
+
+    func registerCategories() {
+        let complete = UNNotificationAction(
+            identifier: "COMPLETE",
+            title: "Accomplir",
+            options: [.authenticationRequired]
+        )
+        let snooze = UNNotificationAction(
+            identifier: "SNOOZE",
+            title: "Repousser d'une heure",
+            options: []
+        )
+        let taskCategory = UNNotificationCategory(
+            identifier: Self.taskCategory,
+            actions: [complete, snooze],
+            intentIdentifiers: [],
+            options: []
+        )
+        let reviewCategory = UNNotificationCategory(
+            identifier: Self.reviewCategory,
+            actions: [],
+            intentIdentifiers: [],
+            options: []
+        )
+        center.setNotificationCategories([taskCategory, reviewCategory])
+    }
+
+    // MARK: Échéances
+
+    func identifier(for task: TaskItem) -> String {
+        "task.\(task.identifier.uuidString)"
+    }
+
+    /// (Re)programme le rappel d'une quête. Sans échéance ou une fois accomplie,
+    /// le rappel est simplement retiré.
+    func schedule(for task: TaskItem, calendar: Calendar = .questly(), defaultHour: Int = 9) {
+        let id = identifier(for: task)
+        center.removePendingNotificationRequests(withIdentifiers: [id])
+
+        guard task.isOpen, let dueDate = task.dueDate else { return }
+
+        var fireDate = task.hasTime
+            ? dueDate
+            : calendar.setting(hour: defaultHour, minute: 0, of: dueDate)
+
+        if let offset = task.reminderMinutesBefore, offset > 0 {
+            fireDate = fireDate.addingTimeInterval(TimeInterval(-offset * 60))
+        }
+        guard fireDate > Date() else { return }
+
+        let content = UNMutableNotificationContent()
+        content.title = task.isBoss ? "👑 Un boss t'attend" : "Une quête t'attend"
+        content.body = task.title
+        content.sound = .default
+        content.categoryIdentifier = Self.taskCategory
+        content.userInfo = ["taskID": task.identifier.uuidString]
+        if task.previewXP > 0 {
+            content.subtitle = "+\(task.previewXP) XP à la clé"
+        }
+
+        let components = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: fireDate)
+        let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: false)
+        center.add(UNNotificationRequest(identifier: id, content: content, trigger: trigger))
+    }
+
+    func cancel(for task: TaskItem) {
+        center.removePendingNotificationRequests(withIdentifiers: [identifier(for: task)])
+    }
+
+    func rescheduleAll(tasks: [TaskItem], calendar: Calendar, defaultHour: Int) {
+        for task in tasks {
+            schedule(for: task, calendar: calendar, defaultHour: defaultHour)
+        }
+    }
+
+    // MARK: Rendez-vous quotidiens
+
+    /// Revue du soir : un rappel doux pour boucler la journée et préparer demain.
+    func scheduleDailyReview(hour: Int, minute: Int = 0) {
+        let id = "daily.review"
+        center.removePendingNotificationRequests(withIdentifiers: [id])
+
+        let content = UNMutableNotificationContent()
+        content.title = "Revue du soir"
+        content.body = "Deux minutes pour clore la journée et préparer demain."
+        content.sound = .default
+        content.categoryIdentifier = Self.reviewCategory
+
+        var components = DateComponents()
+        components.hour = hour
+        components.minute = minute
+        let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: true)
+        center.add(UNNotificationRequest(identifier: id, content: content, trigger: trigger))
+    }
+
+    /// Filet de sécurité : prévient en fin de journée si la série va tomber.
+    func scheduleStreakReminder(hour: Int = 20, minute: Int = 30, streak: Int) {
+        let id = "streak.risk"
+        center.removePendingNotificationRequests(withIdentifiers: [id])
+        guard streak > 0 else { return }
+
+        let content = UNMutableNotificationContent()
+        content.title = "🔥 Série de \(streak) jours"
+        content.body = "Une seule quête suffit à la garder en vie."
+        content.sound = .default
+
+        var components = DateComponents()
+        components.hour = hour
+        components.minute = minute
+        let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: true)
+        center.add(UNNotificationRequest(identifier: id, content: content, trigger: trigger))
+    }
+
+    func cancelStreakReminder() {
+        center.removePendingNotificationRequests(withIdentifiers: ["streak.risk"])
+    }
+
+    /// Notification immédiate de fin de session de concentration.
+    func notifyFocusFinished(taskTitle: String, minutes: Int) {
+        let content = UNMutableNotificationContent()
+        content.title = "Session terminée"
+        content.body = taskTitle.isEmpty
+            ? "\(minutes) minutes de concentration au compteur."
+            : "\(minutes) min sur « \(taskTitle) ». Bien joué."
+        content.sound = .default
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+        center.add(UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger))
+    }
+
+    func cancelAll() {
+        center.removeAllPendingNotificationRequests()
+    }
+}

--- a/QuestlyApp/Questly/Services/SettingsStore.swift
+++ b/QuestlyApp/Questly/Services/SettingsStore.swift
@@ -1,0 +1,150 @@
+import SwiftUI
+import QuestlyKit
+
+/// Préférences de l'utilisateur, persistées dans `UserDefaults`.
+/// Tout est exposé en une seule classe observable pour éviter de disséminer
+/// des `@AppStorage` dans toutes les vues.
+@Observable
+final class SettingsStore {
+
+    // MARK: Clés
+
+    private enum Key {
+        static let themeID = "settings.themeID"
+        static let hapticsEnabled = "settings.haptics"
+        static let soundEnabled = "settings.sound"
+        static let firstWeekday = "settings.firstWeekday"
+        static let workStartMinute = "settings.workStart"
+        static let workEndMinute = "settings.workEnd"
+        static let peakStartMinute = "settings.peakStart"
+        static let peakEndMinute = "settings.peakEnd"
+        static let workingWeekdays = "settings.workingWeekdays"
+        static let defaultDueHour = "settings.defaultDueHour"
+        static let defaultReminderMinutes = "settings.defaultReminder"
+        static let showCompletedTasks = "settings.showCompleted"
+        static let confettiEnabled = "settings.confetti"
+        static let calendarSyncEnabled = "settings.calendarSync"
+        static let dailyReviewHour = "settings.dailyReviewHour"
+        static let focusDuration = "settings.focusDuration"
+        static let breakDuration = "settings.breakDuration"
+        static let longBreakDuration = "settings.longBreakDuration"
+        static let sessionsBeforeLongBreak = "settings.sessionsBeforeLongBreak"
+        static let reduceMotion = "settings.reduceMotion"
+        static let hasSeenOnboarding = "settings.onboarding"
+    }
+
+    private let defaults: UserDefaults
+
+    // MARK: Propriétés
+
+    var themeID: String { didSet { defaults.set(themeID, forKey: Key.themeID) } }
+    var hapticsEnabled: Bool {
+        didSet {
+            defaults.set(hapticsEnabled, forKey: Key.hapticsEnabled)
+            Haptics.isEnabled = hapticsEnabled
+        }
+    }
+    var soundEnabled: Bool { didSet { defaults.set(soundEnabled, forKey: Key.soundEnabled) } }
+    var confettiEnabled: Bool { didSet { defaults.set(confettiEnabled, forKey: Key.confettiEnabled) } }
+    var reduceMotion: Bool { didSet { defaults.set(reduceMotion, forKey: Key.reduceMotion) } }
+
+    var firstWeekday: Int { didSet { defaults.set(firstWeekday, forKey: Key.firstWeekday) } }
+    var workStartMinute: Int { didSet { defaults.set(workStartMinute, forKey: Key.workStartMinute) } }
+    var workEndMinute: Int { didSet { defaults.set(workEndMinute, forKey: Key.workEndMinute) } }
+    var peakStartMinute: Int { didSet { defaults.set(peakStartMinute, forKey: Key.peakStartMinute) } }
+    var peakEndMinute: Int { didSet { defaults.set(peakEndMinute, forKey: Key.peakEndMinute) } }
+    var workingWeekdays: [Int] { didSet { defaults.set(workingWeekdays, forKey: Key.workingWeekdays) } }
+
+    var defaultDueHour: Int { didSet { defaults.set(defaultDueHour, forKey: Key.defaultDueHour) } }
+    var defaultReminderMinutes: Int { didSet { defaults.set(defaultReminderMinutes, forKey: Key.defaultReminderMinutes) } }
+    var showCompletedTasks: Bool { didSet { defaults.set(showCompletedTasks, forKey: Key.showCompletedTasks) } }
+    var calendarSyncEnabled: Bool { didSet { defaults.set(calendarSyncEnabled, forKey: Key.calendarSyncEnabled) } }
+    var dailyReviewHour: Int { didSet { defaults.set(dailyReviewHour, forKey: Key.dailyReviewHour) } }
+
+    var focusDuration: Int { didSet { defaults.set(focusDuration, forKey: Key.focusDuration) } }
+    var breakDuration: Int { didSet { defaults.set(breakDuration, forKey: Key.breakDuration) } }
+    var longBreakDuration: Int { didSet { defaults.set(longBreakDuration, forKey: Key.longBreakDuration) } }
+    var sessionsBeforeLongBreak: Int { didSet { defaults.set(sessionsBeforeLongBreak, forKey: Key.sessionsBeforeLongBreak) } }
+
+    var hasSeenOnboarding: Bool { didSet { defaults.set(hasSeenOnboarding, forKey: Key.hasSeenOnboarding) } }
+
+    // MARK: Init
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+
+        func int(_ key: String, _ fallback: Int) -> Int {
+            defaults.object(forKey: key) as? Int ?? fallback
+        }
+        func bool(_ key: String, _ fallback: Bool) -> Bool {
+            defaults.object(forKey: key) as? Bool ?? fallback
+        }
+
+        self.themeID = defaults.string(forKey: Key.themeID) ?? ThemeCatalog.default.id
+        self.hapticsEnabled = bool(Key.hapticsEnabled, true)
+        self.soundEnabled = bool(Key.soundEnabled, true)
+        self.confettiEnabled = bool(Key.confettiEnabled, true)
+        self.reduceMotion = bool(Key.reduceMotion, false)
+        self.firstWeekday = int(Key.firstWeekday, 2)
+        self.workStartMinute = int(Key.workStartMinute, 9 * 60)
+        self.workEndMinute = int(Key.workEndMinute, 18 * 60)
+        self.peakStartMinute = int(Key.peakStartMinute, 9 * 60)
+        self.peakEndMinute = int(Key.peakEndMinute, 12 * 60)
+        self.workingWeekdays = defaults.array(forKey: Key.workingWeekdays) as? [Int] ?? [2, 3, 4, 5, 6]
+        self.defaultDueHour = int(Key.defaultDueHour, 9)
+        self.defaultReminderMinutes = int(Key.defaultReminderMinutes, 15)
+        self.showCompletedTasks = bool(Key.showCompletedTasks, false)
+        self.calendarSyncEnabled = bool(Key.calendarSyncEnabled, false)
+        self.dailyReviewHour = int(Key.dailyReviewHour, 20)
+        self.focusDuration = int(Key.focusDuration, 25)
+        self.breakDuration = int(Key.breakDuration, 5)
+        self.longBreakDuration = int(Key.longBreakDuration, 15)
+        self.sessionsBeforeLongBreak = int(Key.sessionsBeforeLongBreak, 4)
+        self.hasSeenOnboarding = bool(Key.hasSeenOnboarding, false)
+
+        Haptics.isEnabled = self.hapticsEnabled
+    }
+
+    // MARK: Dérivés
+
+    var calendar: Calendar {
+        .questly(timeZone: .current, firstWeekday: firstWeekday)
+    }
+
+    var workingHours: WorkingHours {
+        WorkingHours(
+            startMinute: workStartMinute,
+            endMinute: workEndMinute,
+            weekdays: Set(workingWeekdays),
+            peakStartMinute: peakStartMinute,
+            peakEndMinute: peakEndMinute
+        )
+    }
+
+    /// Animation à utiliser : neutralisée si l'utilisateur préfère la sobriété.
+    func animation(_ animation: Animation) -> Animation? {
+        reduceMotion ? nil : animation
+    }
+
+    func resetToDefaults() {
+        themeID = ThemeCatalog.default.id
+        hapticsEnabled = true
+        soundEnabled = true
+        confettiEnabled = true
+        reduceMotion = false
+        firstWeekday = 2
+        workStartMinute = 9 * 60
+        workEndMinute = 18 * 60
+        peakStartMinute = 9 * 60
+        peakEndMinute = 12 * 60
+        workingWeekdays = [2, 3, 4, 5, 6]
+        defaultDueHour = 9
+        defaultReminderMinutes = 15
+        showCompletedTasks = false
+        dailyReviewHour = 20
+        focusDuration = 25
+        breakDuration = 5
+        longBreakDuration = 15
+        sessionsBeforeLongBreak = 4
+    }
+}

--- a/QuestlyApp/README.md
+++ b/QuestlyApp/README.md
@@ -1,0 +1,217 @@
+# Questly — la liste de tâches qui se joue
+
+Application iOS native (SwiftUI + SwiftData) de gestion de tâches **gamifiée**,
+avec un **calendrier complet** : jour, semaine, mois, année, agenda,
+time-blocking par glisser-déposer et lecture du calendrier système.
+
+> **Nom & identité** — l'app s'appelle « Questly » et le bundle est
+> `com.navidjan.questly`. Les deux se changent en une ligne
+> (`PRODUCT_BUNDLE_IDENTIFIER` et `INFOPLIST_KEY_CFBundleDisplayName` dans les
+> réglages de la cible).
+
+---
+
+## Ouvrir le projet
+
+```bash
+open QuestlyApp/Questly.xcodeproj
+```
+
+- **Xcode 16 ou plus récent** (le projet utilise les groupes synchronisés :
+  tout fichier ajouté dans `Questly/` entre automatiquement dans la cible,
+  sans toucher au `.pbxproj`).
+- **iOS 17.0 minimum**, iPhone et iPad.
+- Aucune dépendance externe : un seul package local, `QuestlyKit`, déjà
+  référencé par le projet.
+- Signature : choisir son équipe dans *Signing & Capabilities* au premier lancement.
+
+### Lancer les tests du cœur métier
+
+```bash
+cd QuestlyApp/Packages/QuestlyKit && swift test
+```
+
+**159 tests, tous au vert** — ils couvrent la courbe d'XP, le moteur de
+récompenses, les séries, la récurrence (y compris changement d'heure et années
+bissextiles), l'analyseur de langage naturel, le planificateur et les
+statistiques.
+
+---
+
+## Ce que fait l'app
+
+### Gestion de tâches
+
+| | |
+|---|---|
+| **Saisie naturelle** | « Appeler le dentiste demain 14h30 #santé p2 » crée la quête, la date, l'heure, l'étiquette et la priorité |
+| **Organisation** | projets (campagnes), étiquettes, sous-quêtes, notes, pièces jointes de contexte |
+| **Listes intelligentes** | Boîte de réception, Aujourd'hui, À venir, En retard, N'importe quand, Un jour, Épinglées, Boss, Accomplies |
+| **Tri & regroupement** | intelligent, échéance, priorité, difficulté, alphabétique, XP · groupé par date, priorité, projet, domaine ou difficulté |
+| **Récurrence** | quotidienne / hebdo / mensuelle / annuelle, tous les N, jours de semaine choisis, jour du mois (dont « dernier jour »), fin après N fois ou à une date, et mode **« X jours après accomplissement »** |
+| **Rappels** | notification à l'échéance ou N minutes avant, revue du soir, alerte de série en danger |
+| **Balayages** | reporter à aujourd'hui / demain, épingler, promouvoir en boss, supprimer |
+| **Recherche** | plein texte sur titres, notes et étiquettes, insensible aux accents |
+| **Export** | JSON complet (quêtes, projets, historique, progression) |
+
+### Calendrier, de A à Z
+
+- **Jour** — timeline horaire, trait de l'instant présent, bande « toute la journée ».
+- **Semaine** — sept colonnes, pagination par balayage, en-tête tapable.
+- **Mois** — grille 6×7 avec pastilles par domaine, teinte de charge, couronne
+  des boss ; la journée choisie s'ouvre juste en dessous avec ses créneaux.
+- **Année** — douze mini-mois teintés par l'activité.
+- **Agenda** — liste continue des jours à venir, chargée par tranches.
+- **Time-blocking** — on fait **glisser une quête du tiroir sur la timeline**
+  pour réserver un créneau ; un appui long sur un bloc le **déplace** (aimanté
+  au quart d'heure), le menu contextuel le redimensionne.
+- **Calendrier iOS** — les évènements système s'affichent en lecture seule et
+  bloquent les créneaux, pour que la planification reste honnête.
+- **Planification automatique** — « Planifier ma journée » range les quêtes du
+  jour dans les trous libres : échéance d'abord, puis priorité, en plaçant
+  l'exigeant dans la fenêtre de pointe. Le plan est **proposé, jamais imposé**.
+
+### La couche jeu
+
+- **XP et niveaux** — la récompense dépend de la difficulté, de la priorité, de
+  la durée, des sous-quêtes, de la concentration investie et de la ponctualité.
+  La fiche affiche le **détail ligne par ligne** : aucune récompense n'est magique.
+- **Combos** — enchaîner des quêtes en moins de 5 minutes fait monter un
+  multiplicateur (jusqu'à +25 %), avec sablier à l'écran.
+- **Séries** — jours consécutifs, jusqu'à +30 % d'XP. Trois soupapes évitent la
+  spirale de culpabilité : la journée en cours ne casse jamais la série, les
+  **gels** comblent un trou isolé, les **jours de repos** sont neutres.
+- **Boss** — une grosse quête devient un combat : ses points de vie sont des
+  minutes de concentration, chaque session de Donjon lui en retire.
+- **Attributs** — six domaines de vie (Corps, Esprit, Cœur, Œuvre, Fortune,
+  Foyer) montent en niveau séparément. Le tableau de quêtes cible
+  automatiquement le domaine délaissé.
+- **Quêtes du jour** — trois quotidiennes + un défi hebdomadaire, **générés de
+  façon déterministe** (même jour = mêmes quêtes, un rafraîchissement ne rebat
+  pas les cartes).
+- **Hauts faits** — 50+ trophées en 8 catégories, dont des secrets.
+- **Économie** — pièces et gemmes, échoppe (potions d'XP, gels de série, jours
+  de repos, coffres, ambiances, apparence), coffres à butin animés.
+- **Héros** — avatar composé d'emojis et de symboles système : visage,
+  couvre-chef, familier, aura, cadre. Zéro image à charger, net à toute taille.
+
+### Concentration (le Donjon)
+
+Minuteur Pomodoro complet — durées réglables, enchaînement automatique
+travail/pause/grande pause, compteur de distractions, journal des sessions du
+jour, et le temps continue de courir correctement en arrière-plan (les calculs
+partent des dates, pas d'un décompte de tics).
+
+### Chroniques
+
+Graphiques Swift Charts : XP dans le temps avec moyenne mobile, quêtes par jour,
+rythme hebdomadaire, heures fortes, équilibre entre domaines, carte de chaleur
+annuelle. Puis des **observations en français** — « le mardi est ton jour fort »,
+« tes estimations sont fiables », « le domaine Cœur dort ».
+
+### Le reste
+
+- 8 ambiances visuelles, fond « aurore » animé, verre dépoli, confettis, éclats
+  de validation, textes d'XP flottants, haptique différenciée par évènement.
+- Réglages : heures de travail, fenêtre de pointe, jours travaillés, premier
+  jour de la semaine, durées de concentration, notifications, réduction des
+  animations, réinitialisation, export.
+- Raccourcis Siri : « Ajouter une quête », « Résumé de ma journée »,
+  « Démarrer une session ».
+- Onboarding en quatre écrans qui sème des quêtes de départ adaptées aux
+  domaines choisis.
+
+---
+
+## Syntaxe de saisie rapide
+
+| Écrire | Effet |
+|---|---|
+| `demain`, `lundi`, `lundi prochain`, `dans 3 jours`, `15/03`, `20 mars`, `fin du mois` | échéance |
+| `14h30`, `9h`, `09:15`, `7:30pm`, `ce soir`, `ce matin` | heure |
+| `30min`, `2 heures`, `pendant 1h30` | durée estimée |
+| `p1` … `p4` (ou `!1` … `!4`), `urgent`, `important` | priorité |
+| `#étiquette`, `@contexte` | étiquettes |
+| `+projet` | projet |
+| `*facile`, `*ardu`, `*épique`, `*légendaire` | difficulté (donc XP) |
+| `%corps`, `%esprit`, `%cœur`, `%œuvre`, `%fortune`, `%foyer` | domaine de vie |
+| `!boss` | boss (XP ×2, barre de PV) |
+| `tous les jours`, `chaque lundi`, `tous les 3 jours`, `en semaine`, `le 5 du mois` | répétition |
+| `rappel 30min avant` | rappel |
+
+L'anglais est reconnu en parallèle (`tomorrow`, `every 2 weeks`, `9am`, `in 5 days`…).
+Le domaine de vie est **deviné** à partir des mots (« courses » → Foyer,
+« facture » → Fortune) quand il n'est pas précisé.
+
+Deux conventions à connaître : `14h` est une **heure**, `2 heures` est une
+**durée** ; et `15/03` est lu **jour/mois**.
+
+---
+
+## Architecture
+
+```
+QuestlyApp/
+├── Questly.xcodeproj          projet (groupes synchronisés Xcode 16)
+├── Packages/QuestlyKit/       cœur métier, sans UI ni base de données
+│   ├── Sources/QuestlyKit/
+│   │   ├── Core/              énumérations, outils de dates
+│   │   ├── Gamification/      XP, niveaux, séries, hauts faits, quêtes, économie
+│   │   ├── Parsing/           analyseur de langage naturel
+│   │   ├── Recurrence/        moteur de récurrence
+│   │   ├── Scheduling/        créneaux libres, planification automatique
+│   │   └── Stats/             statistiques et observations
+│   └── Tests/                 159 tests
+└── Questly/
+    ├── App/                   point d'entrée, conteneur, coque
+    ├── Data/                  modèles SwiftData + QuestlyStore
+    ├── DesignSystem/          thèmes, composants, effets
+    ├── Features/              Today, Tasks, Calendar, Focus, Hero, Stats, Settings…
+    ├── Services/              haptique, notifications, EventKit, réglages, Siri
+    └── Resources/             catalogue d'assets
+```
+
+Deux principes structurent le tout :
+
+1. **Les règles du jeu vivent dans `QuestlyKit`**, en Foundation pur. Aucune
+   dépendance à SwiftUI ni à SwiftData, donc testable en une seconde et
+   réutilisable par un widget ou une extension.
+2. **Une seule porte d'écriture** : les vues lisent via `@Query` (SwiftData les
+   tient à jour) et passent toutes par `QuestlyStore` pour écrire. XP, séries,
+   quêtes, hauts faits et récurrences sont donc appliqués au même endroit,
+   jamais dupliqués dans une vue.
+
+Le modèle de données respecte les contraintes CloudKit (valeurs par défaut
+partout, aucune contrainte d'unicité) : activer la synchronisation iCloud ne
+demandera pas de migration.
+
+---
+
+## État de vérification
+
+Ce qui est **prouvé** :
+
+- `QuestlyKit` compile (Swift 6.0.3) et passe **159 tests unitaires**, dont les
+  cas pénibles : passage à l'heure d'été, 31 janvier → 28 février, année
+  bissextile, fins de série, ordre des règles dans l'analyseur.
+
+Ce qui **ne l'est pas** :
+
+- La cible iOS (SwiftUI + SwiftData) **n'a pas pu être compilée ici** : ces
+  frameworks n'existent que dans le SDK Apple, indisponible sur cette machine.
+  Le code a été relu et vérifié par analyse statique (types déclarés/référencés,
+  équilibre syntaxique, collisions de noms, API disponibles en iOS 17), et les
+  constructions douteuses ont été testées séparément avec le vrai compilateur.
+  **Attendez-vous malgré tout à quelques ajustements au premier build dans Xcode** —
+  c'est la première compilation réelle de cette couche.
+
+---
+
+## Pistes suivantes
+
+- Widgets WidgetKit (quête du jour, série, anneau d'XP) et Live Activity pour le
+  minuteur — `QuestlyKit` est déjà prêt à être partagé avec une extension.
+- Synchronisation iCloud (le schéma est compatible, il reste à activer la
+  capacité et à passer `cloudKitDatabase` au `ModelConfiguration`).
+- Icône d'application : `Questly/Resources/Assets.xcassets/AppIcon.appiconset`
+  attend un PNG 1024×1024.

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title:               My digital garden
 include:             ['_pages']
-exclude:             ['_includes/notes_graph.json']
+exclude:             ['_includes/notes_graph.json', 'QuestlyApp']
 # You may need to change the base URL depending on your deploy configuration.
 baseurl:             ''
 


### PR DESCRIPTION
## Ce que contient cette PR

Une application iOS native complète (SwiftUI + SwiftData, iOS 17+) dans un nouveau dossier `QuestlyApp/`, sans toucher au site Jekyll existant.

Ouvrir avec `open QuestlyApp/Questly.xcodeproj` (Xcode 16+). Aucune dépendance externe.

## Architecture

Deux couches, séparées volontairement :

- **`Packages/QuestlyKit/`** — tout le métier en Foundation pur : XP, niveaux, séries, récurrence, analyseur de langage naturel, planificateur, statistiques. Aucune dépendance UI ou base de données, donc testable en une seconde.
- **`Questly/`** — l'app : modèles SwiftData, `QuestlyStore` comme unique porte d'écriture, système de design, écrans.

Les vues lisent via `@Query` et écrivent uniquement via le store : les règles du jeu ne sont jamais dupliquées dans une vue.

## Fonctionnalités

**Tâches** — saisie naturelle (« Appeler le dentiste demain 14h30 #santé p2 »), projets, étiquettes, sous-quêtes, 9 listes intelligentes, tri et regroupement, récurrences avancées (intervalles, jours choisis, dernier jour du mois, fin après N fois, mode « N jours après accomplissement »), rappels, recherche insensible aux accents, export JSON.

**Calendrier** — jour, semaine, mois, année, agenda. Timeline avec trait de l'instant présent, time-blocking par glisser-déposer depuis un tiroir de quêtes, déplacement des blocs aimanté au quart d'heure, gestion des chevauchements en colonnes, évènements du calendrier iOS en lecture seule (ils bloquent les créneaux), et planification automatique de la journée — proposée avant application, jamais imposée.

**Jeu** — XP détaillé ligne par ligne sur la fiche de chaque quête, combos, séries avec gels et jours de repos (la journée en cours ne casse jamais la série), boss dont les points de vie sont des minutes de concentration, six attributs de vie, quêtes quotidiennes déterministes, 50+ hauts faits, échoppe et coffres à butin, avatar composable.

**Concentration** — Pomodoro complet, enchaînement automatique des pauses, compteur de distractions, temps recalculé depuis les dates (correct en arrière-plan).

**Chroniques** — Swift Charts (XP, rythme hebdomadaire, heures fortes, équilibre de vie, carte de chaleur annuelle) et observations en français.

Plus : 8 ambiances, fond animé, confettis, haptique différenciée par évènement, raccourcis Siri, onboarding, réglages détaillés.

## Vérification

**Prouvé** : `QuestlyKit` compile (Swift 6.0.3) et passe **159 tests unitaires**, tous au vert. Ils couvrent les cas pénibles — passage à l'heure d'été, 31 janvier → 28 février, année bissextile, fins de série, ordre des règles de l'analyseur.

```
Executed 159 tests, with 0 failures (0 unexpected)
```

**Non prouvé** : la cible iOS n'a pas pu être compilée ici — SwiftUI et SwiftData n'existent que dans le SDK Apple, indisponible sur la machine de build. Le code a été relu et vérifié par analyse statique (types déclarés/référencés, équilibre syntaxique, collisions de noms, disponibilité des API en iOS 17) et les constructions douteuses ont été testées séparément avec le vrai compilateur Swift. **Quelques ajustements sont à prévoir au premier build dans Xcode** : c'est la première compilation réelle de cette couche.

## Reste à faire

- Icône d'application (le catalogue attend un PNG 1024×1024)
- Widgets WidgetKit et Live Activity — `QuestlyKit` est déjà prêt à être partagé avec une extension
- Synchronisation iCloud : le schéma est déjà compatible CloudKit, il reste à activer la capacité

---
_Generated by [Claude Code](https://claude.ai/code/session_01XB2f3gY4orgRdTbUajMmCx)_